### PR TITLE
Add family member properties and filtering

### DIFF
--- a/FamilyCalendarEventPlanner/docs/icd.md
+++ b/FamilyCalendarEventPlanner/docs/icd.md
@@ -199,12 +199,13 @@ Mark a calendar event as completed.
 
 ### 3.1 GET /api/familymembers
 
-Get all family members, optionally filtered by family ID.
+Get all family members, optionally filtered by family ID and/or immediate family status.
 
 **Query Parameters:**
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
 | familyId | Guid | No | Filter members by family ID |
+| isImmediate | bool | No | Filter by immediate family status (true = immediate family only, false = extended family only) |
 
 **Response:** `200 OK`
 ```json
@@ -213,9 +214,11 @@ Get all family members, optionally filtered by family ID.
     "memberId": "guid",
     "familyId": "guid",
     "name": "string",
-    "email": "string",
+    "email": "string|null",
     "color": "string",
-    "role": "Admin|Member|ViewOnly"
+    "role": "Admin|Member|ViewOnly",
+    "isImmediate": "boolean",
+    "relationType": "Self|Spouse|Child|Parent|Sibling|Grandparent|Grandchild|AuntUncle|NieceNephew|Cousin|InLaw|Other"
   }
 ]
 ```
@@ -235,9 +238,11 @@ Get a specific family member by ID.
   "memberId": "guid",
   "familyId": "guid",
   "name": "string",
-  "email": "string",
+  "email": "string|null",
   "color": "string",
-  "role": "Admin|Member|ViewOnly"
+  "role": "Admin|Member|ViewOnly",
+  "isImmediate": "boolean",
+  "relationType": "Self|Spouse|Child|Parent|Sibling|Grandparent|Grandchild|AuntUncle|NieceNephew|Cousin|InLaw|Other"
 }
 ```
 
@@ -250,9 +255,11 @@ Create a new family member.
 {
   "familyId": "guid",
   "name": "string",
-  "email": "string",
+  "email": "string|null",
   "color": "string",
-  "role": "Admin|Member|ViewOnly"
+  "role": "Admin|Member|ViewOnly",
+  "isImmediate": "boolean",
+  "relationType": "Self|Spouse|Child|Parent|Sibling|Grandparent|Grandchild|AuntUncle|NieceNephew|Cousin|InLaw|Other"
 }
 ```
 
