### PR TITLE
Mandate backend namespaces match file locations

### DIFF
--- a/AnniversaryBirthdayReminder/docs/specs/implementation-specs.md
+++ b/AnniversaryBirthdayReminder/docs/specs/implementation-specs.md
@@ -41,6 +41,20 @@ The following architectural constraints are fundamental to the AnniversaryBirthd
 ### 2.1 Namespace Architecture
 **REQ-SYS-001**: The system SHALL use flattened namespaces throughout all projects.
 
+**REQ-SYS-001-A**: **CRITICAL** - All backend code namespaces SHALL exactly match the file's physical location within the project structure. The namespace declaration in each file SHALL correspond to the folder path where the file resides.
+
+**Example (Compliant):**
+```
+// File: {AppName}.Core/Model/{Aggregate}Aggregate/Events/{Event}.cs
+namespace {AppName}.Core.Model.{Aggregate}Aggregate.Events;
+```
+
+**Example (Non-Compliant):**
+```
+// File: {AppName}.Core/Model/{Aggregate}Aggregate/Events/{Event}.cs
+namespace {AppName}.Core;  // Does not match file location
+```
+
 ### 2.8 Frontend Theme and Colours
 **REQ-SYS-011**: The frontend SHALL use the default Angular Material colours and theme. No new colours are to be introduced.
 

--- a/AnnualHealthScreeningReminder/docs/specs/implementation-specs.md
+++ b/AnnualHealthScreeningReminder/docs/specs/implementation-specs.md
@@ -41,6 +41,20 @@ The following architectural constraints are fundamental to the AnnualHealthScree
 ### 2.1 Namespace Architecture
 **REQ-SYS-001**: The system SHALL use flattened namespaces throughout all projects.
 
+**REQ-SYS-001-A**: **CRITICAL** - All backend code namespaces SHALL exactly match the file's physical location within the project structure. The namespace declaration in each file SHALL correspond to the folder path where the file resides.
+
+**Example (Compliant):**
+```
+// File: {AppName}.Core/Model/{Aggregate}Aggregate/Events/{Event}.cs
+namespace {AppName}.Core.Model.{Aggregate}Aggregate.Events;
+```
+
+**Example (Non-Compliant):**
+```
+// File: {AppName}.Core/Model/{Aggregate}Aggregate/Events/{Event}.cs
+namespace {AppName}.Core;  // Does not match file location
+```
+
 ### 2.8 Frontend Theme and Colours
 **REQ-SYS-011**: The frontend SHALL use the default Angular Material colours and theme. No new colours are to be introduced.
 

--- a/ApplianceWarrantyManualOrganizer/docs/specs/implementation-specs.md
+++ b/ApplianceWarrantyManualOrganizer/docs/specs/implementation-specs.md
@@ -41,6 +41,20 @@ The following architectural constraints are fundamental to the ApplianceWarranty
 ### 2.1 Namespace Architecture
 **REQ-SYS-001**: The system SHALL use flattened namespaces throughout all projects.
 
+**REQ-SYS-001-A**: **CRITICAL** - All backend code namespaces SHALL exactly match the file's physical location within the project structure. The namespace declaration in each file SHALL correspond to the folder path where the file resides.
+
+**Example (Compliant):**
+```
+// File: {AppName}.Core/Model/{Aggregate}Aggregate/Events/{Event}.cs
+namespace {AppName}.Core.Model.{Aggregate}Aggregate.Events;
+```
+
+**Example (Non-Compliant):**
+```
+// File: {AppName}.Core/Model/{Aggregate}Aggregate/Events/{Event}.cs
+namespace {AppName}.Core;  // Does not match file location
+```
+
 ### 2.8 Frontend Theme and Colours
 **REQ-SYS-011**: The frontend SHALL use the default Angular Material colours and theme. No new colours are to be introduced.
 

--- a/BBQGrillingRecipeBook/docs/specs/implementation-specs.md
+++ b/BBQGrillingRecipeBook/docs/specs/implementation-specs.md
@@ -41,6 +41,20 @@ The following architectural constraints are fundamental to the BBQGrillingRecipe
 ### 2.1 Namespace Architecture
 **REQ-SYS-001**: The system SHALL use flattened namespaces throughout all projects.
 
+**REQ-SYS-001-A**: **CRITICAL** - All backend code namespaces SHALL exactly match the file's physical location within the project structure. The namespace declaration in each file SHALL correspond to the folder path where the file resides.
+
+**Example (Compliant):**
+```
+// File: {AppName}.Core/Model/{Aggregate}Aggregate/Events/{Event}.cs
+namespace {AppName}.Core.Model.{Aggregate}Aggregate.Events;
+```
+
+**Example (Non-Compliant):**
+```
+// File: {AppName}.Core/Model/{Aggregate}Aggregate/Events/{Event}.cs
+namespace {AppName}.Core;  // Does not match file location
+```
+
 ### 2.8 Frontend Theme and Colours
 **REQ-SYS-011**: The frontend SHALL use the default Angular Material colours and theme. No new colours are to be introduced.
 

--- a/BillPaymentScheduler/docs/specs/implementation-specs.md
+++ b/BillPaymentScheduler/docs/specs/implementation-specs.md
@@ -41,6 +41,20 @@ The following architectural constraints are fundamental to the BillPaymentSchedu
 ### 2.1 Namespace Architecture
 **REQ-SYS-001**: The system SHALL use flattened namespaces throughout all projects.
 
+**REQ-SYS-001-A**: **CRITICAL** - All backend code namespaces SHALL exactly match the file's physical location within the project structure. The namespace declaration in each file SHALL correspond to the folder path where the file resides.
+
+**Example (Compliant):**
+```
+// File: {AppName}.Core/Model/{Aggregate}Aggregate/Events/{Event}.cs
+namespace {AppName}.Core.Model.{Aggregate}Aggregate.Events;
+```
+
+**Example (Non-Compliant):**
+```
+// File: {AppName}.Core/Model/{Aggregate}Aggregate/Events/{Event}.cs
+namespace {AppName}.Core;  // Does not match file location
+```
+
 ### 2.8 Frontend Theme and Colours
 **REQ-SYS-011**: The frontend SHALL use the default Angular Material colours and theme. No new colours are to be introduced.
 

--- a/BloodPressureMonitor/docs/specs/implementation-specs.md
+++ b/BloodPressureMonitor/docs/specs/implementation-specs.md
@@ -41,6 +41,20 @@ The following architectural constraints are fundamental to the BloodPressureMoni
 ### 2.1 Namespace Architecture
 **REQ-SYS-001**: The system SHALL use flattened namespaces throughout all projects.
 
+**REQ-SYS-001-A**: **CRITICAL** - All backend code namespaces SHALL exactly match the file's physical location within the project structure. The namespace declaration in each file SHALL correspond to the folder path where the file resides.
+
+**Example (Compliant):**
+```
+// File: {AppName}.Core/Model/{Aggregate}Aggregate/Events/{Event}.cs
+namespace {AppName}.Core.Model.{Aggregate}Aggregate.Events;
+```
+
+**Example (Non-Compliant):**
+```
+// File: {AppName}.Core/Model/{Aggregate}Aggregate/Events/{Event}.cs
+namespace {AppName}.Core;  // Does not match file location
+```
+
 ### 2.8 Frontend Theme and Colours
 **REQ-SYS-011**: The frontend SHALL use the default Angular Material colours and theme. No new colours are to be introduced.
 

--- a/BookReadingTrackerLibrary/docs/specs/implementation-specs.md
+++ b/BookReadingTrackerLibrary/docs/specs/implementation-specs.md
@@ -41,6 +41,20 @@ The following architectural constraints are fundamental to the BookReadingTracke
 ### 2.1 Namespace Architecture
 **REQ-SYS-001**: The system SHALL use flattened namespaces throughout all projects.
 
+**REQ-SYS-001-A**: **CRITICAL** - All backend code namespaces SHALL exactly match the file's physical location within the project structure. The namespace declaration in each file SHALL correspond to the folder path where the file resides.
+
+**Example (Compliant):**
+```
+// File: {AppName}.Core/Model/{Aggregate}Aggregate/Events/{Event}.cs
+namespace {AppName}.Core.Model.{Aggregate}Aggregate.Events;
+```
+
+**Example (Non-Compliant):**
+```
+// File: {AppName}.Core/Model/{Aggregate}Aggregate/Events/{Event}.cs
+namespace {AppName}.Core;  // Does not match file location
+```
+
 ### 2.8 Frontend Theme and Colours
 **REQ-SYS-011**: The frontend SHALL use the default Angular Material colours and theme. No new colours are to be introduced.
 

--- a/BucketListManager/docs/specs/implementation-specs.md
+++ b/BucketListManager/docs/specs/implementation-specs.md
@@ -41,6 +41,20 @@ The following architectural constraints are fundamental to the BucketListManager
 ### 2.1 Namespace Architecture
 **REQ-SYS-001**: The system SHALL use flattened namespaces throughout all projects.
 
+**REQ-SYS-001-A**: **CRITICAL** - All backend code namespaces SHALL exactly match the file's physical location within the project structure. The namespace declaration in each file SHALL correspond to the folder path where the file resides.
+
+**Example (Compliant):**
+```
+// File: {AppName}.Core/Model/{Aggregate}Aggregate/Events/{Event}.cs
+namespace {AppName}.Core.Model.{Aggregate}Aggregate.Events;
+```
+
+**Example (Non-Compliant):**
+```
+// File: {AppName}.Core/Model/{Aggregate}Aggregate/Events/{Event}.cs
+namespace {AppName}.Core;  // Does not match file location
+```
+
 ### 2.8 Frontend Theme and Colours
 **REQ-SYS-011**: The frontend SHALL use the default Angular Material colours and theme. No new colours are to be introduced.
 

--- a/CampingTripPlanner/docs/specs/implementation-specs.md
+++ b/CampingTripPlanner/docs/specs/implementation-specs.md
@@ -41,6 +41,20 @@ The following architectural constraints are fundamental to the CampingTripPlanne
 ### 2.1 Namespace Architecture
 **REQ-SYS-001**: The system SHALL use flattened namespaces throughout all projects.
 
+**REQ-SYS-001-A**: **CRITICAL** - All backend code namespaces SHALL exactly match the file's physical location within the project structure. The namespace declaration in each file SHALL correspond to the folder path where the file resides.
+
+**Example (Compliant):**
+```
+// File: {AppName}.Core/Model/{Aggregate}Aggregate/Events/{Event}.cs
+namespace {AppName}.Core.Model.{Aggregate}Aggregate.Events;
+```
+
+**Example (Non-Compliant):**
+```
+// File: {AppName}.Core/Model/{Aggregate}Aggregate/Events/{Event}.cs
+namespace {AppName}.Core;  // Does not match file location
+```
+
 ### 2.8 Frontend Theme and Colours
 **REQ-SYS-011**: The frontend SHALL use the default Angular Material colours and theme. No new colours are to be introduced.
 

--- a/CarModificationPartsDatabase/docs/specs/implementation-specs.md
+++ b/CarModificationPartsDatabase/docs/specs/implementation-specs.md
@@ -41,6 +41,20 @@ The following architectural constraints are fundamental to the CarModificationPa
 ### 2.1 Namespace Architecture
 **REQ-SYS-001**: The system SHALL use flattened namespaces throughout all projects.
 
+**REQ-SYS-001-A**: **CRITICAL** - All backend code namespaces SHALL exactly match the file's physical location within the project structure. The namespace declaration in each file SHALL correspond to the folder path where the file resides.
+
+**Example (Compliant):**
+```
+// File: {AppName}.Core/Model/{Aggregate}Aggregate/Events/{Event}.cs
+namespace {AppName}.Core.Model.{Aggregate}Aggregate.Events;
+```
+
+**Example (Non-Compliant):**
+```
+// File: {AppName}.Core/Model/{Aggregate}Aggregate/Events/{Event}.cs
+namespace {AppName}.Core;  // Does not match file location
+```
+
 ### 2.8 Frontend Theme and Colours
 **REQ-SYS-011**: The frontend SHALL use the default Angular Material colours and theme. No new colours are to be introduced.
 

--- a/CharitableGivingTracker/docs/specs/implementation-specs.md
+++ b/CharitableGivingTracker/docs/specs/implementation-specs.md
@@ -41,6 +41,20 @@ The following architectural constraints are fundamental to the CharitableGivingT
 ### 2.1 Namespace Architecture
 **REQ-SYS-001**: The system SHALL use flattened namespaces throughout all projects.
 
+**REQ-SYS-001-A**: **CRITICAL** - All backend code namespaces SHALL exactly match the file's physical location within the project structure. The namespace declaration in each file SHALL correspond to the folder path where the file resides.
+
+**Example (Compliant):**
+```
+// File: {AppName}.Core/Model/{Aggregate}Aggregate/Events/{Event}.cs
+namespace {AppName}.Core.Model.{Aggregate}Aggregate.Events;
+```
+
+**Example (Non-Compliant):**
+```
+// File: {AppName}.Core/Model/{Aggregate}Aggregate/Events/{Event}.cs
+namespace {AppName}.Core;  // Does not match file location
+```
+
 ### 2.8 Frontend Theme and Colours
 **REQ-SYS-011**: The frontend SHALL use the default Angular Material colours and theme. No new colours are to be introduced.
 

--- a/ChoreAssignmentTracker/docs/specs/implementation-specs.md
+++ b/ChoreAssignmentTracker/docs/specs/implementation-specs.md
@@ -41,6 +41,20 @@ The following architectural constraints are fundamental to the ChoreAssignmentTr
 ### 2.1 Namespace Architecture
 **REQ-SYS-001**: The system SHALL use flattened namespaces throughout all projects.
 
+**REQ-SYS-001-A**: **CRITICAL** - All backend code namespaces SHALL exactly match the file's physical location within the project structure. The namespace declaration in each file SHALL correspond to the folder path where the file resides.
+
+**Example (Compliant):**
+```
+// File: {AppName}.Core/Model/{Aggregate}Aggregate/Events/{Event}.cs
+namespace {AppName}.Core.Model.{Aggregate}Aggregate.Events;
+```
+
+**Example (Non-Compliant):**
+```
+// File: {AppName}.Core/Model/{Aggregate}Aggregate/Events/{Event}.cs
+namespace {AppName}.Core;  // Does not match file location
+```
+
 ### 2.8 Frontend Theme and Colours
 **REQ-SYS-011**: The frontend SHALL use the default Angular Material colours and theme. No new colours are to be introduced.
 

--- a/ClassicCarRestorationLog/docs/specs/implementation-specs.md
+++ b/ClassicCarRestorationLog/docs/specs/implementation-specs.md
@@ -41,6 +41,20 @@ The following architectural constraints are fundamental to the ClassicCarRestora
 ### 2.1 Namespace Architecture
 **REQ-SYS-001**: The system SHALL use flattened namespaces throughout all projects.
 
