### PR TITLE
Implement delete family member command

### DIFF
--- a/FamilyCalendarEventPlanner/src/FamilyCalendarEventPlanner.Api/Controllers/FamilyMembersController.cs
+++ b/FamilyCalendarEventPlanner/src/FamilyCalendarEventPlanner.Api/Controllers/FamilyMembersController.cs
@@ -100,4 +100,21 @@ public class FamilyMembersController : ControllerBase
 
         return Ok(result);
     }
+
+    [HttpDelete("{memberId:guid}")]
+    [ProducesResponseType(StatusCodes.Status204NoContent)]
+    [ProducesResponseType(StatusCodes.Status404NotFound)]
+    public async Task<IActionResult> DeleteFamilyMember(Guid memberId)
+    {
+        _logger.LogInformation("Deleting family member {MemberId}", memberId);
+
+        var result = await _mediator.Send(new DeleteFamilyMemberCommand { MemberId = memberId });
+
+        if (!result)
+        {
+            return NotFound();
+        }
+
+        return NoContent();
+    }
 }

--- a/FamilyCalendarEventPlanner/src/FamilyCalendarEventPlanner.Api/Features/FamilyMembers/DeleteFamilyMemberCommand.cs
+++ b/FamilyCalendarEventPlanner/src/FamilyCalendarEventPlanner.Api/Features/FamilyMembers/DeleteFamilyMemberCommand.cs
@@ -1,0 +1,46 @@
+using FamilyCalendarEventPlanner.Core;
+using MediatR;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
+
+namespace FamilyCalendarEventPlanner.Api.Features.FamilyMembers;
+
+public record DeleteFamilyMemberCommand : IRequest<bool>
+{
+    public Guid MemberId { get; init; }
+}
+
+public class DeleteFamilyMemberCommandHandler : IRequestHandler<DeleteFamilyMemberCommand, bool>
+{
+    private readonly IFamilyCalendarEventPlannerContext _context;
+    private readonly ILogger<DeleteFamilyMemberCommandHandler> _logger;
+
+    public DeleteFamilyMemberCommandHandler(
+        IFamilyCalendarEventPlannerContext context,
+        ILogger<DeleteFamilyMemberCommandHandler> logger)
+    {
+        _context = context;
+        _logger = logger;
+    }
+
+    public async Task<bool> Handle(DeleteFamilyMemberCommand request, CancellationToken cancellationToken)
+    {
+        _logger.LogInformation("Deleting family member {MemberId}", request.MemberId);
+
+        var member = await _context.FamilyMembers
+            .FirstOrDefaultAsync(m => m.MemberId == request.MemberId, cancellationToken);
+
+        if (member == null)
+        {
+            _logger.LogWarning("Family member {MemberId} not found", request.MemberId);
+            return false;
+        }
+
+        _context.FamilyMembers.Remove(member);
+        await _context.SaveChangesAsync(cancellationToken);
+
+        _logger.LogInformation("Deleted family member {MemberId}", request.MemberId);
+
+        return true;
+    }
+}


### PR DESCRIPTION
Implement DeleteFamilyMemberCommand with MediatR handler that allows the admin UI to delete family members from the database. The command follows the existing pattern used for DeleteAvailabilityBlockCommand.

Changes:
- Add DeleteFamilyMemberCommand.cs with handler in Features/FamilyMembers
- Add DELETE endpoint to FamilyMembersController