@@ -272,7 +279,9 @@ Update an existing family member's profile.
 {
   "name": "string|null",
   "email": "string|null",
-  "color": "string|null"
+  "color": "string|null",
+  "isImmediate": "boolean|null",
+  "relationType": "Self|Spouse|Child|Parent|Sibling|Grandparent|Grandchild|AuntUncle|NieceNephew|Cousin|InLaw|Other|null"
 }
 ```
 
@@ -580,24 +589,38 @@ Delete a reminder.
 - Member
 - ViewOnly
 
-### 8.5 RSVPStatus
+### 8.5 RelationType
+- Self
+- Spouse
+- Child
+- Parent
+- Sibling
+- Grandparent
+- Grandchild
+- AuntUncle
+- NieceNephew
+- Cousin
+- InLaw
+- Other
+
+### 8.6 RSVPStatus
 - Pending
 - Accepted
 - Declined
 - Tentative
 
-### 8.6 BlockType
+### 8.7 BlockType
 - Busy
 - OutOfOffice
 - Personal
 
-### 8.7 ConflictSeverity
+### 8.8 ConflictSeverity
 - Low
 - Medium
 - High
 - Critical
 
-### 8.8 NotificationChannel
+### 8.9 NotificationChannel
 - Email
 - Push
 - SMS
@@ -632,6 +655,7 @@ getEvents(): Observable<CalendarEvent[]> {
 | Version | Date | Description |
 |---------|------|-------------|
 | 1.0 | 2025-12-29 | Initial ICD document |
+| 1.1 | 2025-12-30 | Added IsImmediate, RelationType to FamilyMember; made email optional; added isImmediate query filter |
 
 ---
 

--- a/FamilyCalendarEventPlanner/src/FamilyCalendarEventPlanner.Api/Controllers/FamilyMembersController.cs
+++ b/FamilyCalendarEventPlanner/src/FamilyCalendarEventPlanner.Api/Controllers/FamilyMembersController.cs
@@ -19,11 +19,20 @@ public class FamilyMembersController : ControllerBase
 
     [HttpGet]
     [ProducesResponseType(typeof(IEnumerable<FamilyMemberDto>), StatusCodes.Status200OK)]
-    public async Task<ActionResult<IEnumerable<FamilyMemberDto>>> GetFamilyMembers([FromQuery] Guid? familyId)
+    public async Task<ActionResult<IEnumerable<FamilyMemberDto>>> GetFamilyMembers(
+        [FromQuery] Guid? familyId,
+        [FromQuery] bool? isImmediate)
     {
-        _logger.LogInformation("Getting family members for family {FamilyId}", familyId);
+        _logger.LogInformation(
+            "Getting family members for family {FamilyId}, isImmediate: {IsImmediate}",
+            familyId,
+            isImmediate);
 
-        var result = await _mediator.Send(new GetFamilyMembersQuery { FamilyId = familyId });
+        var result = await _mediator.Send(new GetFamilyMembersQuery
+        {
+            FamilyId = familyId,
+            IsImmediate = isImmediate
+        });
 
         return Ok(result);
     }

--- a/FamilyCalendarEventPlanner/src/FamilyCalendarEventPlanner.Api/Features/FamilyMembers/CreateFamilyMemberCommand.cs
+++ b/FamilyCalendarEventPlanner/src/FamilyCalendarEventPlanner.Api/Features/FamilyMembers/CreateFamilyMemberCommand.cs
@@ -10,9 +10,11 @@ public record CreateFamilyMemberCommand : IRequest<FamilyMemberDto>
 {
     public Guid FamilyId { get; init; }
     public string Name { get; init; } = string.Empty;
-    public string Email { get; init; } = string.Empty;
+    public string? Email { get; init; }
     public string Color { get; init; } = string.Empty;
     public MemberRole Role { get; init; }
+    public bool IsImmediate { get; init; } = true;
+    public RelationType RelationType { get; init; } = RelationType.Self;
 }
 
 public class CreateFamilyMemberCommandHandler : IRequestHandler<CreateFamilyMemberCommand, FamilyMemberDto>
@@ -40,7 +42,9 @@ public class CreateFamilyMemberCommandHandler : IRequestHandler<CreateFamilyMemb
             request.Name,
             request.Email,
             request.Color,
-            request.Role);
+            request.Role,
+            request.IsImmediate,
+            request.RelationType);
 
         _context.FamilyMembers.Add(member);
         await _context.SaveChangesAsync(cancellationToken);

--- a/FamilyCalendarEventPlanner/src/FamilyCalendarEventPlanner.Api/Features/FamilyMembers/FamilyMemberDto.cs
+++ b/FamilyCalendarEventPlanner/src/FamilyCalendarEventPlanner.Api/Features/FamilyMembers/FamilyMemberDto.cs
@@ -8,9 +8,11 @@ public record FamilyMemberDto
     public Guid MemberId { get; init; }
     public Guid FamilyId { get; init; }
     public string Name { get; init; } = string.Empty;
-    public string Email { get; init; } = string.Empty;
+    public string? Email { get; init; }
     public string Color { get; init; } = string.Empty;
     public MemberRole Role { get; init; }
+    public bool IsImmediate { get; init; }
+    public RelationType RelationType { get; init; }
 }
 
 public static class FamilyMemberExtensions
@@ -25,6 +27,8 @@ public static class FamilyMemberExtensions
             Email = member.Email,
             Color = member.Color,
             Role = member.Role,
+            IsImmediate = member.IsImmediate,
+            RelationType = member.RelationType,
         };
     }
 }

--- a/FamilyCalendarEventPlanner/src/FamilyCalendarEventPlanner.Api/Features/FamilyMembers/GetFamilyMembersQuery.cs
+++ b/FamilyCalendarEventPlanner/src/FamilyCalendarEventPlanner.Api/Features/FamilyMembers/GetFamilyMembersQuery.cs
@@ -8,6 +8,7 @@ namespace FamilyCalendarEventPlanner.Api.Features.FamilyMembers;
 public record GetFamilyMembersQuery : IRequest<IEnumerable<FamilyMemberDto>>
 {
     public Guid? FamilyId { get; init; }
+    public bool? IsImmediate { get; init; }
 }
 
 public class GetFamilyMembersQueryHandler : IRequestHandler<GetFamilyMembersQuery, IEnumerable<FamilyMemberDto>>
@@ -25,13 +26,21 @@ public class GetFamilyMembersQueryHandler : IRequestHandler<GetFamilyMembersQuer
 
     public async Task<IEnumerable<FamilyMemberDto>> Handle(GetFamilyMembersQuery request, CancellationToken cancellationToken)
     {
-        _logger.LogInformation("Getting family members for family {FamilyId}", request.FamilyId);
+        _logger.LogInformation(
+            "Getting family members for family {FamilyId}, isImmediate: {IsImmediate}",
+            request.FamilyId,
+            request.IsImmediate);
 
         var query = _context.FamilyMembers.AsNoTracking();
 
         if (request.FamilyId.HasValue)
         {
             query = query.Where(m => m.FamilyId == request.FamilyId.Value);
+        }
+
+        if (request.IsImmediate.HasValue)
+        {
+            query = query.Where(m => m.IsImmediate == request.IsImmediate.Value);
         }
 
         var members = await query

--- a/FamilyCalendarEventPlanner/src/FamilyCalendarEventPlanner.Api/Features/FamilyMembers/UpdateFamilyMemberCommand.cs
+++ b/FamilyCalendarEventPlanner/src/FamilyCalendarEventPlanner.Api/Features/FamilyMembers/UpdateFamilyMemberCommand.cs
@@ -1,4 +1,5 @@
 using FamilyCalendarEventPlanner.Core;
+using FamilyCalendarEventPlanner.Core.Model.FamilyMemberAggregate.Enums;
 using MediatR;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging;
@@ -11,6 +12,8 @@ public record UpdateFamilyMemberCommand : IRequest<FamilyMemberDto?>
     public string? Name { get; init; }
     public string? Email { get; init; }
     public string? Color { get; init; }
+    public bool? IsImmediate { get; init; }
+    public RelationType? RelationType { get; init; }
 }
 
 public class UpdateFamilyMemberCommandHandler : IRequestHandler<UpdateFamilyMemberCommand, FamilyMemberDto?>
@@ -39,7 +42,12 @@ public class UpdateFamilyMemberCommandHandler : IRequestHandler<UpdateFamilyMemb
             return null;
         }
 
-        member.UpdateProfile(request.Name, request.Email, request.Color);
+        member.UpdateProfile(
+            request.Name,
+            request.Email,
+            request.Color,
+            request.IsImmediate,
+            request.RelationType);
         await _context.SaveChangesAsync(cancellationToken);
 
         _logger.LogInformation("Updated family member {MemberId}", request.MemberId);

--- a/FamilyCalendarEventPlanner/src/FamilyCalendarEventPlanner.Core/Model/FamilyMemberAggregate/Enums/RelationType.cs
+++ b/FamilyCalendarEventPlanner/src/FamilyCalendarEventPlanner.Core/Model/FamilyMemberAggregate/Enums/RelationType.cs
@@ -1,0 +1,17 @@
+namespace FamilyCalendarEventPlanner.Core.Model.FamilyMemberAggregate.Enums;
+
+public enum RelationType
+{
+    Self,
+    Spouse,
+    Child,
+    Parent,
+    Sibling,
+    Grandparent,
+    Grandchild,
+    AuntUncle,
+    NieceNephew,
+    Cousin,
+    InLaw,
+    Other
+}

--- a/FamilyCalendarEventPlanner/src/FamilyCalendarEventPlanner.Core/Model/FamilyMemberAggregate/FamilyMember.cs
+++ b/FamilyCalendarEventPlanner/src/FamilyCalendarEventPlanner.Core/Model/FamilyMemberAggregate/FamilyMember.cs
@@ -7,24 +7,28 @@ public class FamilyMember
     public Guid MemberId { get; private set; }
     public Guid FamilyId { get; private set; }
     public string Name { get; private set; } = string.Empty;
-    public string Email { get; private set; } = string.Empty;
+    public string? Email { get; private set; }
     public string Color { get; private set; } = string.Empty;
     public MemberRole Role { get; private set; }
+    public bool IsImmediate { get; private set; }
+    public RelationType RelationType { get; private set; }
 
     private FamilyMember()
     {
     }
 
-    public FamilyMember(Guid familyId, string name, string email, string color, MemberRole role = MemberRole.Member)
+    public FamilyMember(
+        Guid familyId,
+        string name,
+        string? email,
+        string color,
+        MemberRole role = MemberRole.Member,
+        bool isImmediate = true,
+        RelationType relationType = RelationType.Self)
     {
         if (string.IsNullOrWhiteSpace(name))
         {
             throw new ArgumentException("Name cannot be empty.", nameof(name));
-        }
-
-        if (string.IsNullOrWhiteSpace(email))
-        {
-            throw new ArgumentException("Email cannot be empty.", nameof(email));
         }
 
         if (string.IsNullOrWhiteSpace(color))
@@ -35,12 +39,19 @@ public class FamilyMember
         MemberId = Guid.NewGuid();
         FamilyId = familyId;
         Name = name;
-        Email = email;
+        Email = string.IsNullOrWhiteSpace(email) ? null : email;
         Color = color;
         Role = role;
+        IsImmediate = isImmediate;
+        RelationType = relationType;
     }
 
-    public void UpdateProfile(string? name = null, string? email = null, string? color = null)
+    public void UpdateProfile(
+        string? name = null,
+        string? email = null,
+        string? color = null,
+        bool? isImmediate = null,
+        RelationType? relationType = null)
     {
         if (name != null)
         {
@@ -54,12 +65,7 @@ public class FamilyMember
 
         if (email != null)
         {
-            if (string.IsNullOrWhiteSpace(email))
-            {
-                throw new ArgumentException("Email cannot be empty.", nameof(email));
-            }
-
-            Email = email;
+            Email = string.IsNullOrWhiteSpace(email) ? null : email;
         }
 
         if (color != null)
@@ -70,6 +76,16 @@ public class FamilyMember
             }
 
             Color = color;
+        }
+
+        if (isImmediate.HasValue)
+        {
+            IsImmediate = isImmediate.Value;
+        }
+
+        if (relationType.HasValue)
+        {
+            RelationType = relationType.Value;
         }
     }
 

--- a/FamilyCalendarEventPlanner/src/FamilyCalendarEventPlanner.Infrastructure/Data/Configurations/FamilyMemberConfiguration.cs
+++ b/FamilyCalendarEventPlanner/src/FamilyCalendarEventPlanner.Infrastructure/Data/Configurations/FamilyMemberConfiguration.cs
@@ -18,14 +18,24 @@ public class FamilyMemberConfiguration : IEntityTypeConfiguration<FamilyMember>
             .HasMaxLength(100);
 
         builder.Property(m => m.Email)
-            .IsRequired()
+            .IsRequired(false)
             .HasMaxLength(255);
 
         builder.Property(m => m.Color)
             .IsRequired()
             .HasMaxLength(50);
 
+        builder.Property(m => m.IsImmediate)
+            .IsRequired()
+            .HasDefaultValue(true);
+
+        builder.Property(m => m.RelationType)
+            .IsRequired()
+            .HasConversion<string>()
+            .HasMaxLength(50);
+
         builder.HasIndex(m => m.FamilyId);
         builder.HasIndex(m => m.Email);
+        builder.HasIndex(m => m.IsImmediate);
     }
 }

--- a/FamilyCalendarEventPlanner/src/FamilyCalendarEventPlanner.WebApp/projects/family-calendar-event-planner-admin/src/app/components/create-or-edit-family-member-dialog/create-or-edit-family-member-dialog.html
+++ b/FamilyCalendarEventPlanner/src/FamilyCalendarEventPlanner.WebApp/projects/family-calendar-event-planner-admin/src/app/components/create-or-edit-family-member-dialog/create-or-edit-family-member-dialog.html
@@ -11,13 +11,22 @@
     </mat-form-field>
 
     <mat-form-field appearance="outline" class="dialog-form__field">
-      <mat-label>Email</mat-label>
-      <input matInput type="email" formControlName="email" placeholder="Enter email address" required>
-      @if (form.get('email')?.hasError('required') && form.get('email')?.touched) {
-        <mat-error>Email is required</mat-error>
-      }
+      <mat-label>Email (optional)</mat-label>
+      <input matInput type="email" formControlName="email" placeholder="Enter email address">
       @if (form.get('email')?.hasError('email') && form.get('email')?.touched) {
         <mat-error>Please enter a valid email address</mat-error>
+      }
+    </mat-form-field>
+
+    <mat-form-field appearance="outline" class="dialog-form__field">
+      <mat-label>Relation Type</mat-label>
+      <mat-select formControlName="relationType" required>
+        @for (relationType of availableRelationTypes; track relationType.value) {
+          <mat-option [value]="relationType.value">{{ relationType.label }}</mat-option>
+        }
+      </mat-select>
+      @if (form.get('relationType')?.hasError('required') && form.get('relationType')?.touched) {
+        <mat-error>Relation type is required</mat-error>
       }
     </mat-form-field>
 
@@ -49,6 +58,13 @@
         <mat-error>Color is required</mat-error>
       }
     </mat-form-field>
+
+    <div class="dialog-form__checkbox">
+      <mat-checkbox formControlName="isImmediate">
+        Immediate Family Member
+      </mat-checkbox>
+      <span class="dialog-form__hint">Check if this is an immediate family member (spouse, child, parent, sibling)</span>
+    </div>
   </form>
 </mat-dialog-content>
 

--- a/FamilyCalendarEventPlanner/src/FamilyCalendarEventPlanner.WebApp/projects/family-calendar-event-planner-admin/src/app/components/create-or-edit-family-member-dialog/create-or-edit-family-member-dialog.ts
+++ b/FamilyCalendarEventPlanner/src/FamilyCalendarEventPlanner.WebApp/projects/family-calendar-event-planner-admin/src/app/components/create-or-edit-family-member-dialog/create-or-edit-family-member-dialog.ts
@@ -6,7 +6,8 @@ import { MatFormFieldModule } from '@angular/material/form-field';
 import { MatInputModule } from '@angular/material/input';
 import { MatButtonModule } from '@angular/material/button';
 import { MatSelectModule } from '@angular/material/select';
-import { FamilyMemberDto } from '../../models/family-member-dto';
+import { MatCheckboxModule } from '@angular/material/checkbox';
+import { FamilyMemberDto, RelationType } from '../../models/family-member-dto';
 import { CreateFamilyMemberCommand } from '../../models/create-family-member-command';
 
 export interface CreateOrEditFamilyMemberDialogData {
@@ -29,7 +30,8 @@ export interface CreateOrEditFamilyMemberDialogResult {
     MatFormFieldModule,
     MatInputModule,
     MatButtonModule,
-    MatSelectModule
+    MatSelectModule,
+    MatCheckboxModule
   ],
   templateUrl: './create-or-edit-family-member-dialog.html',
   styleUrls: ['./create-or-edit-family-member-dialog.scss']
@@ -56,15 +58,32 @@ export class CreateOrEditFamilyMemberDialog {
     { value: 'ViewOnly', label: 'View Only' }
   ];
 
+  availableRelationTypes: { value: RelationType; label: string }[] = [
+    { value: 'Self', label: 'Self' },
+    { value: 'Spouse', label: 'Spouse' },
+    { value: 'Child', label: 'Child' },
+    { value: 'Parent', label: 'Parent' },
+    { value: 'Sibling', label: 'Sibling' },
+    { value: 'Grandparent', label: 'Grandparent' },
+    { value: 'Grandchild', label: 'Grandchild' },
+    { value: 'AuntUncle', label: 'Aunt/Uncle' },
+    { value: 'NieceNephew', label: 'Niece/Nephew' },
+    { value: 'Cousin', label: 'Cousin' },
+    { value: 'InLaw', label: 'In-Law' },
+    { value: 'Other', label: 'Other' }
+  ];
+
   constructor(
     public dialogRef: MatDialogRef<CreateOrEditFamilyMemberDialog>,
     @Inject(MAT_DIALOG_DATA) public data: CreateOrEditFamilyMemberDialogData
   ) {
     this.form = this.fb.group({
       name: [data.member?.name || '', Validators.required],
-      email: [data.member?.email || '', [Validators.required, Validators.email]],
+      email: [data.member?.email || '', [Validators.email]],
       color: [data.member?.color || '#3b82f6', Validators.required],
-      role: [data.member?.role || 'Member', Validators.required]
+      role: [data.member?.role || 'Member', Validators.required],
+      isImmediate: [data.member?.isImmediate ?? true],
+      relationType: [data.member?.relationType || 'Self', Validators.required]
     });
   }
 
@@ -85,9 +104,11 @@ export class CreateOrEditFamilyMemberDialog {
         data: {
           familyId: this.data.familyId,
           name: formValue.name,
-          email: formValue.email,
+          email: formValue.email || null,
           color: formValue.color,
           role: formValue.role,
+          isImmediate: formValue.isImmediate,
+          relationType: formValue.relationType,
           ...(this.isEditMode && { memberId: this.data.member!.memberId })
         }
       };

--- a/FamilyCalendarEventPlanner/src/FamilyCalendarEventPlanner.WebApp/projects/family-calendar-event-planner-admin/src/app/models/create-family-member-command.ts
+++ b/FamilyCalendarEventPlanner/src/FamilyCalendarEventPlanner.WebApp/projects/family-calendar-event-planner-admin/src/app/models/create-family-member-command.ts
@@ -1,7 +1,11 @@
+import { RelationType } from './family-member-dto';
+
 export interface CreateFamilyMemberCommand {
   familyId: string;
   name: string;
-  email: string;
+  email?: string | null;
   color: string;
   role: string;
+  isImmediate: boolean;
+  relationType: RelationType;
 }

--- a/FamilyCalendarEventPlanner/src/FamilyCalendarEventPlanner.WebApp/projects/family-calendar-event-planner-admin/src/app/models/family-member-dto.ts
+++ b/FamilyCalendarEventPlanner/src/FamilyCalendarEventPlanner.WebApp/projects/family-calendar-event-planner-admin/src/app/models/family-member-dto.ts
@@ -1,8 +1,24 @@
+export type RelationType =
+  | 'Self'
+  | 'Spouse'
+  | 'Child'
+  | 'Parent'
+  | 'Sibling'
+  | 'Grandparent'
+  | 'Grandchild'
+  | 'AuntUncle'
+  | 'NieceNephew'
+  | 'Cousin'
+  | 'InLaw'
+  | 'Other';
+
 export interface FamilyMemberDto {
   memberId: string;
   familyId: string;
   name: string;
-  email: string;
+  email: string | null;
   color: string;
   role: string;
+  isImmediate: boolean;
+  relationType: RelationType;
 }

--- a/FamilyCalendarEventPlanner/src/FamilyCalendarEventPlanner.WebApp/projects/family-calendar-event-planner-admin/src/app/pages/family-members/family-members.html
+++ b/FamilyCalendarEventPlanner/src/FamilyCalendarEventPlanner.WebApp/projects/family-calendar-event-planner-admin/src/app/pages/family-members/family-members.html
@@ -13,6 +13,14 @@
     </button>
   </div>
 
+  <div class="family-members__filters">
+    <mat-button-toggle-group [value]="(immediateFilter$ | async)" (change)="onFilterChange($event.value)">
+      <mat-button-toggle value="all">All Members</mat-button-toggle>
+      <mat-button-toggle value="immediate">Immediate Family</mat-button-toggle>
+      <mat-button-toggle value="extended">Extended Family</mat-button-toggle>
+    </mat-button-toggle-group>
+  </div>
+
   <div class="family-members__table-container">
     <table mat-table [dataSource]="(members$ | async) || []" class="family-members__table">
       <!-- Avatar Column -->
@@ -34,7 +42,13 @@
       <!-- Email Column -->
       <ng-container matColumnDef="email">
         <th mat-header-cell *matHeaderCellDef>Email</th>
-        <td mat-cell *matCellDef="let member">{{ member.email }}</td>
+        <td mat-cell *matCellDef="let member">{{ member.email || '-' }}</td>
+      </ng-container>
+
+      <!-- Relation Type Column -->
+      <ng-container matColumnDef="relationType">
+        <th mat-header-cell *matHeaderCellDef>Relation</th>
+        <td mat-cell *matCellDef="let member">{{ getRelationTypeLabel(member.relationType) }}</td>
       </ng-container>
 
       <!-- Role Column -->
@@ -44,6 +58,17 @@
           <span class="family-members__role-badge" [class.family-members__role-badge--admin]="member.role === 'Admin'">
             {{ member.role }}
           </span>
+        </td>
+      </ng-container>
+
+      <!-- Is Immediate Column -->
+      <ng-container matColumnDef="isImmediate">
+        <th mat-header-cell *matHeaderCellDef>Immediate</th>
+        <td mat-cell *matCellDef="let member">
+          <mat-icon [class.family-members__immediate--yes]="member.isImmediate"
+                    [class.family-members__immediate--no]="!member.isImmediate">
+            {{ member.isImmediate ? 'check_circle' : 'cancel' }}
+          </mat-icon>
         </td>
       </ng-container>
 

--- a/FamilyCalendarEventPlanner/src/FamilyCalendarEventPlanner.WebApp/projects/family-calendar-event-planner-admin/src/app/services/family-members.service.ts
+++ b/FamilyCalendarEventPlanner/src/FamilyCalendarEventPlanner.WebApp/projects/family-calendar-event-planner-admin/src/app/services/family-members.service.ts
@@ -5,17 +5,25 @@ import { environment } from '../../environments';
 import { FamilyMemberDto } from '../models/family-member-dto';
 import { CreateFamilyMemberCommand } from '../models/create-family-member-command';
 
+export interface GetFamilyMembersParams {
+  familyId?: string;
+  isImmediate?: boolean;
+}
+
 @Injectable({ providedIn: 'root' })
 export class FamilyMembersService {
   private readonly http = inject(HttpClient);
   private readonly baseUrl = environment.apiBaseUrl;
 
-  getFamilyMembers(familyId?: string): Observable<FamilyMemberDto[]> {
-    let params = new HttpParams();
-    if (familyId) {
-      params = params.set('familyId', familyId);
+  getFamilyMembers(params?: GetFamilyMembersParams): Observable<FamilyMemberDto[]> {
+    let httpParams = new HttpParams();
+    if (params?.familyId) {
+      httpParams = httpParams.set('familyId', params.familyId);
     }
-    return this.http.get<FamilyMemberDto[]>(`${this.baseUrl}/api/familymembers`, { params });
+    if (params?.isImmediate !== undefined) {
+      httpParams = httpParams.set('isImmediate', params.isImmediate.toString());
+    }
+    return this.http.get<FamilyMemberDto[]>(`${this.baseUrl}/api/familymembers`, { params: httpParams });
   }
 
   getFamilyMemberById(memberId: string): Observable<FamilyMemberDto> {
@@ -26,7 +34,7 @@ export class FamilyMembersService {
     return this.http.post<FamilyMemberDto>(`${this.baseUrl}/api/familymembers`, command);
   }
 
-  updateFamilyMember(memberId: string, command: Partial<CreateFamilyMemberCommand>): Observable<FamilyMemberDto> {
+  updateFamilyMember(memberId: string, command: Partial<CreateFamilyMemberCommand> & { memberId: string }): Observable<FamilyMemberDto> {
     return this.http.put<FamilyMemberDto>(`${this.baseUrl}/api/familymembers/${memberId}`, command);
   }
 

--- a/FamilyCalendarEventPlanner/src/FamilyCalendarEventPlanner.WebApp/projects/family-calendar-event-planner/src/app/components/member-card/member-card.html
+++ b/FamilyCalendarEventPlanner/src/FamilyCalendarEventPlanner.WebApp/projects/family-calendar-event-planner/src/app/components/member-card/member-card.html
@@ -7,11 +7,22 @@
     </div>
     <div class="member-card__info">
       <h3 class="member-card__name">{{ member.name }}</h3>
-      <mat-chip [class]="getRoleBadgeClass()">
-        <mat-icon>{{ getRoleIcon() }}</mat-icon>
-        {{ member.role }}
-      </mat-chip>
-      <p class="member-card__email">{{ member.email }}</p>
+      <div class="member-card__badges">
+        <mat-chip [class]="getRoleBadgeClass()">
+          <mat-icon>{{ getRoleIcon() }}</mat-icon>
+          {{ member.role }}
+        </mat-chip>
+        @if (member.isImmediate) {
+          <mat-chip class="member-card__immediate-badge">
+            <mat-icon>family_restroom</mat-icon>
+            Immediate
+          </mat-chip>
+        }
+      </div>
+      <p class="member-card__relation">{{ getRelationTypeLabel() }}</p>
+      @if (member.email) {
+        <p class="member-card__email">{{ member.email }}</p>
+      }
     </div>
   </mat-card-header>
 

--- a/FamilyCalendarEventPlanner/src/FamilyCalendarEventPlanner.WebApp/projects/family-calendar-event-planner/src/app/components/member-card/member-card.spec.ts
+++ b/FamilyCalendarEventPlanner/src/FamilyCalendarEventPlanner.WebApp/projects/family-calendar-event-planner/src/app/components/member-card/member-card.spec.ts
@@ -1,6 +1,6 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { MemberCard } from './member-card';
-import { FamilyMember, MemberRole } from '../../services/models';
+import { FamilyMember, MemberRole, RelationType } from '../../services/models';
 
 describe('MemberCard', () => {
   let component: MemberCard;
@@ -12,7 +12,9 @@ describe('MemberCard', () => {
     name: 'John Doe',
     email: 'john@example.com',
     color: '#3b82f6',
-    role: MemberRole.Admin
+    role: MemberRole.Admin,
+    isImmediate: true,
+    relationType: RelationType.Self
   };
 
   beforeEach(async () => {
@@ -38,6 +40,13 @@ describe('MemberCard', () => {
   it('should display member email', () => {
     const compiled = fixture.nativeElement;
     expect(compiled.textContent).toContain('john@example.com');
+  });
+
+  it('should not display email when null', () => {
+    component.member = { ...mockMember, email: null };
+    fixture.detectChanges();
+    const compiled = fixture.nativeElement;
+    expect(compiled.querySelector('.member-card__email')).toBeFalsy();
   });
 
   it('should get correct initials', () => {
@@ -70,6 +79,35 @@ describe('MemberCard', () => {
   it('should return correct role icon for ViewOnly', () => {
     component.member = { ...mockMember, role: MemberRole.ViewOnly };
     expect(component.getRoleIcon()).toBe('visibility');
+  });
+
+  it('should return correct relation type label for Self', () => {
+    expect(component.getRelationTypeLabel()).toBe('Self');
+  });
+
+  it('should return correct relation type label for Spouse', () => {
+    component.member = { ...mockMember, relationType: RelationType.Spouse };
+    expect(component.getRelationTypeLabel()).toBe('Spouse');
+  });
+
+  it('should return correct relation type label for AuntUncle', () => {
+    component.member = { ...mockMember, relationType: RelationType.AuntUncle };
+    expect(component.getRelationTypeLabel()).toBe('Aunt/Uncle');
+  });
+
+  it('should display immediate badge when isImmediate is true', () => {
+    component.member = { ...mockMember, isImmediate: true };
+    fixture.detectChanges();
+    const compiled = fixture.nativeElement;
+    expect(compiled.textContent).toContain('Immediate');
+  });
+
+  it('should not display immediate badge when isImmediate is false', () => {
+    component.member = { ...mockMember, isImmediate: false };
+    fixture.detectChanges();
+    const compiled = fixture.nativeElement;
+    const immediateBadge = compiled.querySelector('.member-card__immediate-badge');
+    expect(immediateBadge).toBeFalsy();
   });
 
   it('should emit editClick event', () => {

--- a/FamilyCalendarEventPlanner/src/FamilyCalendarEventPlanner.WebApp/projects/family-calendar-event-planner/src/app/components/member-card/member-card.ts
+++ b/FamilyCalendarEventPlanner/src/FamilyCalendarEventPlanner.WebApp/projects/family-calendar-event-planner/src/app/components/member-card/member-card.ts
@@ -4,7 +4,7 @@ import { MatCardModule } from '@angular/material/card';
 import { MatButtonModule } from '@angular/material/button';
 import { MatIconModule } from '@angular/material/icon';
 import { MatChipsModule } from '@angular/material/chips';
-import { FamilyMember, MemberRole } from '../../services/models';
+import { FamilyMember, MemberRole, RelationType } from '../../services/models';
 
 @Component({
   selector: 'app-member-card',
@@ -39,6 +39,24 @@ export class MemberCard {
       default:
         return 'person';
     }
+  }
+
+  getRelationTypeLabel(): string {
+    const labels: Record<RelationType, string> = {
+      [RelationType.Self]: 'Self',
+      [RelationType.Spouse]: 'Spouse',
+      [RelationType.Child]: 'Child',
+      [RelationType.Parent]: 'Parent',
+      [RelationType.Sibling]: 'Sibling',
+      [RelationType.Grandparent]: 'Grandparent',
+      [RelationType.Grandchild]: 'Grandchild',
+      [RelationType.AuntUncle]: 'Aunt/Uncle',
+      [RelationType.NieceNephew]: 'Niece/Nephew',
+      [RelationType.Cousin]: 'Cousin',
+      [RelationType.InLaw]: 'In-Law',
+      [RelationType.Other]: 'Other'
+    };
+    return labels[this.member.relationType] || this.member.relationType;
   }
 
   onEditClick(): void {

--- a/FamilyCalendarEventPlanner/src/FamilyCalendarEventPlanner.WebApp/projects/family-calendar-event-planner/src/app/pages/family-members/family-members.html
+++ b/FamilyCalendarEventPlanner/src/FamilyCalendarEventPlanner.WebApp/projects/family-calendar-event-planner/src/app/pages/family-members/family-members.html
@@ -15,6 +15,14 @@
     </button>
   </div>
 
+  <div class="family-members__filters">
+    <mat-button-toggle-group [value]="(immediateFilter$ | async)" (change)="onFilterChange($event.value)">
+      <mat-button-toggle value="all">All Members</mat-button-toggle>
+      <mat-button-toggle value="immediate">Immediate Family</mat-button-toggle>
+      <mat-button-toggle value="extended">Extended Family</mat-button-toggle>
+    </mat-button-toggle-group>
+  </div>
+
   @if (viewModel$ | async; as vm) {
     <div class="family-members__stats">
       <mat-card class="family-members__stat-card">
@@ -22,12 +30,12 @@
         <div class="family-members__stat-label">Active Members</div>
       </mat-card>
       <mat-card class="family-members__stat-card">
-        <div class="family-members__stat-number">{{ vm.stats.admins }}</div>
-        <div class="family-members__stat-label">Admins</div>
+        <div class="family-members__stat-number">{{ vm.stats.immediateFamily }}</div>
+        <div class="family-members__stat-label">Immediate Family</div>
       </mat-card>
       <mat-card class="family-members__stat-card">
-        <div class="family-members__stat-number">{{ vm.stats.pendingInvitations }}</div>
-        <div class="family-members__stat-label">Pending Invitations</div>
+        <div class="family-members__stat-number">{{ vm.stats.admins }}</div>
+        <div class="family-members__stat-label">Admins</div>
       </mat-card>
     </div>
 

--- a/FamilyCalendarEventPlanner/src/FamilyCalendarEventPlanner.WebApp/projects/family-calendar-event-planner/src/app/services/family-members.service.spec.ts
+++ b/FamilyCalendarEventPlanner/src/FamilyCalendarEventPlanner.WebApp/projects/family-calendar-event-planner/src/app/services/family-members.service.spec.ts
@@ -1,7 +1,7 @@
 import { TestBed } from '@angular/core/testing';
 import { HttpClientTestingModule, HttpTestingController } from '@angular/common/http/testing';
 import { FamilyMembersService } from './family-members.service';
-import { FamilyMember, CreateFamilyMemberRequest, MemberRole } from './models';
+import { FamilyMember, CreateFamilyMemberRequest, MemberRole, RelationType } from './models';
 
 describe('FamilyMembersService', () => {
   let service: FamilyMembersService;
@@ -14,7 +14,9 @@ describe('FamilyMembersService', () => {
     name: 'John Doe',
     email: 'john@example.com',
     color: '#3b82f6',
-    role: MemberRole.Admin
+    role: MemberRole.Admin,
+    isImmediate: true,
+    relationType: RelationType.Self
   };
 
   beforeEach(() => {
@@ -46,11 +48,41 @@ describe('FamilyMembersService', () => {
     });
 
     it('should get family members with familyId filter', () => {
-      service.getFamilyMembers('family1').subscribe(members => {
+      service.getFamilyMembers({ familyId: 'family1' }).subscribe(members => {
         expect(members).toEqual([mockMember]);
       });
 
       const req = httpMock.expectOne(`${baseUrl}/api/familymembers?familyId=family1`);
+      expect(req.request.method).toBe('GET');
+      req.flush([mockMember]);
+    });
+
+    it('should get immediate family members only', () => {
+      service.getFamilyMembers({ isImmediate: true }).subscribe(members => {
+        expect(members).toEqual([mockMember]);
+      });
+
+      const req = httpMock.expectOne(`${baseUrl}/api/familymembers?isImmediate=true`);
+      expect(req.request.method).toBe('GET');
+      req.flush([mockMember]);
+    });
+
+    it('should get extended family members only', () => {
+      service.getFamilyMembers({ isImmediate: false }).subscribe(members => {
+        expect(members).toEqual([mockMember]);
+      });
+
+      const req = httpMock.expectOne(`${baseUrl}/api/familymembers?isImmediate=false`);
+      expect(req.request.method).toBe('GET');
+      req.flush([mockMember]);
+    });
+
+    it('should get family members with multiple filters', () => {
+      service.getFamilyMembers({ familyId: 'family1', isImmediate: true }).subscribe(members => {
+        expect(members).toEqual([mockMember]);
+      });
+
+      const req = httpMock.expectOne(`${baseUrl}/api/familymembers?familyId=family1&isImmediate=true`);
       expect(req.request.method).toBe('GET');
       req.flush([mockMember]);
     });
@@ -75,7 +107,9 @@ describe('FamilyMembersService', () => {
         name: 'Jane Doe',
         email: 'jane@example.com',
         color: '#10b981',
-        role: MemberRole.Member
+        role: MemberRole.Member,
+        isImmediate: true,
+        relationType: RelationType.Spouse
       };
 
       service.createFamilyMember(createRequest).subscribe(member => {
@@ -86,6 +120,26 @@ describe('FamilyMembersService', () => {
       expect(req.request.method).toBe('POST');
       expect(req.request.body).toEqual(createRequest);
       req.flush(mockMember);
+    });
+
+    it('should create a family member without email', () => {
+      const createRequest: CreateFamilyMemberRequest = {
+        familyId: 'family1',
+        name: 'Baby Doe',
+        color: '#10b981',
+        role: MemberRole.Member,
+        isImmediate: true,
+        relationType: RelationType.Child
+      };
+
+      service.createFamilyMember(createRequest).subscribe(member => {
+        expect(member).toBeTruthy();
+      });
+
+      const req = httpMock.expectOne(`${baseUrl}/api/familymembers`);
+      expect(req.request.method).toBe('POST');
+      expect(req.request.body).toEqual(createRequest);
+      req.flush({ ...mockMember, email: null });
     });
   });
 
@@ -100,6 +154,22 @@ describe('FamilyMembersService', () => {
       const req = httpMock.expectOne(`${baseUrl}/api/familymembers/1`);
       expect(req.request.method).toBe('PUT');
       req.flush(mockMember);
+    });
+
+    it('should update isImmediate and relationType', () => {
+      const updateRequest = {
+        memberId: '1',
+        isImmediate: false,
+        relationType: RelationType.Cousin
+      };
+
+      service.updateFamilyMember(updateRequest).subscribe(member => {
+        expect(member).toBeTruthy();
+      });
+
+      const req = httpMock.expectOne(`${baseUrl}/api/familymembers/1`);
+      expect(req.request.method).toBe('PUT');
+      req.flush({ ...mockMember, isImmediate: false, relationType: RelationType.Cousin });
     });
   });
 

--- a/FamilyCalendarEventPlanner/src/FamilyCalendarEventPlanner.WebApp/projects/family-calendar-event-planner/src/app/services/family-members.service.ts
+++ b/FamilyCalendarEventPlanner/src/FamilyCalendarEventPlanner.WebApp/projects/family-calendar-event-planner/src/app/services/family-members.service.ts
@@ -9,6 +9,11 @@ import {
   ChangeMemberRoleRequest
 } from './models';
 
+export interface GetFamilyMembersParams {
+  familyId?: string;
+  isImmediate?: boolean;
+}
+
 @Injectable({
   providedIn: 'root'
 })
@@ -16,12 +21,15 @@ export class FamilyMembersService {
   private readonly http = inject(HttpClient);
   private readonly baseUrl = environment.apiBaseUrl;
 
-  getFamilyMembers(familyId?: string): Observable<FamilyMember[]> {
-    let params = new HttpParams();
-    if (familyId) {
-      params = params.set('familyId', familyId);
+  getFamilyMembers(params?: GetFamilyMembersParams): Observable<FamilyMember[]> {
+    let httpParams = new HttpParams();
+    if (params?.familyId) {
+      httpParams = httpParams.set('familyId', params.familyId);
     }
-    return this.http.get<FamilyMember[]>(`${this.baseUrl}/api/familymembers`, { params });
+    if (params?.isImmediate !== undefined) {
+      httpParams = httpParams.set('isImmediate', params.isImmediate.toString());
+    }
+    return this.http.get<FamilyMember[]>(`${this.baseUrl}/api/familymembers`, { params: httpParams });
   }
 
   getFamilyMemberById(memberId: string): Observable<FamilyMember> {

--- a/FamilyCalendarEventPlanner/src/FamilyCalendarEventPlanner.WebApp/projects/family-calendar-event-planner/src/app/services/models.ts
+++ b/FamilyCalendarEventPlanner/src/FamilyCalendarEventPlanner.WebApp/projects/family-calendar-event-planner/src/app/services/models.ts
@@ -28,6 +28,21 @@ export enum MemberRole {
   ViewOnly = 'ViewOnly'
 }
 
+export enum RelationType {
+  Self = 'Self',
+  Spouse = 'Spouse',
+  Child = 'Child',
+  Parent = 'Parent',
+  Sibling = 'Sibling',
+  Grandparent = 'Grandparent',
+  Grandchild = 'Grandchild',
+  AuntUncle = 'AuntUncle',
+  NieceNephew = 'NieceNephew',
+  Cousin = 'Cousin',
+  InLaw = 'InLaw',
+  Other = 'Other'
+}
+
 export enum RSVPStatus {
   Pending = 'Pending',
   Accepted = 'Accepted',
@@ -102,24 +117,30 @@ export interface FamilyMember {
   memberId: string;
   familyId: string;
   name: string;
-  email: string;
+  email: string | null;
   color: string;
   role: MemberRole;
+  isImmediate: boolean;
+  relationType: RelationType;
 }
 
 export interface CreateFamilyMemberRequest {
   familyId: string;
   name: string;
-  email: string;
+  email?: string | null;
   color: string;
   role: MemberRole;
+  isImmediate: boolean;
+  relationType: RelationType;
 }
 
 export interface UpdateFamilyMemberRequest {
   memberId: string;
   name?: string;
-  email?: string;
+  email?: string | null;
   color?: string;
+  isImmediate?: boolean;
+  relationType?: RelationType;
 }
 
 export interface ChangeMemberRoleRequest {

--- a/FamilyCalendarEventPlanner/tests/FamilyCalendarEventPlanner.Core.Tests/FamilyMemberTests.cs
+++ b/FamilyCalendarEventPlanner/tests/FamilyCalendarEventPlanner.Core.Tests/FamilyMemberTests.cs
@@ -20,6 +20,8 @@ public class FamilyMemberTests
             Assert.That(member.Email, Is.EqualTo("john@example.com"));
             Assert.That(member.Color, Is.EqualTo("#FF5733"));
             Assert.That(member.Role, Is.EqualTo(MemberRole.Member));
+            Assert.That(member.IsImmediate, Is.True);
+            Assert.That(member.RelationType, Is.EqualTo(RelationType.Self));
         });
     }
 
@@ -29,6 +31,49 @@ public class FamilyMemberTests
         var member = new FamilyMember(_familyId, "Jane Doe", "jane@example.com", "#0000FF", MemberRole.Admin);
 
         Assert.That(member.Role, Is.EqualTo(MemberRole.Admin));
+    }
+
+    [Test]
+    public void Constructor_WithIsImmediateAndRelationType_SetsProperties()
+    {
+        var member = new FamilyMember(
+            _familyId,
+            "Uncle Bob",
+            "bob@example.com",
+            "#00FF00",
+            MemberRole.Member,
+            isImmediate: false,
+            relationType: RelationType.AuntUncle);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(member.IsImmediate, Is.False);
+            Assert.That(member.RelationType, Is.EqualTo(RelationType.AuntUncle));
+        });
+    }
+
+    [Test]
+    public void Constructor_WithNullEmail_SetsEmailToNull()
+    {
+        var member = new FamilyMember(_familyId, "John Doe", null, "#FF5733");
+
+        Assert.That(member.Email, Is.Null);
+    }
+
+    [Test]
+    public void Constructor_WithEmptyEmail_SetsEmailToNull()
+    {
+        var member = new FamilyMember(_familyId, "John Doe", "", "#FF5733");
+
+        Assert.That(member.Email, Is.Null);
+    }
+
+    [Test]
+    public void Constructor_WithWhitespaceEmail_SetsEmailToNull()
+    {
+        var member = new FamilyMember(_familyId, "John Doe", "   ", "#FF5733");
+
+        Assert.That(member.Email, Is.Null);
     }
 
     [Test]
@@ -43,13 +88,6 @@ public class FamilyMemberTests
     {
         Assert.Throws<ArgumentException>(() =>
             new FamilyMember(_familyId, "   ", "test@example.com", "#000000"));
-    }
-
-    [Test]
-    public void Constructor_EmptyEmail_ThrowsArgumentException()
-    {
-        Assert.Throws<ArgumentException>(() =>
-            new FamilyMember(_familyId, "Test", "", "#000000"));
     }
 
     [Test]
@@ -88,11 +126,13 @@ public class FamilyMemberTests
     }
 
     [Test]
-    public void UpdateProfile_EmptyEmail_ThrowsArgumentException()
+    public void UpdateProfile_EmptyEmail_SetsEmailToNull()
     {
         var member = CreateDefaultMember();
 
-        Assert.Throws<ArgumentException>(() => member.UpdateProfile(email: ""));
+        member.UpdateProfile(email: "");
+
+        Assert.That(member.Email, Is.Null);
     }
 
     [Test]
@@ -114,17 +154,45 @@ public class FamilyMemberTests
     }
 
     [Test]
+    public void UpdateProfile_IsImmediate_UpdatesIsImmediate()
+    {
+        var member = CreateDefaultMember();
+        Assert.That(member.IsImmediate, Is.True);
+
+        member.UpdateProfile(isImmediate: false);
+
+        Assert.That(member.IsImmediate, Is.False);
+    }
+
+    [Test]
+    public void UpdateProfile_RelationType_UpdatesRelationType()
+    {
+        var member = CreateDefaultMember();
+
+        member.UpdateProfile(relationType: RelationType.Spouse);
+
+        Assert.That(member.RelationType, Is.EqualTo(RelationType.Spouse));
+    }
+
+    [Test]
     public void UpdateProfile_MultipleProperties_UpdatesAll()
     {
         var member = CreateDefaultMember();
 
-        member.UpdateProfile(name: "New Name", email: "new@example.com", color: "#123456");
+        member.UpdateProfile(
+            name: "New Name",
+            email: "new@example.com",
+            color: "#123456",
+            isImmediate: false,
+            relationType: RelationType.Parent);
 
         Assert.Multiple(() =>
         {
             Assert.That(member.Name, Is.EqualTo("New Name"));
             Assert.That(member.Email, Is.EqualTo("new@example.com"));
             Assert.That(member.Color, Is.EqualTo("#123456"));
+            Assert.That(member.IsImmediate, Is.False);
+            Assert.That(member.RelationType, Is.EqualTo(RelationType.Parent));
         });
     }
 


### PR DESCRIPTION
- Make FamilyMember email property optional (nullable)
- Add IsImmediate boolean property to distinguish immediate vs extended family
- Add RelationType enum (Self, Spouse, Child, Parent, Sibling, etc.)
- Add isImmediate query parameter filter to GET /api/familymembers
- Update admin app with IsImmediate filter toggle and RelationType dropdown
- Update viewer app with IsImmediate filter and display of new properties
- Update all DTOs, commands, queries to support new properties
- Update database configuration for new columns with proper indexes
- Update unit tests for new functionality
- Update ICD documentation with new fields and RelationType enum