+**REQ-SYS-001-A**: **CRITICAL** - All backend code namespaces SHALL exactly match the file's physical location within the project structure. The namespace declaration in each file SHALL correspond to the folder path where the file resides.
+
+**Example (Compliant):**
+```
+// File: {AppName}.Core/Model/{Aggregate}Aggregate/Events/{Event}.cs
+namespace {AppName}.Core.Model.{Aggregate}Aggregate.Events;
+```
+
+**Example (Non-Compliant):**
+```
+// File: {AppName}.Core/Model/{Aggregate}Aggregate/Events/{Event}.cs
+namespace {AppName}.Core;  // Does not match file location
+```
+
 ### 2.8 Frontend Theme and Colours
 **REQ-SYS-011**: The frontend SHALL use the default Angular Material colours and theme. No new colours are to be introduced.
 

--- a/CollegeSavingsPlanner/docs/specs/implementation-specs.md
+++ b/CollegeSavingsPlanner/docs/specs/implementation-specs.md
@@ -41,6 +41,20 @@ The following architectural constraints are fundamental to the CollegeSavingsPla
 ### 2.1 Namespace Architecture
 **REQ-SYS-001**: The system SHALL use flattened namespaces throughout all projects.
 
+**REQ-SYS-001-A**: **CRITICAL** - All backend code namespaces SHALL exactly match the file's physical location within the project structure. The namespace declaration in each file SHALL correspond to the folder path where the file resides.
+
+**Example (Compliant):**
+```
+// File: {AppName}.Core/Model/{Aggregate}Aggregate/Events/{Event}.cs
+namespace {AppName}.Core.Model.{Aggregate}Aggregate.Events;
+```
+
+**Example (Non-Compliant):**
+```
+// File: {AppName}.Core/Model/{Aggregate}Aggregate/Events/{Event}.cs
+namespace {AppName}.Core;  // Does not match file location
+```
+
 ### 2.8 Frontend Theme and Colours
 **REQ-SYS-011**: The frontend SHALL use the default Angular Material colours and theme. No new colours are to be introduced.
 

--- a/ConferenceEventManager/docs/specs/implementation-specs.md
+++ b/ConferenceEventManager/docs/specs/implementation-specs.md
@@ -41,6 +41,20 @@ The following architectural constraints are fundamental to the ConferenceEventMa
 ### 2.1 Namespace Architecture
 **REQ-SYS-001**: The system SHALL use flattened namespaces throughout all projects.
 
+**REQ-SYS-001-A**: **CRITICAL** - All backend code namespaces SHALL exactly match the file's physical location within the project structure. The namespace declaration in each file SHALL correspond to the folder path where the file resides.
+
+**Example (Compliant):**
+```
+// File: {AppName}.Core/Model/{Aggregate}Aggregate/Events/{Event}.cs
+namespace {AppName}.Core.Model.{Aggregate}Aggregate.Events;
+```
+
+**Example (Non-Compliant):**
+```
+// File: {AppName}.Core/Model/{Aggregate}Aggregate/Events/{Event}.cs
+namespace {AppName}.Core;  // Does not match file location
+```
+
 ### 2.8 Frontend Theme and Colours
 **REQ-SYS-011**: The frontend SHALL use the default Angular Material colours and theme. No new colours are to be introduced.
 

--- a/ConversationStarterApp/docs/specs/implementation-specs.md
+++ b/ConversationStarterApp/docs/specs/implementation-specs.md
@@ -41,6 +41,20 @@ The following architectural constraints are fundamental to the ConversationStart
 ### 2.1 Namespace Architecture
 **REQ-SYS-001**: The system SHALL use flattened namespaces throughout all projects.
 
+**REQ-SYS-001-A**: **CRITICAL** - All backend code namespaces SHALL exactly match the file's physical location within the project structure. The namespace declaration in each file SHALL correspond to the folder path where the file resides.
+
+**Example (Compliant):**
+```
+// File: {AppName}.Core/Model/{Aggregate}Aggregate/Events/{Event}.cs
+namespace {AppName}.Core.Model.{Aggregate}Aggregate.Events;
+```
+
+**Example (Non-Compliant):**
+```
+// File: {AppName}.Core/Model/{Aggregate}Aggregate/Events/{Event}.cs
+namespace {AppName}.Core;  // Does not match file location
+```
+
 ### 2.8 Frontend Theme and Colours
 **REQ-SYS-011**: The frontend SHALL use the default Angular Material colours and theme. No new colours are to be introduced.
 

--- a/CouplesGoalTracker/docs/specs/implementation-specs.md
+++ b/CouplesGoalTracker/docs/specs/implementation-specs.md
@@ -41,6 +41,20 @@ The following architectural constraints are fundamental to the CouplesGoalTracke
 ### 2.1 Namespace Architecture
 **REQ-SYS-001**: The system SHALL use flattened namespaces throughout all projects.
 
+**REQ-SYS-001-A**: **CRITICAL** - All backend code namespaces SHALL exactly match the file's physical location within the project structure. The namespace declaration in each file SHALL correspond to the folder path where the file resides.
+
+**Example (Compliant):**
+```
+// File: {AppName}.Core/Model/{Aggregate}Aggregate/Events/{Event}.cs
+namespace {AppName}.Core.Model.{Aggregate}Aggregate.Events;
+```
+
+**Example (Non-Compliant):**
+```
+// File: {AppName}.Core/Model/{Aggregate}Aggregate/Events/{Event}.cs
+namespace {AppName}.Core;  // Does not match file location
+```
+
 ### 2.8 Frontend Theme and Colours
 **REQ-SYS-011**: The frontend SHALL use the default Angular Material colours and theme. No new colours are to be introduced.
 

--- a/CryptoPortfolioManager/docs/specs/implementation-specs.md
+++ b/CryptoPortfolioManager/docs/specs/implementation-specs.md
@@ -41,6 +41,20 @@ The following architectural constraints are fundamental to the CryptoPortfolioMa
 ### 2.1 Namespace Architecture
 **REQ-SYS-001**: The system SHALL use flattened namespaces throughout all projects.
 
+**REQ-SYS-001-A**: **CRITICAL** - All backend code namespaces SHALL exactly match the file's physical location within the project structure. The namespace declaration in each file SHALL correspond to the folder path where the file resides.
+
+**Example (Compliant):**
+```
+// File: {AppName}.Core/Model/{Aggregate}Aggregate/Events/{Event}.cs
+namespace {AppName}.Core.Model.{Aggregate}Aggregate.Events;
+```
+
+**Example (Non-Compliant):**
+```
+// File: {AppName}.Core/Model/{Aggregate}Aggregate/Events/{Event}.cs
+namespace {AppName}.Core;  // Does not match file location
+```
+
 ### 2.8 Frontend Theme and Colours
 **REQ-SYS-011**: The frontend SHALL use the default Angular Material colours and theme. No new colours are to be introduced.
 

--- a/DailyJournalingApp/docs/specs/implementation-specs.md
+++ b/DailyJournalingApp/docs/specs/implementation-specs.md
@@ -41,6 +41,20 @@ The following architectural constraints are fundamental to the DailyJournalingAp
 ### 2.1 Namespace Architecture
 **REQ-SYS-001**: The system SHALL use flattened namespaces throughout all projects.
 
+**REQ-SYS-001-A**: **CRITICAL** - All backend code namespaces SHALL exactly match the file's physical location within the project structure. The namespace declaration in each file SHALL correspond to the folder path where the file resides.
+
+**Example (Compliant):**
+```
+// File: {AppName}.Core/Model/{Aggregate}Aggregate/Events/{Event}.cs
+namespace {AppName}.Core.Model.{Aggregate}Aggregate.Events;
+```
+
+**Example (Non-Compliant):**
+```
+// File: {AppName}.Core/Model/{Aggregate}Aggregate/Events/{Event}.cs
+namespace {AppName}.Core;  // Does not match file location
+```
+
 ### 2.8 Frontend Theme and Colours
 **REQ-SYS-011**: The frontend SHALL use the default Angular Material colours and theme. No new colours are to be introduced.
 

--- a/DateNightIdeaGenerator/docs/specs/implementation-specs.md
+++ b/DateNightIdeaGenerator/docs/specs/implementation-specs.md
@@ -41,6 +41,20 @@ The following architectural constraints are fundamental to the DateNightIdeaGene
 ### 2.1 Namespace Architecture
 **REQ-SYS-001**: The system SHALL use flattened namespaces throughout all projects.
 
+**REQ-SYS-001-A**: **CRITICAL** - All backend code namespaces SHALL exactly match the file's physical location within the project structure. The namespace declaration in each file SHALL correspond to the folder path where the file resides.
+
+**Example (Compliant):**
+```
+// File: {AppName}.Core/Model/{Aggregate}Aggregate/Events/{Event}.cs
+namespace {AppName}.Core.Model.{Aggregate}Aggregate.Events;
+```
+
+**Example (Non-Compliant):**
+```
+// File: {AppName}.Core/Model/{Aggregate}Aggregate/Events/{Event}.cs
+namespace {AppName}.Core;  // Does not match file location
+```
+
 ### 2.8 Frontend Theme and Colours
 **REQ-SYS-011**: The frontend SHALL use the default Angular Material colours and theme. No new colours are to be introduced.
 

--- a/DigitalLegacyPlanner/docs/specs/implementation-specs.md
+++ b/DigitalLegacyPlanner/docs/specs/implementation-specs.md
@@ -41,6 +41,20 @@ The following architectural constraints are fundamental to the DigitalLegacyPlan
 ### 2.1 Namespace Architecture
 **REQ-SYS-001**: The system SHALL use flattened namespaces throughout all projects.
 
+**REQ-SYS-001-A**: **CRITICAL** - All backend code namespaces SHALL exactly match the file's physical location within the project structure. The namespace declaration in each file SHALL correspond to the folder path where the file resides.
+
+**Example (Compliant):**
+```
+// File: {AppName}.Core/Model/{Aggregate}Aggregate/Events/{Event}.cs
+namespace {AppName}.Core.Model.{Aggregate}Aggregate.Events;
+```
+
+**Example (Non-Compliant):**
+```
+// File: {AppName}.Core/Model/{Aggregate}Aggregate/Events/{Event}.cs
+namespace {AppName}.Core;  // Does not match file location
+```
+
 ### 2.8 Frontend Theme and Colours
 **REQ-SYS-011**: The frontend SHALL use the default Angular Material colours and theme. No new colours are to be introduced.
 

--- a/DocumentVaultOrganizer/docs/specs/implementation-specs.md
+++ b/DocumentVaultOrganizer/docs/specs/implementation-specs.md
@@ -41,6 +41,20 @@ The following architectural constraints are fundamental to the DocumentVaultOrga
 ### 2.1 Namespace Architecture
 **REQ-SYS-001**: The system SHALL use flattened namespaces throughout all projects.
 
+**REQ-SYS-001-A**: **CRITICAL** - All backend code namespaces SHALL exactly match the file's physical location within the project structure. The namespace declaration in each file SHALL correspond to the folder path where the file resides.
+
+**Example (Compliant):**
+```
+// File: {AppName}.Core/Model/{Aggregate}Aggregate/Events/{Event}.cs
+namespace {AppName}.Core.Model.{Aggregate}Aggregate.Events;
+```
+
+**Example (Non-Compliant):**
+```
+// File: {AppName}.Core/Model/{Aggregate}Aggregate/Events/{Event}.cs
+namespace {AppName}.Core;  // Does not match file location
+```
+
 ### 2.8 Frontend Theme and Colours
 **REQ-SYS-011**: The frontend SHALL use the default Angular Material colours and theme. No new colours are to be introduced.
 

--- a/FamilyCalendarEventPlanner/docs/specs/implementation-specs.md
+++ b/FamilyCalendarEventPlanner/docs/specs/implementation-specs.md
@@ -41,6 +41,20 @@ The following architectural constraints are fundamental to the FamilyCalendarEve
 ### 2.1 Namespace Architecture
 **REQ-SYS-001**: The system SHALL use flattened namespaces throughout all projects.
 
+**REQ-SYS-001-A**: **CRITICAL** - All backend code namespaces SHALL exactly match the file's physical location within the project structure. The namespace declaration in each file SHALL correspond to the folder path where the file resides.
+
+**Example (Compliant):**
+```
+// File: {AppName}.Core/Model/{Aggregate}Aggregate/Events/{Event}.cs
+namespace {AppName}.Core.Model.{Aggregate}Aggregate.Events;
+```
+
+**Example (Non-Compliant):**
+```
+// File: {AppName}.Core/Model/{Aggregate}Aggregate/Events/{Event}.cs
+namespace {AppName}.Core;  // Does not match file location
+```
+
 ### 2.8 Frontend Theme and Colours
 **REQ-SYS-011**: The frontend SHALL use the default Angular Material colours and theme. No new colours are to be introduced.
 

--- a/FamilyPhotoAlbumOrganizer/docs/specs/implementation-specs.md
+++ b/FamilyPhotoAlbumOrganizer/docs/specs/implementation-specs.md
@@ -41,6 +41,20 @@ The following architectural constraints are fundamental to the FamilyPhotoAlbumO
 ### 2.1 Namespace Architecture
 **REQ-SYS-001**: The system SHALL use flattened namespaces throughout all projects.
 
+**REQ-SYS-001-A**: **CRITICAL** - All backend code namespaces SHALL exactly match the file's physical location within the project structure. The namespace declaration in each file SHALL correspond to the folder path where the file resides.
+
+**Example (Compliant):**
+```
+// File: {AppName}.Core/Model/{Aggregate}Aggregate/Events/{Event}.cs
+namespace {AppName}.Core.Model.{Aggregate}Aggregate.Events;
+```
+
+**Example (Non-Compliant):**
+```
+// File: {AppName}.Core/Model/{Aggregate}Aggregate/Events/{Event}.cs
+namespace {AppName}.Core;  // Does not match file location
+```
+
 ### 2.8 Frontend Theme and Colours
 **REQ-SYS-011**: The frontend SHALL use the default Angular Material colours and theme. No new colours are to be introduced.
 

--- a/FamilyTreeBuilder/docs/specs/implementation-specs.md
+++ b/FamilyTreeBuilder/docs/specs/implementation-specs.md
@@ -41,6 +41,20 @@ The following architectural constraints are fundamental to the FamilyTreeBuilder
 ### 2.1 Namespace Architecture
 **REQ-SYS-001**: The system SHALL use flattened namespaces throughout all projects.
 
+**REQ-SYS-001-A**: **CRITICAL** - All backend code namespaces SHALL exactly match the file's physical location within the project structure. The namespace declaration in each file SHALL correspond to the folder path where the file resides.
+
+**Example (Compliant):**
+```
+// File: {AppName}.Core/Model/{Aggregate}Aggregate/Events/{Event}.cs
+namespace {AppName}.Core.Model.{Aggregate}Aggregate.Events;
+```
+
+**Example (Non-Compliant):**
+```
+// File: {AppName}.Core/Model/{Aggregate}Aggregate/Events/{Event}.cs
+namespace {AppName}.Core;  // Does not match file location
+```
+
 ### 2.8 Frontend Theme and Colours
 **REQ-SYS-011**: The frontend SHALL use the default Angular Material colours and theme. No new colours are to be introduced.
 

--- a/FamilyVacationPlanner/docs/specs/implementation-specs.md
+++ b/FamilyVacationPlanner/docs/specs/implementation-specs.md
@@ -41,6 +41,20 @@ The following architectural constraints are fundamental to the FamilyVacationPla
 ### 2.1 Namespace Architecture
 **REQ-SYS-001**: The system SHALL use flattened namespaces throughout all projects.
 
+**REQ-SYS-001-A**: **CRITICAL** - All backend code namespaces SHALL exactly match the file's physical location within the project structure. The namespace declaration in each file SHALL correspond to the folder path where the file resides.
+
+**Example (Compliant):**
+```
+// File: {AppName}.Core/Model/{Aggregate}Aggregate/Events/{Event}.cs
+namespace {AppName}.Core.Model.{Aggregate}Aggregate.Events;
+```
+
+**Example (Non-Compliant):**
+```
+// File: {AppName}.Core/Model/{Aggregate}Aggregate/Events/{Event}.cs
+namespace {AppName}.Core;  // Does not match file location
+```
+
 ### 2.8 Frontend Theme and Colours
 **REQ-SYS-011**: The frontend SHALL use the default Angular Material colours and theme. No new colours are to be introduced.
 

--- a/FinancialGoalTracker/docs/specs/implementation-specs.md
+++ b/FinancialGoalTracker/docs/specs/implementation-specs.md
@@ -41,6 +41,20 @@ The following architectural constraints are fundamental to the FinancialGoalTrac
 ### 2.1 Namespace Architecture
 **REQ-SYS-001**: The system SHALL use flattened namespaces throughout all projects.
 
+**REQ-SYS-001-A**: **CRITICAL** - All backend code namespaces SHALL exactly match the file's physical location within the project structure. The namespace declaration in each file SHALL correspond to the folder path where the file resides.
+
+**Example (Compliant):**
+```
+// File: {AppName}.Core/Model/{Aggregate}Aggregate/Events/{Event}.cs
+namespace {AppName}.Core.Model.{Aggregate}Aggregate.Events;
+```
+
+**Example (Non-Compliant):**
+```
+// File: {AppName}.Core/Model/{Aggregate}Aggregate/Events/{Event}.cs
+namespace {AppName}.Core;  // Does not match file location
+```
+
 ### 2.8 Frontend Theme and Colours
 **REQ-SYS-011**: The frontend SHALL use the default Angular Material colours and theme. No new colours are to be introduced.
 

--- a/FishingLogSpotTracker/docs/specs/implementation-specs.md
+++ b/FishingLogSpotTracker/docs/specs/implementation-specs.md
@@ -41,6 +41,20 @@ The following architectural constraints are fundamental to the FishingLogSpotTra
 ### 2.1 Namespace Architecture
 **REQ-SYS-001**: The system SHALL use flattened namespaces throughout all projects.
 
+**REQ-SYS-001-A**: **CRITICAL** - All backend code namespaces SHALL exactly match the file's physical location within the project structure. The namespace declaration in each file SHALL correspond to the folder path where the file resides.
+
+**Example (Compliant):**
+```
+// File: {AppName}.Core/Model/{Aggregate}Aggregate/Events/{Event}.cs
+namespace {AppName}.Core.Model.{Aggregate}Aggregate.Events;
+```
+
+**Example (Non-Compliant):**
+```
+// File: {AppName}.Core/Model/{Aggregate}Aggregate/Events/{Event}.cs
+namespace {AppName}.Core;  // Does not match file location
+```
+
 ### 2.8 Frontend Theme and Colours
 **REQ-SYS-011**: The frontend SHALL use the default Angular Material colours and theme. No new colours are to be introduced.
 

--- a/FocusSessionTracker/docs/specs/implementation-specs.md
+++ b/FocusSessionTracker/docs/specs/implementation-specs.md
@@ -41,6 +41,20 @@ The following architectural constraints are fundamental to the FocusSessionTrack
 ### 2.1 Namespace Architecture
 **REQ-SYS-001**: The system SHALL use flattened namespaces throughout all projects.
 
+**REQ-SYS-001-A**: **CRITICAL** - All backend code namespaces SHALL exactly match the file's physical location within the project structure. The namespace declaration in each file SHALL correspond to the folder path where the file resides.
+
+**Example (Compliant):**
+```
+// File: {AppName}.Core/Model/{Aggregate}Aggregate/Events/{Event}.cs
+namespace {AppName}.Core.Model.{Aggregate}Aggregate.Events;
+```
+
+**Example (Non-Compliant):**
+```
+// File: {AppName}.Core/Model/{Aggregate}Aggregate/Events/{Event}.cs
+namespace {AppName}.Core;  // Does not match file location
+```
+
 ### 2.8 Frontend Theme and Colours
 **REQ-SYS-011**: The frontend SHALL use the default Angular Material colours and theme. No new colours are to be introduced.
 

--- a/FreelanceProjectManager/docs/specs/implementation-specs.md
+++ b/FreelanceProjectManager/docs/specs/implementation-specs.md
@@ -41,6 +41,20 @@ The following architectural constraints are fundamental to the FreelanceProjectM
 ### 2.1 Namespace Architecture
 **REQ-SYS-001**: The system SHALL use flattened namespaces throughout all projects.
 
+**REQ-SYS-001-A**: **CRITICAL** - All backend code namespaces SHALL exactly match the file's physical location within the project structure. The namespace declaration in each file SHALL correspond to the folder path where the file resides.
+
+**Example (Compliant):**
+```
+// File: {AppName}.Core/Model/{Aggregate}Aggregate/Events/{Event}.cs
+namespace {AppName}.Core.Model.{Aggregate}Aggregate.Events;
+```
+
+**Example (Non-Compliant):**
+```
+// File: {AppName}.Core/Model/{Aggregate}Aggregate/Events/{Event}.cs
+namespace {AppName}.Core;  // Does not match file location
+```
+
 ### 2.8 Frontend Theme and Colours
 **REQ-SYS-011**: The frontend SHALL use the default Angular Material colours and theme. No new colours are to be introduced.
 

--- a/FriendGroupEventCoordinator/docs/specs/implementation-specs.md
+++ b/FriendGroupEventCoordinator/docs/specs/implementation-specs.md
@@ -41,6 +41,20 @@ The following architectural constraints are fundamental to the FriendGroupEventC
 ### 2.1 Namespace Architecture
 **REQ-SYS-001**: The system SHALL use flattened namespaces throughout all projects.
 
+**REQ-SYS-001-A**: **CRITICAL** - All backend code namespaces SHALL exactly match the file's physical location within the project structure. The namespace declaration in each file SHALL correspond to the folder path where the file resides.
+
+**Example (Compliant):**
+```
+// File: {AppName}.Core/Model/{Aggregate}Aggregate/Events/{Event}.cs
+namespace {AppName}.Core.Model.{Aggregate}Aggregate.Events;
+```
+
+**Example (Non-Compliant):**
+```
+// File: {AppName}.Core/Model/{Aggregate}Aggregate/Events/{Event}.cs
+namespace {AppName}.Core;  // Does not match file location
+```
+
 ### 2.8 Frontend Theme and Colours
 **REQ-SYS-011**: The frontend SHALL use the default Angular Material colours and theme. No new colours are to be introduced.
 

--- a/FuelEconomyTracker/docs/specs/implementation-specs.md
+++ b/FuelEconomyTracker/docs/specs/implementation-specs.md
@@ -41,6 +41,20 @@ The following architectural constraints are fundamental to the FuelEconomyTracke
 ### 2.1 Namespace Architecture
 **REQ-SYS-001**: The system SHALL use flattened namespaces throughout all projects.
 
+**REQ-SYS-001-A**: **CRITICAL** - All backend code namespaces SHALL exactly match the file's physical location within the project structure. The namespace declaration in each file SHALL correspond to the folder path where the file resides.
+
+**Example (Compliant):**
+```
+// File: {AppName}.Core/Model/{Aggregate}Aggregate/Events/{Event}.cs
+namespace {AppName}.Core.Model.{Aggregate}Aggregate.Events;
+```
+
+**Example (Non-Compliant):**
+```
+// File: {AppName}.Core/Model/{Aggregate}Aggregate/Events/{Event}.cs
+namespace {AppName}.Core;  // Does not match file location
+```
+
 ### 2.8 Frontend Theme and Colours
 **REQ-SYS-011**: The frontend SHALL use the default Angular Material colours and theme. No new colours are to be introduced.
 

--- a/GiftIdeaTracker/docs/specs/implementation-specs.md
+++ b/GiftIdeaTracker/docs/specs/implementation-specs.md
@@ -41,6 +41,20 @@ The following architectural constraints are fundamental to the GiftIdeaTracker s
 ### 2.1 Namespace Architecture
 **REQ-SYS-001**: The system SHALL use flattened namespaces throughout all projects.
 
+**REQ-SYS-001-A**: **CRITICAL** - All backend code namespaces SHALL exactly match the file's physical location within the project structure. The namespace declaration in each file SHALL correspond to the folder path where the file resides.
+
+**Example (Compliant):**
+```
+// File: {AppName}.Core/Model/{Aggregate}Aggregate/Events/{Event}.cs
+namespace {AppName}.Core.Model.{Aggregate}Aggregate.Events;
+```
+
+**Example (Non-Compliant):**
+```
+// File: {AppName}.Core/Model/{Aggregate}Aggregate/Events/{Event}.cs
+namespace {AppName}.Core;  // Does not match file location
+```
+
 ### 2.8 Frontend Theme and Colours
 **REQ-SYS-011**: The frontend SHALL use the default Angular Material colours and theme. No new colours are to be introduced.
 

--- a/GolfScoreTracker/docs/specs/implementation-specs.md
+++ b/GolfScoreTracker/docs/specs/implementation-specs.md
@@ -41,6 +41,20 @@ The following architectural constraints are fundamental to the GolfScoreTracker 
 ### 2.1 Namespace Architecture
 **REQ-SYS-001**: The system SHALL use flattened namespaces throughout all projects.
 
+**REQ-SYS-001-A**: **CRITICAL** - All backend code namespaces SHALL exactly match the file's physical location within the project structure. The namespace declaration in each file SHALL correspond to the folder path where the file resides.
+
+**Example (Compliant):**
+```
+// File: {AppName}.Core/Model/{Aggregate}Aggregate/Events/{Event}.cs
+namespace {AppName}.Core.Model.{Aggregate}Aggregate.Events;
+```
+
+**Example (Non-Compliant):**
+```
+// File: {AppName}.Core/Model/{Aggregate}Aggregate/Events/{Event}.cs
+namespace {AppName}.Core;  // Does not match file location
+```
+
 ### 2.8 Frontend Theme and Colours
 **REQ-SYS-011**: The frontend SHALL use the default Angular Material colours and theme. No new colours are to be introduced.
 

--- a/GroceryShoppingListApp/docs/specs/implementation-specs.md
+++ b/GroceryShoppingListApp/docs/specs/implementation-specs.md
@@ -41,6 +41,20 @@ The following architectural constraints are fundamental to the GroceryShoppingLi
 ### 2.1 Namespace Architecture
 **REQ-SYS-001**: The system SHALL use flattened namespaces throughout all projects.
 
+**REQ-SYS-001-A**: **CRITICAL** - All backend code namespaces SHALL exactly match the file's physical location within the project structure. The namespace declaration in each file SHALL correspond to the folder path where the file resides.
+
+**Example (Compliant):**
+```
+// File: {AppName}.Core/Model/{Aggregate}Aggregate/Events/{Event}.cs
+namespace {AppName}.Core.Model.{Aggregate}Aggregate.Events;
+```
+
+**Example (Non-Compliant):**
+```
+// File: {AppName}.Core/Model/{Aggregate}Aggregate/Events/{Event}.cs
+namespace {AppName}.Core;  // Does not match file location
+```
+
 ### 2.8 Frontend Theme and Colours
 **REQ-SYS-011**: The frontend SHALL use the default Angular Material colours and theme. No new colours are to be introduced.
 

--- a/HabitFormationApp/docs/specs/implementation-specs.md
+++ b/HabitFormationApp/docs/specs/implementation-specs.md
@@ -41,6 +41,20 @@ The following architectural constraints are fundamental to the HabitFormationApp
 ### 2.1 Namespace Architecture
 **REQ-SYS-001**: The system SHALL use flattened namespaces throughout all projects.
 
+**REQ-SYS-001-A**: **CRITICAL** - All backend code namespaces SHALL exactly match the file's physical location within the project structure. The namespace declaration in each file SHALL correspond to the folder path where the file resides.
+
+**Example (Compliant):**
+```
+// File: {AppName}.Core/Model/{Aggregate}Aggregate/Events/{Event}.cs
+namespace {AppName}.Core.Model.{Aggregate}Aggregate.Events;
+```
+
+**Example (Non-Compliant):**
+```
+// File: {AppName}.Core/Model/{Aggregate}Aggregate/Events/{Event}.cs
+namespace {AppName}.Core;  // Does not match file location
+```
+
 ### 2.8 Frontend Theme and Colours
 **REQ-SYS-011**: The frontend SHALL use the default Angular Material colours and theme. No new colours are to be introduced.
 

--- a/HomeBrewingTracker/docs/specs/implementation-specs.md
+++ b/HomeBrewingTracker/docs/specs/implementation-specs.md
@@ -41,6 +41,20 @@ The following architectural constraints are fundamental to the HomeBrewingTracke
 ### 2.1 Namespace Architecture
 **REQ-SYS-001**: The system SHALL use flattened namespaces throughout all projects.
 
+**REQ-SYS-001-A**: **CRITICAL** - All backend code namespaces SHALL exactly match the file's physical location within the project structure. The namespace declaration in each file SHALL correspond to the folder path where the file resides.
+
+**Example (Compliant):**
+```
+// File: {AppName}.Core/Model/{Aggregate}Aggregate/Events/{Event}.cs
+namespace {AppName}.Core.Model.{Aggregate}Aggregate.Events;
+```
+
+**Example (Non-Compliant):**
+```
+// File: {AppName}.Core/Model/{Aggregate}Aggregate/Events/{Event}.cs
+namespace {AppName}.Core;  // Does not match file location
+```
+
 ### 2.8 Frontend Theme and Colours
 **REQ-SYS-011**: The frontend SHALL use the default Angular Material colours and theme. No new colours are to be introduced.
 

--- a/HomeEnergyUsageTracker/docs/specs/implementation-specs.md
+++ b/HomeEnergyUsageTracker/docs/specs/implementation-specs.md
@@ -41,6 +41,20 @@ The following architectural constraints are fundamental to the HomeEnergyUsageTr
 ### 2.1 Namespace Architecture
 **REQ-SYS-001**: The system SHALL use flattened namespaces throughout all projects.
 
+**REQ-SYS-001-A**: **CRITICAL** - All backend code namespaces SHALL exactly match the file's physical location within the project structure. The namespace declaration in each file SHALL correspond to the folder path where the file resides.
+
+**Example (Compliant):**
+```
+// File: {AppName}.Core/Model/{Aggregate}Aggregate/Events/{Event}.cs
+namespace {AppName}.Core.Model.{Aggregate}Aggregate.Events;
+```
+
+**Example (Non-Compliant):**
+```
+// File: {AppName}.Core/Model/{Aggregate}Aggregate/Events/{Event}.cs
+namespace {AppName}.Core;  // Does not match file location
+```
+
 ### 2.8 Frontend Theme and Colours
 **REQ-SYS-011**: The frontend SHALL use the default Angular Material colours and theme. No new colours are to be introduced.
 

--- a/HomeGymEquipmentManager/docs/specs/implementation-specs.md
+++ b/HomeGymEquipmentManager/docs/specs/implementation-specs.md
@@ -41,6 +41,20 @@ The following architectural constraints are fundamental to the HomeGymEquipmentM
 ### 2.1 Namespace Architecture
 **REQ-SYS-001**: The system SHALL use flattened namespaces throughout all projects.
 
+**REQ-SYS-001-A**: **CRITICAL** - All backend code namespaces SHALL exactly match the file's physical location within the project structure. The namespace declaration in each file SHALL correspond to the folder path where the file resides.
+
+**Example (Compliant):**
+```
+// File: {AppName}.Core/Model/{Aggregate}Aggregate/Events/{Event}.cs
+namespace {AppName}.Core.Model.{Aggregate}Aggregate.Events;
+```
+
+**Example (Non-Compliant):**
+```
+// File: {AppName}.Core/Model/{Aggregate}Aggregate/Events/{Event}.cs
+namespace {AppName}.Core;  // Does not match file location
+```
+
 ### 2.8 Frontend Theme and Colours
 **REQ-SYS-011**: The frontend SHALL use the default Angular Material colours and theme. No new colours are to be introduced.
 

--- a/HomeImprovementProjectManager/docs/specs/implementation-specs.md
+++ b/HomeImprovementProjectManager/docs/specs/implementation-specs.md
@@ -41,6 +41,20 @@ The following architectural constraints are fundamental to the HomeImprovementPr
 ### 2.1 Namespace Architecture
 **REQ-SYS-001**: The system SHALL use flattened namespaces throughout all projects.
 
+**REQ-SYS-001-A**: **CRITICAL** - All backend code namespaces SHALL exactly match the file's physical location within the project structure. The namespace declaration in each file SHALL correspond to the folder path where the file resides.
+
+**Example (Compliant):**
+```
+// File: {AppName}.Core/Model/{Aggregate}Aggregate/Events/{Event}.cs
+namespace {AppName}.Core.Model.{Aggregate}Aggregate.Events;
+```
+
+**Example (Non-Compliant):**
+```
+// File: {AppName}.Core/Model/{Aggregate}Aggregate/Events/{Event}.cs
+namespace {AppName}.Core;  // Does not match file location
+```
+
 ### 2.8 Frontend Theme and Colours
 **REQ-SYS-011**: The frontend SHALL use the default Angular Material colours and theme. No new colours are to be introduced.
 

--- a/HomeInventoryManager/docs/specs/implementation-specs.md
+++ b/HomeInventoryManager/docs/specs/implementation-specs.md
@@ -41,6 +41,20 @@ The following architectural constraints are fundamental to the HomeInventoryMana
 ### 2.1 Namespace Architecture
 **REQ-SYS-001**: The system SHALL use flattened namespaces throughout all projects.
 
+**REQ-SYS-001-A**: **CRITICAL** - All backend code namespaces SHALL exactly match the file's physical location within the project structure. The namespace declaration in each file SHALL correspond to the folder path where the file resides.
+
+**Example (Compliant):**
+```
+// File: {AppName}.Core/Model/{Aggregate}Aggregate/Events/{Event}.cs
+namespace {AppName}.Core.Model.{Aggregate}Aggregate.Events;
+```
+
+**Example (Non-Compliant):**
+```
+// File: {AppName}.Core/Model/{Aggregate}Aggregate/Events/{Event}.cs
+namespace {AppName}.Core;  // Does not match file location
+```
+
 ### 2.8 Frontend Theme and Colours
 **REQ-SYS-011**: The frontend SHALL use the default Angular Material colours and theme. No new colours are to be introduced.
 

--- a/HomeMaintenanceSchedule/docs/specs/implementation-specs.md
+++ b/HomeMaintenanceSchedule/docs/specs/implementation-specs.md
@@ -41,6 +41,20 @@ The following architectural constraints are fundamental to the HomeMaintenanceSc
 ### 2.1 Namespace Architecture
 **REQ-SYS-001**: The system SHALL use flattened namespaces throughout all projects.
 
+**REQ-SYS-001-A**: **CRITICAL** - All backend code namespaces SHALL exactly match the file's physical location within the project structure. The namespace declaration in each file SHALL correspond to the folder path where the file resides.
+
+**Example (Compliant):**
+```
+// File: {AppName}.Core/Model/{Aggregate}Aggregate/Events/{Event}.cs
+namespace {AppName}.Core.Model.{Aggregate}Aggregate.Events;
+```
+
+**Example (Non-Compliant):**
+```
+// File: {AppName}.Core/Model/{Aggregate}Aggregate/Events/{Event}.cs
+namespace {AppName}.Core;  // Does not match file location
+```
+
 ### 2.8 Frontend Theme and Colours
 **REQ-SYS-011**: The frontend SHALL use the default Angular Material colours and theme. No new colours are to be introduced.
 

--- a/HouseholdBudgetManager/docs/specs/implementation-specs.md
+++ b/HouseholdBudgetManager/docs/specs/implementation-specs.md
@@ -41,6 +41,20 @@ The following architectural constraints are fundamental to the HouseholdBudgetMa
 ### 2.1 Namespace Architecture
 **REQ-SYS-001**: The system SHALL use flattened namespaces throughout all projects.
 
+**REQ-SYS-001-A**: **CRITICAL** - All backend code namespaces SHALL exactly match the file's physical location within the project structure. The namespace declaration in each file SHALL correspond to the folder path where the file resides.
+
+**Example (Compliant):**
+```
+// File: {AppName}.Core/Model/{Aggregate}Aggregate/Events/{Event}.cs
+namespace {AppName}.Core.Model.{Aggregate}Aggregate.Events;
+```
+
+**Example (Non-Compliant):**
+```
+// File: {AppName}.Core/Model/{Aggregate}Aggregate/Events/{Event}.cs
+namespace {AppName}.Core;  // Does not match file location
+```
+
 ### 2.8 Frontend Theme and Colours
 **REQ-SYS-011**: The frontend SHALL use the default Angular Material colours and theme. No new colours are to be introduced.
 

--- a/HydrationTracker/docs/specs/implementation-specs.md
+++ b/HydrationTracker/docs/specs/implementation-specs.md
@@ -41,6 +41,20 @@ The following architectural constraints are fundamental to the HydrationTracker 
 ### 2.1 Namespace Architecture
 **REQ-SYS-001**: The system SHALL use flattened namespaces throughout all projects.
 
+**REQ-SYS-001-A**: **CRITICAL** - All backend code namespaces SHALL exactly match the file's physical location within the project structure. The namespace declaration in each file SHALL correspond to the folder path where the file resides.
+
+**Example (Compliant):**
+```
+// File: {AppName}.Core/Model/{Aggregate}Aggregate/Events/{Event}.cs
+namespace {AppName}.Core.Model.{Aggregate}Aggregate.Events;
+```
+
+**Example (Non-Compliant):**
+```
+// File: {AppName}.Core/Model/{Aggregate}Aggregate/Events/{Event}.cs
+namespace {AppName}.Core;  // Does not match file location
+```
+
 ### 2.8 Frontend Theme and Colours
 **REQ-SYS-011**: The frontend SHALL use the default Angular Material colours and theme. No new colours are to be introduced.
 

--- a/InjuryPreventionRecoveryTracker/docs/specs/implementation-specs.md
+++ b/InjuryPreventionRecoveryTracker/docs/specs/implementation-specs.md
@@ -41,6 +41,20 @@ The following architectural constraints are fundamental to the InjuryPreventionR
 ### 2.1 Namespace Architecture
 **REQ-SYS-001**: The system SHALL use flattened namespaces throughout all projects.
 
+**REQ-SYS-001-A**: **CRITICAL** - All backend code namespaces SHALL exactly match the file's physical location within the project structure. The namespace declaration in each file SHALL correspond to the folder path where the file resides.
+
+**Example (Compliant):**
+```
+// File: {AppName}.Core/Model/{Aggregate}Aggregate/Events/{Event}.cs
+namespace {AppName}.Core.Model.{Aggregate}Aggregate.Events;
+```
+
+**Example (Non-Compliant):**
+```
+// File: {AppName}.Core/Model/{Aggregate}Aggregate/Events/{Event}.cs
+namespace {AppName}.Core;  // Does not match file location
+```
+
 ### 2.8 Frontend Theme and Colours
 **REQ-SYS-011**: The frontend SHALL use the default Angular Material colours and theme. No new colours are to be introduced.
 

--- a/InvestmentPortfolioTracker/docs/specs/implementation-specs.md
+++ b/InvestmentPortfolioTracker/docs/specs/implementation-specs.md
@@ -41,6 +41,20 @@ The following architectural constraints are fundamental to the InvestmentPortfol
 ### 2.1 Namespace Architecture
 **REQ-SYS-001**: The system SHALL use flattened namespaces throughout all projects.
 
+**REQ-SYS-001-A**: **CRITICAL** - All backend code namespaces SHALL exactly match the file's physical location within the project structure. The namespace declaration in each file SHALL correspond to the folder path where the file resides.
+
+**Example (Compliant):**
+```
+// File: {AppName}.Core/Model/{Aggregate}Aggregate/Events/{Event}.cs
+namespace {AppName}.Core.Model.{Aggregate}Aggregate.Events;
+```
+
+**Example (Non-Compliant):**
+```
+// File: {AppName}.Core/Model/{Aggregate}Aggregate/Events/{Event}.cs
+namespace {AppName}.Core;  // Does not match file location
+```
+
 ### 2.8 Frontend Theme and Colours
 **REQ-SYS-011**: The frontend SHALL use the default Angular Material colours and theme. No new colours are to be introduced.
 

--- a/JobSearchOrganizer/docs/specs/implementation-specs.md
+++ b/JobSearchOrganizer/docs/specs/implementation-specs.md
@@ -41,6 +41,20 @@ The following architectural constraints are fundamental to the JobSearchOrganize
 ### 2.1 Namespace Architecture
 **REQ-SYS-001**: The system SHALL use flattened namespaces throughout all projects.
 
+**REQ-SYS-001-A**: **CRITICAL** - All backend code namespaces SHALL exactly match the file's physical location within the project structure. The namespace declaration in each file SHALL correspond to the folder path where the file resides.
+
+**Example (Compliant):**
+```
+// File: {AppName}.Core/Model/{Aggregate}Aggregate/Events/{Event}.cs
+namespace {AppName}.Core.Model.{Aggregate}Aggregate.Events;
+```
+
+**Example (Non-Compliant):**
+```
+// File: {AppName}.Core/Model/{Aggregate}Aggregate/Events/{Event}.cs
+namespace {AppName}.Core;  // Does not match file location
+```
+
 ### 2.8 Frontend Theme and Colours
 **REQ-SYS-011**: The frontend SHALL use the default Angular Material colours and theme. No new colours are to be introduced.
 

--- a/KidsActivitySportsTracker/docs/specs/implementation-specs.md
+++ b/KidsActivitySportsTracker/docs/specs/implementation-specs.md
@@ -41,6 +41,20 @@ The following architectural constraints are fundamental to the KidsActivitySport
 ### 2.1 Namespace Architecture
 **REQ-SYS-001**: The system SHALL use flattened namespaces throughout all projects.
 
+**REQ-SYS-001-A**: **CRITICAL** - All backend code namespaces SHALL exactly match the file's physical location within the project structure. The namespace declaration in each file SHALL correspond to the folder path where the file resides.
+
+**Example (Compliant):**
+```
+// File: {AppName}.Core/Model/{Aggregate}Aggregate/Events/{Event}.cs
+namespace {AppName}.Core.Model.{Aggregate}Aggregate.Events;
+```
+
+**Example (Non-Compliant):**
+```
+// File: {AppName}.Core/Model/{Aggregate}Aggregate/Events/{Event}.cs
+namespace {AppName}.Core;  // Does not match file location
+```
+
 ### 2.8 Frontend Theme and Colours
 **REQ-SYS-011**: The frontend SHALL use the default Angular Material colours and theme. No new colours are to be introduced.
 

--- a/KnowledgeBaseSecondBrain/docs/specs/implementation-specs.md
+++ b/KnowledgeBaseSecondBrain/docs/specs/implementation-specs.md
@@ -41,6 +41,20 @@ The following architectural constraints are fundamental to the KnowledgeBaseSeco
 ### 2.1 Namespace Architecture
 **REQ-SYS-001**: The system SHALL use flattened namespaces throughout all projects.
 
+**REQ-SYS-001-A**: **CRITICAL** - All backend code namespaces SHALL exactly match the file's physical location within the project structure. The namespace declaration in each file SHALL correspond to the folder path where the file resides.
+
+**Example (Compliant):**
+```
+// File: {AppName}.Core/Model/{Aggregate}Aggregate/Events/{Event}.cs
+namespace {AppName}.Core.Model.{Aggregate}Aggregate.Events;
+```
+
+**Example (Non-Compliant):**
+```
+// File: {AppName}.Core/Model/{Aggregate}Aggregate/Events/{Event}.cs
+namespace {AppName}.Core;  // Does not match file location
+```
+
 ### 2.8 Frontend Theme and Colours
 **REQ-SYS-011**: The frontend SHALL use the default Angular Material colours and theme. No new colours are to be introduced.
 

--- a/LetterToFutureSelf/docs/specs/implementation-specs.md
+++ b/LetterToFutureSelf/docs/specs/implementation-specs.md
@@ -41,6 +41,20 @@ The following architectural constraints are fundamental to the LetterToFutureSel
 ### 2.1 Namespace Architecture
 **REQ-SYS-001**: The system SHALL use flattened namespaces throughout all projects.
 
+**REQ-SYS-001-A**: **CRITICAL** - All backend code namespaces SHALL exactly match the file's physical location within the project structure. The namespace declaration in each file SHALL correspond to the folder path where the file resides.
+
+**Example (Compliant):**
+```
+// File: {AppName}.Core/Model/{Aggregate}Aggregate/Events/{Event}.cs
+namespace {AppName}.Core.Model.{Aggregate}Aggregate.Events;
+```
+
+**Example (Non-Compliant):**
+```
+// File: {AppName}.Core/Model/{Aggregate}Aggregate/Events/{Event}.cs
+namespace {AppName}.Core;  // Does not match file location
+```
+
 ### 2.8 Frontend Theme and Colours
 **REQ-SYS-011**: The frontend SHALL use the default Angular Material colours and theme. No new colours are to be introduced.
 

--- a/LifeAdminDashboard/docs/specs/implementation-specs.md
+++ b/LifeAdminDashboard/docs/specs/implementation-specs.md
@@ -41,6 +41,20 @@ The following architectural constraints are fundamental to the LifeAdminDashboar
 ### 2.1 Namespace Architecture
 **REQ-SYS-001**: The system SHALL use flattened namespaces throughout all projects.
 
+**REQ-SYS-001-A**: **CRITICAL** - All backend code namespaces SHALL exactly match the file's physical location within the project structure. The namespace declaration in each file SHALL correspond to the folder path where the file resides.
+
+**Example (Compliant):**
+```
+// File: {AppName}.Core/Model/{Aggregate}Aggregate/Events/{Event}.cs
+namespace {AppName}.Core.Model.{Aggregate}Aggregate.Events;
+```
+
+**Example (Non-Compliant):**
+```
+// File: {AppName}.Core/Model/{Aggregate}Aggregate/Events/{Event}.cs
+namespace {AppName}.Core;  // Does not match file location
+```
+
 ### 2.8 Frontend Theme and Colours
 **REQ-SYS-011**: The frontend SHALL use the default Angular Material colours and theme. No new colours are to be introduced.
 

--- a/MarriageEnrichmentJournal/docs/specs/implementation-specs.md
+++ b/MarriageEnrichmentJournal/docs/specs/implementation-specs.md
@@ -41,6 +41,20 @@ The following architectural constraints are fundamental to the MarriageEnrichmen
 ### 2.1 Namespace Architecture
 **REQ-SYS-001**: The system SHALL use flattened namespaces throughout all projects.
 
+**REQ-SYS-001-A**: **CRITICAL** - All backend code namespaces SHALL exactly match the file's physical location within the project structure. The namespace declaration in each file SHALL correspond to the folder path where the file resides.
+
+**Example (Compliant):**
+```
+// File: {AppName}.Core/Model/{Aggregate}Aggregate/Events/{Event}.cs
+namespace {AppName}.Core.Model.{Aggregate}Aggregate.Events;
+```
+
+**Example (Non-Compliant):**
+```
+// File: {AppName}.Core/Model/{Aggregate}Aggregate/Events/{Event}.cs
+namespace {AppName}.Core;  // Does not match file location
+```
+
 ### 2.8 Frontend Theme and Colours
 **REQ-SYS-011**: The frontend SHALL use the default Angular Material colours and theme. No new colours are to be introduced.
 

--- a/MealPrepPlanner/docs/specs/implementation-specs.md
+++ b/MealPrepPlanner/docs/specs/implementation-specs.md
@@ -41,6 +41,20 @@ The following architectural constraints are fundamental to the MealPrepPlanner s
 ### 2.1 Namespace Architecture
 **REQ-SYS-001**: The system SHALL use flattened namespaces throughout all projects.
 
+**REQ-SYS-001-A**: **CRITICAL** - All backend code namespaces SHALL exactly match the file's physical location within the project structure. The namespace declaration in each file SHALL correspond to the folder path where the file resides.
+
+**Example (Compliant):**
+```
+// File: {AppName}.Core/Model/{Aggregate}Aggregate/Events/{Event}.cs
+namespace {AppName}.Core.Model.{Aggregate}Aggregate.Events;
+```
+
+**Example (Non-Compliant):**
+```
+// File: {AppName}.Core/Model/{Aggregate}Aggregate/Events/{Event}.cs
+namespace {AppName}.Core;  // Does not match file location
+```
+
 ### 2.8 Frontend Theme and Colours
 **REQ-SYS-011**: The frontend SHALL use the default Angular Material colours and theme. No new colours are to be introduced.
 

--- a/MedicationReminderSystem/docs/specs/implementation-specs.md
+++ b/MedicationReminderSystem/docs/specs/implementation-specs.md
@@ -41,6 +41,20 @@ The following architectural constraints are fundamental to the MedicationReminde
 ### 2.1 Namespace Architecture
 **REQ-SYS-001**: The system SHALL use flattened namespaces throughout all projects.
 
+**REQ-SYS-001-A**: **CRITICAL** - All backend code namespaces SHALL exactly match the file's physical location within the project structure. The namespace declaration in each file SHALL correspond to the folder path where the file resides.
+
+**Example (Compliant):**
+```
+// File: {AppName}.Core/Model/{Aggregate}Aggregate/Events/{Event}.cs
+namespace {AppName}.Core.Model.{Aggregate}Aggregate.Events;
+```
+
+**Example (Non-Compliant):**
+```
+// File: {AppName}.Core/Model/{Aggregate}Aggregate/Events/{Event}.cs
+namespace {AppName}.Core;  // Does not match file location
+```
+
 ### 2.8 Frontend Theme and Colours
 **REQ-SYS-011**: The frontend SHALL use the default Angular Material colours and theme. No new colours are to be introduced.
 

--- a/MeetingNotesActionItemTracker/docs/specs/implementation-specs.md
+++ b/MeetingNotesActionItemTracker/docs/specs/implementation-specs.md
@@ -41,6 +41,20 @@ The following architectural constraints are fundamental to the MeetingNotesActio
 ### 2.1 Namespace Architecture
 **REQ-SYS-001**: The system SHALL use flattened namespaces throughout all projects.
 
+**REQ-SYS-001-A**: **CRITICAL** - All backend code namespaces SHALL exactly match the file's physical location within the project structure. The namespace declaration in each file SHALL correspond to the folder path where the file resides.
+
+**Example (Compliant):**
+```
+// File: {AppName}.Core/Model/{Aggregate}Aggregate/Events/{Event}.cs
+namespace {AppName}.Core.Model.{Aggregate}Aggregate.Events;
+```
+
+**Example (Non-Compliant):**
+```
+// File: {AppName}.Core/Model/{Aggregate}Aggregate/Events/{Event}.cs
+namespace {AppName}.Core;  // Does not match file location
+```
+
 ### 2.8 Frontend Theme and Colours
 **REQ-SYS-011**: The frontend SHALL use the default Angular Material colours and theme. No new colours are to be introduced.
 

--- a/MensGroupDiscussionTracker/docs/specs/implementation-specs.md
+++ b/MensGroupDiscussionTracker/docs/specs/implementation-specs.md
@@ -41,6 +41,20 @@ The following architectural constraints are fundamental to the MensGroupDiscussi
 ### 2.1 Namespace Architecture
 **REQ-SYS-001**: The system SHALL use flattened namespaces throughout all projects.
 
+**REQ-SYS-001-A**: **CRITICAL** - All backend code namespaces SHALL exactly match the file's physical location within the project structure. The namespace declaration in each file SHALL correspond to the folder path where the file resides.
+
+**Example (Compliant):**
+```
+// File: {AppName}.Core/Model/{Aggregate}Aggregate/Events/{Event}.cs
+namespace {AppName}.Core.Model.{Aggregate}Aggregate.Events;
+```
+
+**Example (Non-Compliant):**
+```
+// File: {AppName}.Core/Model/{Aggregate}Aggregate/Events/{Event}.cs
+namespace {AppName}.Core;  // Does not match file location
+```
+
 ### 2.8 Frontend Theme and Colours
 **REQ-SYS-011**: The frontend SHALL use the default Angular Material colours and theme. No new colours are to be introduced.
 

--- a/MorningRoutineBuilder/docs/specs/implementation-specs.md
+++ b/MorningRoutineBuilder/docs/specs/implementation-specs.md
@@ -41,6 +41,20 @@ The following architectural constraints are fundamental to the MorningRoutineBui
 ### 2.1 Namespace Architecture
 **REQ-SYS-001**: The system SHALL use flattened namespaces throughout all projects.
 
+**REQ-SYS-001-A**: **CRITICAL** - All backend code namespaces SHALL exactly match the file's physical location within the project structure. The namespace declaration in each file SHALL correspond to the folder path where the file resides.
+
+**Example (Compliant):**
+```
+// File: {AppName}.Core/Model/{Aggregate}Aggregate/Events/{Event}.cs
+namespace {AppName}.Core.Model.{Aggregate}Aggregate.Events;
+```
+
+**Example (Non-Compliant):**
+```
+// File: {AppName}.Core/Model/{Aggregate}Aggregate/Events/{Event}.cs
+namespace {AppName}.Core;  // Does not match file location
+```
+
 ### 2.8 Frontend Theme and Colours
 **REQ-SYS-011**: The frontend SHALL use the default Angular Material colours and theme. No new colours are to be introduced.
 

--- a/MortgagePayoffOptimizer/docs/specs/implementation-specs.md
+++ b/MortgagePayoffOptimizer/docs/specs/implementation-specs.md
@@ -41,6 +41,20 @@ The following architectural constraints are fundamental to the MortgagePayoffOpt
 ### 2.1 Namespace Architecture
 **REQ-SYS-001**: The system SHALL use flattened namespaces throughout all projects.
 
+**REQ-SYS-001-A**: **CRITICAL** - All backend code namespaces SHALL exactly match the file's physical location within the project structure. The namespace declaration in each file SHALL correspond to the folder path where the file resides.
+
+**Example (Compliant):**
+```
+// File: {AppName}.Core/Model/{Aggregate}Aggregate/Events/{Event}.cs
+namespace {AppName}.Core.Model.{Aggregate}Aggregate.Events;
+```
+
+**Example (Non-Compliant):**
+```
+// File: {AppName}.Core/Model/{Aggregate}Aggregate/Events/{Event}.cs
+namespace {AppName}.Core;  // Does not match file location
+```
+
 ### 2.8 Frontend Theme and Colours
 **REQ-SYS-011**: The frontend SHALL use the default Angular Material colours and theme. No new colours are to be introduced.
 

--- a/MovieTVShowWatchlist/docs/specs/implementation-specs.md
+++ b/MovieTVShowWatchlist/docs/specs/implementation-specs.md
@@ -41,6 +41,20 @@ The following architectural constraints are fundamental to the MovieTVShowWatchl
 ### 2.1 Namespace Architecture
 **REQ-SYS-001**: The system SHALL use flattened namespaces throughout all projects.
 
+**REQ-SYS-001-A**: **CRITICAL** - All backend code namespaces SHALL exactly match the file's physical location within the project structure. The namespace declaration in each file SHALL correspond to the folder path where the file resides.
+
+**Example (Compliant):**
+```
+// File: {AppName}.Core/Model/{Aggregate}Aggregate/Events/{Event}.cs
+namespace {AppName}.Core.Model.{Aggregate}Aggregate.Events;
+```
+
+**Example (Non-Compliant):**
+```
+// File: {AppName}.Core/Model/{Aggregate}Aggregate/Events/{Event}.cs
+namespace {AppName}.Core;  // Does not match file location
+```
+
 ### 2.8 Frontend Theme and Colours
 **REQ-SYS-011**: The frontend SHALL use the default Angular Material colours and theme. No new colours are to be introduced.
 

--- a/MusicCollectionOrganizer/docs/specs/implementation-specs.md
+++ b/MusicCollectionOrganizer/docs/specs/implementation-specs.md
@@ -41,6 +41,20 @@ The following architectural constraints are fundamental to the MusicCollectionOr
 ### 2.1 Namespace Architecture
 **REQ-SYS-001**: The system SHALL use flattened namespaces throughout all projects.
 
+**REQ-SYS-001-A**: **CRITICAL** - All backend code namespaces SHALL exactly match the file's physical location within the project structure. The namespace declaration in each file SHALL correspond to the folder path where the file resides.
+
+**Example (Compliant):**
+```
+// File: {AppName}.Core/Model/{Aggregate}Aggregate/Events/{Event}.cs
+namespace {AppName}.Core.Model.{Aggregate}Aggregate.Events;
+```
+
+**Example (Non-Compliant):**
+```
+// File: {AppName}.Core/Model/{Aggregate}Aggregate/Events/{Event}.cs
+namespace {AppName}.Core;  // Does not match file location
+```
+
 ### 2.8 Frontend Theme and Colours
 **REQ-SYS-011**: The frontend SHALL use the default Angular Material colours and theme. No new colours are to be introduced.
 

--- a/NeighborhoodSocialNetwork/docs/specs/implementation-specs.md
+++ b/NeighborhoodSocialNetwork/docs/specs/implementation-specs.md
@@ -41,6 +41,20 @@ The following architectural constraints are fundamental to the NeighborhoodSocia
 ### 2.1 Namespace Architecture
 **REQ-SYS-001**: The system SHALL use flattened namespaces throughout all projects.
 
+**REQ-SYS-001-A**: **CRITICAL** - All backend code namespaces SHALL exactly match the file's physical location within the project structure. The namespace declaration in each file SHALL correspond to the folder path where the file resides.
+
+**Example (Compliant):**
+```
+// File: {AppName}.Core/Model/{Aggregate}Aggregate/Events/{Event}.cs
+namespace {AppName}.Core.Model.{Aggregate}Aggregate.Events;
+```
+
+**Example (Non-Compliant):**
+```
+// File: {AppName}.Core/Model/{Aggregate}Aggregate/Events/{Event}.cs
+namespace {AppName}.Core;  // Does not match file location
+```
+
 ### 2.8 Frontend Theme and Colours
 **REQ-SYS-011**: The frontend SHALL use the default Angular Material colours and theme. No new colours are to be introduced.
 

--- a/NutritionLabelScanner/docs/specs/implementation-specs.md
+++ b/NutritionLabelScanner/docs/specs/implementation-specs.md
@@ -41,6 +41,20 @@ The following architectural constraints are fundamental to the NutritionLabelSca
 ### 2.1 Namespace Architecture
 **REQ-SYS-001**: The system SHALL use flattened namespaces throughout all projects.
 
+**REQ-SYS-001-A**: **CRITICAL** - All backend code namespaces SHALL exactly match the file's physical location within the project structure. The namespace declaration in each file SHALL correspond to the folder path where the file resides.
+
+**Example (Compliant):**
+```
+// File: {AppName}.Core/Model/{Aggregate}Aggregate/Events/{Event}.cs
+namespace {AppName}.Core.Model.{Aggregate}Aggregate.Events;
+```
+
+**Example (Non-Compliant):**
+```
+// File: {AppName}.Core/Model/{Aggregate}Aggregate/Events/{Event}.cs
+namespace {AppName}.Core;  // Does not match file location
+```
+
 ### 2.8 Frontend Theme and Colours
 **REQ-SYS-011**: The frontend SHALL use the default Angular Material colours and theme. No new colours are to be introduced.
 

--- a/PasswordAccountAuditor/docs/specs/implementation-specs.md
+++ b/PasswordAccountAuditor/docs/specs/implementation-specs.md
@@ -41,6 +41,20 @@ The following architectural constraints are fundamental to the PasswordAccountAu
 ### 2.1 Namespace Architecture
 **REQ-SYS-001**: The system SHALL use flattened namespaces throughout all projects.
 
+**REQ-SYS-001-A**: **CRITICAL** - All backend code namespaces SHALL exactly match the file's physical location within the project structure. The namespace declaration in each file SHALL correspond to the folder path where the file resides.
+
+**Example (Compliant):**
+```
+// File: {AppName}.Core/Model/{Aggregate}Aggregate/Events/{Event}.cs
+namespace {AppName}.Core.Model.{Aggregate}Aggregate.Events;
+```
+
+**Example (Non-Compliant):**
+```
+// File: {AppName}.Core/Model/{Aggregate}Aggregate/Events/{Event}.cs
+namespace {AppName}.Core;  // Does not match file location
+```
+
 ### 2.8 Frontend Theme and Colours
 **REQ-SYS-011**: The frontend SHALL use the default Angular Material colours and theme. No new colours are to be introduced.
 

--- a/PerformanceReviewPrepTool/docs/specs/implementation-specs.md
+++ b/PerformanceReviewPrepTool/docs/specs/implementation-specs.md
@@ -41,6 +41,20 @@ The following architectural constraints are fundamental to the PerformanceReview
 ### 2.1 Namespace Architecture
 **REQ-SYS-001**: The system SHALL use flattened namespaces throughout all projects.
 
+**REQ-SYS-001-A**: **CRITICAL** - All backend code namespaces SHALL exactly match the file's physical location within the project structure. The namespace declaration in each file SHALL correspond to the folder path where the file resides.
+
+**Example (Compliant):**
+```
+// File: {AppName}.Core/Model/{Aggregate}Aggregate/Events/{Event}.cs
+namespace {AppName}.Core.Model.{Aggregate}Aggregate.Events;
+```
+
+**Example (Non-Compliant):**
+```
+// File: {AppName}.Core/Model/{Aggregate}Aggregate/Events/{Event}.cs
+namespace {AppName}.Core;  // Does not match file location
+```
+
 ### 2.8 Frontend Theme and Colours
 **REQ-SYS-011**: The frontend SHALL use the default Angular Material colours and theme. No new colours are to be introduced.
 

--- a/PersonalHealthDashboard/docs/specs/implementation-specs.md
+++ b/PersonalHealthDashboard/docs/specs/implementation-specs.md
@@ -41,6 +41,20 @@ The following architectural constraints are fundamental to the PersonalHealthDas
 ### 2.1 Namespace Architecture
 **REQ-SYS-001**: The system SHALL use flattened namespaces throughout all projects.
 
+**REQ-SYS-001-A**: **CRITICAL** - All backend code namespaces SHALL exactly match the file's physical location within the project structure. The namespace declaration in each file SHALL correspond to the folder path where the file resides.
+
+**Example (Compliant):**
+```
+// File: {AppName}.Core/Model/{Aggregate}Aggregate/Events/{Event}.cs
+namespace {AppName}.Core.Model.{Aggregate}Aggregate.Events;
+```
+
+**Example (Non-Compliant):**
+```
+// File: {AppName}.Core/Model/{Aggregate}Aggregate/Events/{Event}.cs
+namespace {AppName}.Core;  // Does not match file location
+```
+
 ### 2.8 Frontend Theme and Colours
 **REQ-SYS-011**: The frontend SHALL use the default Angular Material colours and theme. No new colours are to be introduced.
 

--- a/PersonalLibraryLessonsLearned/docs/specs/implementation-specs.md
+++ b/PersonalLibraryLessonsLearned/docs/specs/implementation-specs.md
@@ -41,6 +41,20 @@ The following architectural constraints are fundamental to the PersonalLibraryLe
 ### 2.1 Namespace Architecture
 **REQ-SYS-001**: The system SHALL use flattened namespaces throughout all projects.
 
+**REQ-SYS-001-A**: **CRITICAL** - All backend code namespaces SHALL exactly match the file's physical location within the project structure. The namespace declaration in each file SHALL correspond to the folder path where the file resides.
+
+**Example (Compliant):**
+```
+// File: {AppName}.Core/Model/{Aggregate}Aggregate/Events/{Event}.cs
+namespace {AppName}.Core.Model.{Aggregate}Aggregate.Events;
+```
+
+**Example (Non-Compliant):**
+```
+// File: {AppName}.Core/Model/{Aggregate}Aggregate/Events/{Event}.cs
+namespace {AppName}.Core;  // Does not match file location
+```
+
 ### 2.8 Frontend Theme and Colours
 **REQ-SYS-011**: The frontend SHALL use the default Angular Material colours and theme. No new colours are to be introduced.
 

--- a/PersonalLoanComparisonTool/docs/specs/implementation-specs.md
+++ b/PersonalLoanComparisonTool/docs/specs/implementation-specs.md
@@ -41,6 +41,20 @@ The following architectural constraints are fundamental to the PersonalLoanCompa
 ### 2.1 Namespace Architecture
 **REQ-SYS-001**: The system SHALL use flattened namespaces throughout all projects.
 
+**REQ-SYS-001-A**: **CRITICAL** - All backend code namespaces SHALL exactly match the file's physical location within the project structure. The namespace declaration in each file SHALL correspond to the folder path where the file resides.
+
+**Example (Compliant):**
+```
+// File: {AppName}.Core/Model/{Aggregate}Aggregate/Events/{Event}.cs
+namespace {AppName}.Core.Model.{Aggregate}Aggregate.Events;
+```
+
+**Example (Non-Compliant):**
+```
+// File: {AppName}.Core/Model/{Aggregate}Aggregate/Events/{Event}.cs
+namespace {AppName}.Core;  // Does not match file location
+```
+
 ### 2.8 Frontend Theme and Colours
 **REQ-SYS-011**: The frontend SHALL use the default Angular Material colours and theme. No new colours are to be introduced.
 

--- a/PersonalMissionStatementBuilder/docs/specs/implementation-specs.md
+++ b/PersonalMissionStatementBuilder/docs/specs/implementation-specs.md
@@ -41,6 +41,20 @@ The following architectural constraints are fundamental to the PersonalMissionSt
 ### 2.1 Namespace Architecture
 **REQ-SYS-001**: The system SHALL use flattened namespaces throughout all projects.
 
+**REQ-SYS-001-A**: **CRITICAL** - All backend code namespaces SHALL exactly match the file's physical location within the project structure. The namespace declaration in each file SHALL correspond to the folder path where the file resides.
+
+**Example (Compliant):**
+```
+// File: {AppName}.Core/Model/{Aggregate}Aggregate/Events/{Event}.cs
+namespace {AppName}.Core.Model.{Aggregate}Aggregate.Events;
+```
+
+**Example (Non-Compliant):**
+```
+// File: {AppName}.Core/Model/{Aggregate}Aggregate/Events/{Event}.cs
+namespace {AppName}.Core;  // Does not match file location
+```
+
 ### 2.8 Frontend Theme and Colours
 **REQ-SYS-011**: The frontend SHALL use the default Angular Material colours and theme. No new colours are to be introduced.
 

--- a/PersonalNetWorthDashboard/docs/specs/implementation-specs.md
+++ b/PersonalNetWorthDashboard/docs/specs/implementation-specs.md
@@ -41,6 +41,20 @@ The following architectural constraints are fundamental to the PersonalNetWorthD
 ### 2.1 Namespace Architecture
 **REQ-SYS-001**: The system SHALL use flattened namespaces throughout all projects.
 
+**REQ-SYS-001-A**: **CRITICAL** - All backend code namespaces SHALL exactly match the file's physical location within the project structure. The namespace declaration in each file SHALL correspond to the folder path where the file resides.
+
+**Example (Compliant):**
+```
+// File: {AppName}.Core/Model/{Aggregate}Aggregate/Events/{Event}.cs
+namespace {AppName}.Core.Model.{Aggregate}Aggregate.Events;
+```
+
+**Example (Non-Compliant):**
+```
+// File: {AppName}.Core/Model/{Aggregate}Aggregate/Events/{Event}.cs
+namespace {AppName}.Core;  // Does not match file location
+```
+
 ### 2.8 Frontend Theme and Colours
 **REQ-SYS-011**: The frontend SHALL use the default Angular Material colours and theme. No new colours are to be introduced.
 

--- a/PersonalProjectPipeline/docs/specs/implementation-specs.md
+++ b/PersonalProjectPipeline/docs/specs/implementation-specs.md
@@ -41,6 +41,20 @@ The following architectural constraints are fundamental to the PersonalProjectPi
 ### 2.1 Namespace Architecture
 **REQ-SYS-001**: The system SHALL use flattened namespaces throughout all projects.
 
+**REQ-SYS-001-A**: **CRITICAL** - All backend code namespaces SHALL exactly match the file's physical location within the project structure. The namespace declaration in each file SHALL correspond to the folder path where the file resides.
+
+**Example (Compliant):**
+```
+// File: {AppName}.Core/Model/{Aggregate}Aggregate/Events/{Event}.cs
+namespace {AppName}.Core.Model.{Aggregate}Aggregate.Events;
+```
+
+**Example (Non-Compliant):**
+```
+// File: {AppName}.Core/Model/{Aggregate}Aggregate/Events/{Event}.cs
+namespace {AppName}.Core;  // Does not match file location
+```
+
 ### 2.8 Frontend Theme and Colours
 **REQ-SYS-011**: The frontend SHALL use the default Angular Material colours and theme. No new colours are to be introduced.
 

--- a/PersonalWiki/docs/specs/implementation-specs.md
+++ b/PersonalWiki/docs/specs/implementation-specs.md
@@ -41,6 +41,20 @@ The following architectural constraints are fundamental to the PersonalWiki syst
 ### 2.1 Namespace Architecture
 **REQ-SYS-001**: The system SHALL use flattened namespaces throughout all projects.
 
+**REQ-SYS-001-A**: **CRITICAL** - All backend code namespaces SHALL exactly match the file's physical location within the project structure. The namespace declaration in each file SHALL correspond to the folder path where the file resides.
+
+**Example (Compliant):**
+```
+// File: {AppName}.Core/Model/{Aggregate}Aggregate/Events/{Event}.cs
+namespace {AppName}.Core.Model.{Aggregate}Aggregate.Events;
+```
+
+**Example (Non-Compliant):**
+```
+// File: {AppName}.Core/Model/{Aggregate}Aggregate/Events/{Event}.cs
+namespace {AppName}.Core;  // Does not match file location
+```
+
 ### 2.8 Frontend Theme and Colours
 **REQ-SYS-011**: The frontend SHALL use the default Angular Material colours and theme. No new colours are to be introduced.
 

--- a/PetCareManager/docs/specs/implementation-specs.md
+++ b/PetCareManager/docs/specs/implementation-specs.md
@@ -41,6 +41,20 @@ The following architectural constraints are fundamental to the PetCareManager sy
 ### 2.1 Namespace Architecture
 **REQ-SYS-001**: The system SHALL use flattened namespaces throughout all projects.
 
+**REQ-SYS-001-A**: **CRITICAL** - All backend code namespaces SHALL exactly match the file's physical location within the project structure. The namespace declaration in each file SHALL correspond to the folder path where the file resides.
+
+**Example (Compliant):**
+```
+// File: {AppName}.Core/Model/{Aggregate}Aggregate/Events/{Event}.cs
+namespace {AppName}.Core.Model.{Aggregate}Aggregate.Events;
+```
+
+**Example (Non-Compliant):**
+```
+// File: {AppName}.Core/Model/{Aggregate}Aggregate/Events/{Event}.cs
+namespace {AppName}.Core;  // Does not match file location
+```
+
 ### 2.8 Frontend Theme and Colours
 **REQ-SYS-011**: The frontend SHALL use the default Angular Material colours and theme. No new colours are to be introduced.
 

--- a/PhotographySessionLogger/docs/specs/implementation-specs.md
+++ b/PhotographySessionLogger/docs/specs/implementation-specs.md
@@ -41,6 +41,20 @@ The following architectural constraints are fundamental to the PhotographySessio
 ### 2.1 Namespace Architecture
 **REQ-SYS-001**: The system SHALL use flattened namespaces throughout all projects.
 
+**REQ-SYS-001-A**: **CRITICAL** - All backend code namespaces SHALL exactly match the file's physical location within the project structure. The namespace declaration in each file SHALL correspond to the folder path where the file resides.
+
+**Example (Compliant):**
+```
+// File: {AppName}.Core/Model/{Aggregate}Aggregate/Events/{Event}.cs
+namespace {AppName}.Core.Model.{Aggregate}Aggregate.Events;
+```
+
+**Example (Non-Compliant):**
+```
+// File: {AppName}.Core/Model/{Aggregate}Aggregate/Events/{Event}.cs
+namespace {AppName}.Core;  // Does not match file location
+```
+
 ### 2.8 Frontend Theme and Colours
 **REQ-SYS-011**: The frontend SHALL use the default Angular Material colours and theme. No new colours are to be introduced.
 

--- a/PokerGameTracker/docs/specs/implementation-specs.md
+++ b/PokerGameTracker/docs/specs/implementation-specs.md
@@ -41,6 +41,20 @@ The following architectural constraints are fundamental to the PokerGameTracker 
 ### 2.1 Namespace Architecture
 **REQ-SYS-001**: The system SHALL use flattened namespaces throughout all projects.
 
+**REQ-SYS-001-A**: **CRITICAL** - All backend code namespaces SHALL exactly match the file's physical location within the project structure. The namespace declaration in each file SHALL correspond to the folder path where the file resides.
+
+**Example (Compliant):**
+```
+// File: {AppName}.Core/Model/{Aggregate}Aggregate/Events/{Event}.cs
+namespace {AppName}.Core.Model.{Aggregate}Aggregate.Events;
+```
+
+**Example (Non-Compliant):**
+```
+// File: {AppName}.Core/Model/{Aggregate}Aggregate/Events/{Event}.cs
+namespace {AppName}.Core;  // Does not match file location
+```
+
 ### 2.8 Frontend Theme and Colours
 **REQ-SYS-011**: The frontend SHALL use the default Angular Material colours and theme. No new colours are to be introduced.
 

--- a/ProfessionalNetworkCRM/docs/specs/implementation-specs.md
+++ b/ProfessionalNetworkCRM/docs/specs/implementation-specs.md
@@ -41,6 +41,20 @@ The following architectural constraints are fundamental to the ProfessionalNetwo
 ### 2.1 Namespace Architecture
 **REQ-SYS-001**: The system SHALL use flattened namespaces throughout all projects.
 
+**REQ-SYS-001-A**: **CRITICAL** - All backend code namespaces SHALL exactly match the file's physical location within the project structure. The namespace declaration in each file SHALL correspond to the folder path where the file resides.
+
+**Example (Compliant):**
+```
+// File: {AppName}.Core/Model/{Aggregate}Aggregate/Events/{Event}.cs
+namespace {AppName}.Core.Model.{Aggregate}Aggregate.Events;
+```
+
+**Example (Non-Compliant):**
+```
+// File: {AppName}.Core/Model/{Aggregate}Aggregate/Events/{Event}.cs
+namespace {AppName}.Core;  // Does not match file location
+```
+
 ### 2.8 Frontend Theme and Colours
 **REQ-SYS-011**: The frontend SHALL use the default Angular Material colours and theme. No new colours are to be introduced.
 

--- a/ProfessionalReadingList/docs/specs/implementation-specs.md
+++ b/ProfessionalReadingList/docs/specs/implementation-specs.md
@@ -41,6 +41,20 @@ The following architectural constraints are fundamental to the ProfessionalReadi
 ### 2.1 Namespace Architecture
 **REQ-SYS-001**: The system SHALL use flattened namespaces throughout all projects.
 
+**REQ-SYS-001-A**: **CRITICAL** - All backend code namespaces SHALL exactly match the file's physical location within the project structure. The namespace declaration in each file SHALL correspond to the folder path where the file resides.
+
+**Example (Compliant):**
+```
+// File: {AppName}.Core/Model/{Aggregate}Aggregate/Events/{Event}.cs
+namespace {AppName}.Core.Model.{Aggregate}Aggregate.Events;
+```
+
+**Example (Non-Compliant):**
+```
+// File: {AppName}.Core/Model/{Aggregate}Aggregate/Events/{Event}.cs
+namespace {AppName}.Core;  // Does not match file location
+```
+
 ### 2.8 Frontend Theme and Colours
 **REQ-SYS-011**: The frontend SHALL use the default Angular Material colours and theme. No new colours are to be introduced.
 

--- a/RealEstateInvestmentAnalyzer/docs/specs/implementation-specs.md
+++ b/RealEstateInvestmentAnalyzer/docs/specs/implementation-specs.md
@@ -41,6 +41,20 @@ The following architectural constraints are fundamental to the RealEstateInvestm
 ### 2.1 Namespace Architecture
 **REQ-SYS-001**: The system SHALL use flattened namespaces throughout all projects.
 
+**REQ-SYS-001-A**: **CRITICAL** - All backend code namespaces SHALL exactly match the file's physical location within the project structure. The namespace declaration in each file SHALL correspond to the folder path where the file resides.
+
+**Example (Compliant):**
+```
+// File: {AppName}.Core/Model/{Aggregate}Aggregate/Events/{Event}.cs
+namespace {AppName}.Core.Model.{Aggregate}Aggregate.Events;
+```
+
+**Example (Non-Compliant):**
+```
+// File: {AppName}.Core/Model/{Aggregate}Aggregate/Events/{Event}.cs
+namespace {AppName}.Core;  // Does not match file location
+```
+
 ### 2.8 Frontend Theme and Colours
 **REQ-SYS-011**: The frontend SHALL use the default Angular Material colours and theme. No new colours are to be introduced.
 

--- a/RecipeManagerMealPlanner/docs/specs/implementation-specs.md
+++ b/RecipeManagerMealPlanner/docs/specs/implementation-specs.md
@@ -41,6 +41,20 @@ The following architectural constraints are fundamental to the RecipeManagerMeal
 ### 2.1 Namespace Architecture
 **REQ-SYS-001**: The system SHALL use flattened namespaces throughout all projects.
 
+**REQ-SYS-001-A**: **CRITICAL** - All backend code namespaces SHALL exactly match the file's physical location within the project structure. The namespace declaration in each file SHALL correspond to the folder path where the file resides.
+
+**Example (Compliant):**
+```
+// File: {AppName}.Core/Model/{Aggregate}Aggregate/Events/{Event}.cs
+namespace {AppName}.Core.Model.{Aggregate}Aggregate.Events;
+```
+
+**Example (Non-Compliant):**
+```
+// File: {AppName}.Core/Model/{Aggregate}Aggregate/Events/{Event}.cs
+namespace {AppName}.Core;  // Does not match file location
+```
+
 ### 2.8 Frontend Theme and Colours
 **REQ-SYS-011**: The frontend SHALL use the default Angular Material colours and theme. No new colours are to be introduced.
 

--- a/ResumeCareerAchievementTracker/docs/specs/implementation-specs.md
+++ b/ResumeCareerAchievementTracker/docs/specs/implementation-specs.md
@@ -41,6 +41,20 @@ The following architectural constraints are fundamental to the ResumeCareerAchie
 ### 2.1 Namespace Architecture
 **REQ-SYS-001**: The system SHALL use flattened namespaces throughout all projects.
 
+**REQ-SYS-001-A**: **CRITICAL** - All backend code namespaces SHALL exactly match the file's physical location within the project structure. The namespace declaration in each file SHALL correspond to the folder path where the file resides.
+
+**Example (Compliant):**
+```
+// File: {AppName}.Core/Model/{Aggregate}Aggregate/Events/{Event}.cs
+namespace {AppName}.Core.Model.{Aggregate}Aggregate.Events;
+```
+
+**Example (Non-Compliant):**
+```
+// File: {AppName}.Core/Model/{Aggregate}Aggregate/Events/{Event}.cs
+namespace {AppName}.Core;  // Does not match file location
+```
+
 ### 2.8 Frontend Theme and Colours
 **REQ-SYS-011**: The frontend SHALL use the default Angular Material colours and theme. No new colours are to be introduced.
 

--- a/RetirementSavingsCalculator/docs/specs/implementation-specs.md
+++ b/RetirementSavingsCalculator/docs/specs/implementation-specs.md
@@ -41,6 +41,20 @@ The following architectural constraints are fundamental to the RetirementSavings
 ### 2.1 Namespace Architecture
 **REQ-SYS-001**: The system SHALL use flattened namespaces throughout all projects.
 
+**REQ-SYS-001-A**: **CRITICAL** - All backend code namespaces SHALL exactly match the file's physical location within the project structure. The namespace declaration in each file SHALL correspond to the folder path where the file resides.
+
+**Example (Compliant):**
+```
+// File: {AppName}.Core/Model/{Aggregate}Aggregate/Events/{Event}.cs
+namespace {AppName}.Core.Model.{Aggregate}Aggregate.Events;
+```
+
+**Example (Non-Compliant):**
+```
+// File: {AppName}.Core/Model/{Aggregate}Aggregate/Events/{Event}.cs
+namespace {AppName}.Core;  // Does not match file location
+```
+
 ### 2.8 Frontend Theme and Colours
 **REQ-SYS-011**: The frontend SHALL use the default Angular Material colours and theme. No new colours are to be introduced.
 

--- a/RoadsideAssistanceInfoHub/docs/specs/implementation-specs.md
+++ b/RoadsideAssistanceInfoHub/docs/specs/implementation-specs.md
@@ -41,6 +41,20 @@ The following architectural constraints are fundamental to the RoadsideAssistanc
 ### 2.1 Namespace Architecture
 **REQ-SYS-001**: The system SHALL use flattened namespaces throughout all projects.
 
+**REQ-SYS-001-A**: **CRITICAL** - All backend code namespaces SHALL exactly match the file's physical location within the project structure. The namespace declaration in each file SHALL correspond to the folder path where the file resides.
+
+**Example (Compliant):**
+```
+// File: {AppName}.Core/Model/{Aggregate}Aggregate/Events/{Event}.cs
+namespace {AppName}.Core.Model.{Aggregate}Aggregate.Events;
+```
+
+**Example (Non-Compliant):**
+```
+// File: {AppName}.Core/Model/{Aggregate}Aggregate/Events/{Event}.cs
+namespace {AppName}.Core;  // Does not match file location
+```
+
 ### 2.8 Frontend Theme and Colours
 **REQ-SYS-011**: The frontend SHALL use the default Angular Material colours and theme. No new colours are to be introduced.
 

--- a/RunningLogRaceTracker/docs/specs/implementation-specs.md
+++ b/RunningLogRaceTracker/docs/specs/implementation-specs.md
@@ -41,6 +41,20 @@ The following architectural constraints are fundamental to the RunningLogRaceTra
 ### 2.1 Namespace Architecture
 **REQ-SYS-001**: The system SHALL use flattened namespaces throughout all projects.
 
+**REQ-SYS-001-A**: **CRITICAL** - All backend code namespaces SHALL exactly match the file's physical location within the project structure. The namespace declaration in each file SHALL correspond to the folder path where the file resides.
+
+**Example (Compliant):**
+```
+// File: {AppName}.Core/Model/{Aggregate}Aggregate/Events/{Event}.cs
+namespace {AppName}.Core.Model.{Aggregate}Aggregate.Events;
+```
+
+**Example (Non-Compliant):**
+```
+// File: {AppName}.Core/Model/{Aggregate}Aggregate/Events/{Event}.cs
+namespace {AppName}.Core;  // Does not match file location
+```
+
 ### 2.8 Frontend Theme and Colours
 **REQ-SYS-011**: The frontend SHALL use the default Angular Material colours and theme. No new colours are to be introduced.
 

--- a/SalaryCompensationTracker/docs/specs/implementation-specs.md
+++ b/SalaryCompensationTracker/docs/specs/implementation-specs.md
@@ -41,6 +41,20 @@ The following architectural constraints are fundamental to the SalaryCompensatio
 ### 2.1 Namespace Architecture
 **REQ-SYS-001**: The system SHALL use flattened namespaces throughout all projects.
 
+**REQ-SYS-001-A**: **CRITICAL** - All backend code namespaces SHALL exactly match the file's physical location within the project structure. The namespace declaration in each file SHALL correspond to the folder path where the file resides.
+
+**Example (Compliant):**
+```
+// File: {AppName}.Core/Model/{Aggregate}Aggregate/Events/{Event}.cs
+namespace {AppName}.Core.Model.{Aggregate}Aggregate.Events;
+```
+
+**Example (Non-Compliant):**
+```
+// File: {AppName}.Core/Model/{Aggregate}Aggregate/Events/{Event}.cs
+namespace {AppName}.Core;  // Does not match file location
+```
+
 ### 2.8 Frontend Theme and Colours
 **REQ-SYS-011**: The frontend SHALL use the default Angular Material colours and theme. No new colours are to be introduced.
 

--- a/SideHustleIncomeTracker/docs/specs/implementation-specs.md
+++ b/SideHustleIncomeTracker/docs/specs/implementation-specs.md
@@ -41,6 +41,20 @@ The following architectural constraints are fundamental to the SideHustleIncomeT
 ### 2.1 Namespace Architecture
 **REQ-SYS-001**: The system SHALL use flattened namespaces throughout all projects.
 
+**REQ-SYS-001-A**: **CRITICAL** - All backend code namespaces SHALL exactly match the file's physical location within the project structure. The namespace declaration in each file SHALL correspond to the folder path where the file resides.
+
+**Example (Compliant):**
+```
+// File: {AppName}.Core/Model/{Aggregate}Aggregate/Events/{Event}.cs
+namespace {AppName}.Core.Model.{Aggregate}Aggregate.Events;
+```
+
+**Example (Non-Compliant):**
+```
+// File: {AppName}.Core/Model/{Aggregate}Aggregate/Events/{Event}.cs
+namespace {AppName}.Core;  // Does not match file location
+```
+
 ### 2.8 Frontend Theme and Colours
 **REQ-SYS-011**: The frontend SHALL use the default Angular Material colours and theme. No new colours are to be introduced.
 

--- a/SkillDevelopmentTracker/docs/specs/implementation-specs.md
+++ b/SkillDevelopmentTracker/docs/specs/implementation-specs.md
@@ -41,6 +41,20 @@ The following architectural constraints are fundamental to the SkillDevelopmentT
 ### 2.1 Namespace Architecture
 **REQ-SYS-001**: The system SHALL use flattened namespaces throughout all projects.
 
+**REQ-SYS-001-A**: **CRITICAL** - All backend code namespaces SHALL exactly match the file's physical location within the project structure. The namespace declaration in each file SHALL correspond to the folder path where the file resides.
+
+**Example (Compliant):**
+```
+// File: {AppName}.Core/Model/{Aggregate}Aggregate/Events/{Event}.cs
+namespace {AppName}.Core.Model.{Aggregate}Aggregate.Events;
+```
+
+**Example (Non-Compliant):**
+```
+// File: {AppName}.Core/Model/{Aggregate}Aggregate/Events/{Event}.cs
+namespace {AppName}.Core;  // Does not match file location
+```
+
 ### 2.8 Frontend Theme and Colours
 **REQ-SYS-011**: The frontend SHALL use the default Angular Material colours and theme. No new colours are to be introduced.
 

--- a/SleepQualityTracker/docs/specs/implementation-specs.md
+++ b/SleepQualityTracker/docs/specs/implementation-specs.md
@@ -41,6 +41,20 @@ The following architectural constraints are fundamental to the SleepQualityTrack
 ### 2.1 Namespace Architecture
 **REQ-SYS-001**: The system SHALL use flattened namespaces throughout all projects.
 
+**REQ-SYS-001-A**: **CRITICAL** - All backend code namespaces SHALL exactly match the file's physical location within the project structure. The namespace declaration in each file SHALL correspond to the folder path where the file resides.
+
+**Example (Compliant):**
+```
+// File: {AppName}.Core/Model/{Aggregate}Aggregate/Events/{Event}.cs
+namespace {AppName}.Core.Model.{Aggregate}Aggregate.Events;
+```
+
+**Example (Non-Compliant):**
+```
+// File: {AppName}.Core/Model/{Aggregate}Aggregate/Events/{Event}.cs
+namespace {AppName}.Core;  // Does not match file location
+```
+
 ### 2.8 Frontend Theme and Colours
 **REQ-SYS-011**: The frontend SHALL use the default Angular Material colours and theme. No new colours are to be introduced.
 

--- a/SportsTeamFollowingTracker/docs/specs/implementation-specs.md
+++ b/SportsTeamFollowingTracker/docs/specs/implementation-specs.md
@@ -41,6 +41,20 @@ The following architectural constraints are fundamental to the SportsTeamFollowi
 ### 2.1 Namespace Architecture
 **REQ-SYS-001**: The system SHALL use flattened namespaces throughout all projects.
 
+**REQ-SYS-001-A**: **CRITICAL** - All backend code namespaces SHALL exactly match the file's physical location within the project structure. The namespace declaration in each file SHALL correspond to the folder path where the file resides.
+
+**Example (Compliant):**
+```
+// File: {AppName}.Core/Model/{Aggregate}Aggregate/Events/{Event}.cs
+namespace {AppName}.Core.Model.{Aggregate}Aggregate.Events;
+```
+
+**Example (Non-Compliant):**
+```
+// File: {AppName}.Core/Model/{Aggregate}Aggregate/Events/{Event}.cs
+namespace {AppName}.Core;  // Does not match file location
+```
+
 ### 2.8 Frontend Theme and Colours
 **REQ-SYS-011**: The frontend SHALL use the default Angular Material colours and theme. No new colours are to be introduced.
 

--- a/StressMoodTracker/docs/specs/implementation-specs.md
+++ b/StressMoodTracker/docs/specs/implementation-specs.md
@@ -41,6 +41,20 @@ The following architectural constraints are fundamental to the StressMoodTracker
 ### 2.1 Namespace Architecture
 **REQ-SYS-001**: The system SHALL use flattened namespaces throughout all projects.
 
+**REQ-SYS-001-A**: **CRITICAL** - All backend code namespaces SHALL exactly match the file's physical location within the project structure. The namespace declaration in each file SHALL correspond to the folder path where the file resides.
+
+**Example (Compliant):**
+```
+// File: {AppName}.Core/Model/{Aggregate}Aggregate/Events/{Event}.cs
+namespace {AppName}.Core.Model.{Aggregate}Aggregate.Events;
+```
+
+**Example (Non-Compliant):**
+```
+// File: {AppName}.Core/Model/{Aggregate}Aggregate/Events/{Event}.cs
+namespace {AppName}.Core;  // Does not match file location
+```
+
 ### 2.8 Frontend Theme and Colours
 **REQ-SYS-011**: The frontend SHALL use the default Angular Material colours and theme. No new colours are to be introduced.
 

--- a/SubscriptionAuditTool/docs/specs/implementation-specs.md
+++ b/SubscriptionAuditTool/docs/specs/implementation-specs.md
@@ -41,6 +41,20 @@ The following architectural constraints are fundamental to the SubscriptionAudit
 ### 2.1 Namespace Architecture
 **REQ-SYS-001**: The system SHALL use flattened namespaces throughout all projects.
 
+**REQ-SYS-001-A**: **CRITICAL** - All backend code namespaces SHALL exactly match the file's physical location within the project structure. The namespace declaration in each file SHALL correspond to the folder path where the file resides.
+
+**Example (Compliant):**
+```
+// File: {AppName}.Core/Model/{Aggregate}Aggregate/Events/{Event}.cs
+namespace {AppName}.Core.Model.{Aggregate}Aggregate.Events;
+```
+
+**Example (Non-Compliant):**
+```
+// File: {AppName}.Core/Model/{Aggregate}Aggregate/Events/{Event}.cs
+namespace {AppName}.Core;  // Does not match file location
+```
+
 ### 2.8 Frontend Theme and Colours
 **REQ-SYS-011**: The frontend SHALL use the default Angular Material colours and theme. No new colours are to be introduced.
 

--- a/TaxDeductionOrganizer/docs/specs/implementation-specs.md
+++ b/TaxDeductionOrganizer/docs/specs/implementation-specs.md
@@ -41,6 +41,20 @@ The following architectural constraints are fundamental to the TaxDeductionOrgan
 ### 2.1 Namespace Architecture
 **REQ-SYS-001**: The system SHALL use flattened namespaces throughout all projects.
 
+**REQ-SYS-001-A**: **CRITICAL** - All backend code namespaces SHALL exactly match the file's physical location within the project structure. The namespace declaration in each file SHALL correspond to the folder path where the file resides.
+
+**Example (Compliant):**
+```
+// File: {AppName}.Core/Model/{Aggregate}Aggregate/Events/{Event}.cs
+namespace {AppName}.Core.Model.{Aggregate}Aggregate.Events;
+```
+
+**Example (Non-Compliant):**
+```
+// File: {AppName}.Core/Model/{Aggregate}Aggregate/Events/{Event}.cs
+namespace {AppName}.Core;  // Does not match file location
+```
+
 ### 2.8 Frontend Theme and Colours
 **REQ-SYS-011**: The frontend SHALL use the default Angular Material colours and theme. No new colours are to be introduced.
 

--- a/TimeAuditTracker/docs/specs/implementation-specs.md
+++ b/TimeAuditTracker/docs/specs/implementation-specs.md
@@ -41,6 +41,20 @@ The following architectural constraints are fundamental to the TimeAuditTracker 
 ### 2.1 Namespace Architecture
 **REQ-SYS-001**: The system SHALL use flattened namespaces throughout all projects.
 
+**REQ-SYS-001-A**: **CRITICAL** - All backend code namespaces SHALL exactly match the file's physical location within the project structure. The namespace declaration in each file SHALL correspond to the folder path where the file resides.
+
+**Example (Compliant):**
+```
+// File: {AppName}.Core/Model/{Aggregate}Aggregate/Events/{Event}.cs
+namespace {AppName}.Core.Model.{Aggregate}Aggregate.Events;
+```
+
+**Example (Non-Compliant):**
+```
+// File: {AppName}.Core/Model/{Aggregate}Aggregate/Events/{Event}.cs
+namespace {AppName}.Core;  // Does not match file location
+```
+
 ### 2.8 Frontend Theme and Colours
 **REQ-SYS-011**: The frontend SHALL use the default Angular Material colours and theme. No new colours are to be introduced.
 

--- a/TravelDestinationWishlist/docs/specs/implementation-specs.md
+++ b/TravelDestinationWishlist/docs/specs/implementation-specs.md
@@ -41,6 +41,20 @@ The following architectural constraints are fundamental to the TravelDestination
 ### 2.1 Namespace Architecture
 **REQ-SYS-001**: The system SHALL use flattened namespaces throughout all projects.
 
+**REQ-SYS-001-A**: **CRITICAL** - All backend code namespaces SHALL exactly match the file's physical location within the project structure. The namespace declaration in each file SHALL correspond to the folder path where the file resides.
+
+**Example (Compliant):**
+```
+// File: {AppName}.Core/Model/{Aggregate}Aggregate/Events/{Event}.cs
+namespace {AppName}.Core.Model.{Aggregate}Aggregate.Events;
+```
+
+**Example (Non-Compliant):**
+```
+// File: {AppName}.Core/Model/{Aggregate}Aggregate/Events/{Event}.cs
+namespace {AppName}.Core;  // Does not match file location
+```
+
 ### 2.8 Frontend Theme and Colours
 **REQ-SYS-011**: The frontend SHALL use the default Angular Material colours and theme. No new colours are to be introduced.
 

--- a/VehicleMaintenanceLogger/docs/specs/implementation-specs.md
+++ b/VehicleMaintenanceLogger/docs/specs/implementation-specs.md
@@ -41,6 +41,20 @@ The following architectural constraints are fundamental to the VehicleMaintenanc
 ### 2.1 Namespace Architecture
 **REQ-SYS-001**: The system SHALL use flattened namespaces throughout all projects.
 
+**REQ-SYS-001-A**: **CRITICAL** - All backend code namespaces SHALL exactly match the file's physical location within the project structure. The namespace declaration in each file SHALL correspond to the folder path where the file resides.
+
+**Example (Compliant):**
+```
+// File: {AppName}.Core/Model/{Aggregate}Aggregate/Events/{Event}.cs
+namespace {AppName}.Core.Model.{Aggregate}Aggregate.Events;
+```
+
+**Example (Non-Compliant):**
+```
+// File: {AppName}.Core/Model/{Aggregate}Aggregate/Events/{Event}.cs
+namespace {AppName}.Core;  // Does not match file location
+```
+
 ### 2.8 Frontend Theme and Colours
 **REQ-SYS-011**: The frontend SHALL use the default Angular Material colours and theme. No new colours are to be introduced.
 

--- a/VehicleValueTracker/docs/specs/implementation-specs.md
+++ b/VehicleValueTracker/docs/specs/implementation-specs.md
@@ -41,6 +41,20 @@ The following architectural constraints are fundamental to the VehicleValueTrack
 ### 2.1 Namespace Architecture
 **REQ-SYS-001**: The system SHALL use flattened namespaces throughout all projects.
 
+**REQ-SYS-001-A**: **CRITICAL** - All backend code namespaces SHALL exactly match the file's physical location within the project structure. The namespace declaration in each file SHALL correspond to the folder path where the file resides.
+
+**Example (Compliant):**
+```
+// File: {AppName}.Core/Model/{Aggregate}Aggregate/Events/{Event}.cs
+namespace {AppName}.Core.Model.{Aggregate}Aggregate.Events;
+```
+
+**Example (Non-Compliant):**
+```
+// File: {AppName}.Core/Model/{Aggregate}Aggregate/Events/{Event}.cs
+namespace {AppName}.Core;  // Does not match file location
+```
+
 ### 2.8 Frontend Theme and Colours
 **REQ-SYS-011**: The frontend SHALL use the default Angular Material colours and theme. No new colours are to be introduced.
 

--- a/VideoGameCollectionManager/docs/specs/implementation-specs.md
+++ b/VideoGameCollectionManager/docs/specs/implementation-specs.md
@@ -41,6 +41,20 @@ The following architectural constraints are fundamental to the VideoGameCollecti
 ### 2.1 Namespace Architecture
 **REQ-SYS-001**: The system SHALL use flattened namespaces throughout all projects.
 
+**REQ-SYS-001-A**: **CRITICAL** - All backend code namespaces SHALL exactly match the file's physical location within the project structure. The namespace declaration in each file SHALL correspond to the folder path where the file resides.
+
+**Example (Compliant):**
+```
+// File: {AppName}.Core/Model/{Aggregate}Aggregate/Events/{Event}.cs
+namespace {AppName}.Core.Model.{Aggregate}Aggregate.Events;
+```
+
+**Example (Non-Compliant):**
+```
+// File: {AppName}.Core/Model/{Aggregate}Aggregate/Events/{Event}.cs
+namespace {AppName}.Core;  // Does not match file location
+```
+
 ### 2.8 Frontend Theme and Colours
 **REQ-SYS-011**: The frontend SHALL use the default Angular Material colours and theme. No new colours are to be introduced.
 

--- a/WarrantyReturnPeriodTracker/docs/specs/implementation-specs.md
+++ b/WarrantyReturnPeriodTracker/docs/specs/implementation-specs.md
@@ -41,6 +41,20 @@ The following architectural constraints are fundamental to the WarrantyReturnPer
 ### 2.1 Namespace Architecture
 **REQ-SYS-001**: The system SHALL use flattened namespaces throughout all projects.
 
+**REQ-SYS-001-A**: **CRITICAL** - All backend code namespaces SHALL exactly match the file's physical location within the project structure. The namespace declaration in each file SHALL correspond to the folder path where the file resides.
+
+**Example (Compliant):**
+```
+// File: {AppName}.Core/Model/{Aggregate}Aggregate/Events/{Event}.cs
+namespace {AppName}.Core.Model.{Aggregate}Aggregate.Events;
+```
+
+**Example (Non-Compliant):**
+```
+// File: {AppName}.Core/Model/{Aggregate}Aggregate/Events/{Event}.cs
+namespace {AppName}.Core;  // Does not match file location
+```
+
 ### 2.8 Frontend Theme and Colours
 **REQ-SYS-011**: The frontend SHALL use the default Angular Material colours and theme. No new colours are to be introduced.
 

--- a/WeeklyReviewSystem/docs/specs/implementation-specs.md
+++ b/WeeklyReviewSystem/docs/specs/implementation-specs.md
@@ -41,6 +41,20 @@ The following architectural constraints are fundamental to the WeeklyReviewSyste
 ### 2.1 Namespace Architecture
 **REQ-SYS-001**: The system SHALL use flattened namespaces throughout all projects.
 
+**REQ-SYS-001-A**: **CRITICAL** - All backend code namespaces SHALL exactly match the file's physical location within the project structure. The namespace declaration in each file SHALL correspond to the folder path where the file resides.
+
+**Example (Compliant):**
+```
+// File: {AppName}.Core/Model/{Aggregate}Aggregate/Events/{Event}.cs
+namespace {AppName}.Core.Model.{Aggregate}Aggregate.Events;
+```
+
+**Example (Non-Compliant):**
+```
+// File: {AppName}.Core/Model/{Aggregate}Aggregate/Events/{Event}.cs
+namespace {AppName}.Core;  // Does not match file location
+```
+
 ### 2.8 Frontend Theme and Colours
 **REQ-SYS-011**: The frontend SHALL use the default Angular Material colours and theme. No new colours are to be introduced.
 

--- a/WineCellarInventory/docs/specs/implementation-specs.md
+++ b/WineCellarInventory/docs/specs/implementation-specs.md
@@ -41,6 +41,20 @@ The following architectural constraints are fundamental to the WineCellarInvento
 ### 2.1 Namespace Architecture
 **REQ-SYS-001**: The system SHALL use flattened namespaces throughout all projects.
 
+**REQ-SYS-001-A**: **CRITICAL** - All backend code namespaces SHALL exactly match the file's physical location within the project structure. The namespace declaration in each file SHALL correspond to the folder path where the file resides.
+
+**Example (Compliant):**
+```
+// File: {AppName}.Core/Model/{Aggregate}Aggregate/Events/{Event}.cs
+namespace {AppName}.Core.Model.{Aggregate}Aggregate.Events;
+```
+
+**Example (Non-Compliant):**
+```
+// File: {AppName}.Core/Model/{Aggregate}Aggregate/Events/{Event}.cs
+namespace {AppName}.Core;  // Does not match file location
+```
+
 ### 2.8 Frontend Theme and Colours
 **REQ-SYS-011**: The frontend SHALL use the default Angular Material colours and theme. No new colours are to be introduced.
 

--- a/WoodworkingProjectManager/docs/specs/implementation-specs.md
+++ b/WoodworkingProjectManager/docs/specs/implementation-specs.md
@@ -41,6 +41,20 @@ The following architectural constraints are fundamental to the WoodworkingProjec
 ### 2.1 Namespace Architecture
 **REQ-SYS-001**: The system SHALL use flattened namespaces throughout all projects.
 
+**REQ-SYS-001-A**: **CRITICAL** - All backend code namespaces SHALL exactly match the file's physical location within the project structure. The namespace declaration in each file SHALL correspond to the folder path where the file resides.
+
+**Example (Compliant):**
+```
+// File: {AppName}.Core/Model/{Aggregate}Aggregate/Events/{Event}.cs
+namespace {AppName}.Core.Model.{Aggregate}Aggregate.Events;
+```
+
+**Example (Non-Compliant):**
+```
+// File: {AppName}.Core/Model/{Aggregate}Aggregate/Events/{Event}.cs
+namespace {AppName}.Core;  // Does not match file location
+```
+
 ### 2.8 Frontend Theme and Colours
 **REQ-SYS-011**: The frontend SHALL use the default Angular Material colours and theme. No new colours are to be introduced.
 

--- a/WorkoutPlanBuilder/docs/specs/implementation-specs.md
+++ b/WorkoutPlanBuilder/docs/specs/implementation-specs.md
@@ -41,6 +41,20 @@ The following architectural constraints are fundamental to the WorkoutPlanBuilde
 ### 2.1 Namespace Architecture
 **REQ-SYS-001**: The system SHALL use flattened namespaces throughout all projects.
 
+**REQ-SYS-001-A**: **CRITICAL** - All backend code namespaces SHALL exactly match the file's physical location within the project structure. The namespace declaration in each file SHALL correspond to the folder path where the file resides.
+
+**Example (Compliant):**
+```
+// File: {AppName}.Core/Model/{Aggregate}Aggregate/Events/{Event}.cs
+namespace {AppName}.Core.Model.{Aggregate}Aggregate.Events;
+```
+
+**Example (Non-Compliant):**
+```
+// File: {AppName}.Core/Model/{Aggregate}Aggregate/Events/{Event}.cs
+namespace {AppName}.Core;  // Does not match file location
+```
+
 ### 2.8 Frontend Theme and Colours
 **REQ-SYS-011**: The frontend SHALL use the default Angular Material colours and theme. No new colours are to be introduced.
 


### PR DESCRIPTION
…ations

Add REQ-SYS-001-A to all implementation-specs.md files mandating that backend code namespaces must exactly match the file's physical location within the project structure. This ensures consistent namespace organization across all application backends.