### PR TITLE
Add enum text serialization to API projects

### DIFF
--- a/AnniversaryBirthdayReminder/docs/specs/implementation-specs.md
+++ b/AnniversaryBirthdayReminder/docs/specs/implementation-specs.md
@@ -192,6 +192,21 @@ Id
 ### 5.5 CORS Configuration
 **REQ-API-006**: The API SHALL have a CORS policy defined. The origins allowed in the CORS policy SHALL be retrieved from configuration and SHALL include the URLs where the frontend(s) are hosted.
 
+### 5.6 JSON Serialization
+**REQ-API-007**: The API project Program.cs SHALL include the following using statement:
+```csharp
+using System.Text.Json.Serialization;
+```
+
+**REQ-API-008**: The API SHALL configure JSON serialization to handle enums as text strings. The `AddControllers()` call SHALL be configured with `JsonStringEnumConverter`:
+```csharp
+builder.Services.AddControllers()
+    .AddJsonOptions(options =>
+    {
+        options.JsonSerializerOptions.Converters.Add(new JsonStringEnumConverter());
+    });
+```
+
 ---
 
 ## 6. Frontend Requirements
@@ -470,6 +485,7 @@ All changes to this specification SHALL be tracked and versioned appropriately.
 | 1.1     | 2025-12-22 | System | Added structured logging requirements (REQ-SYS-013 through REQ-SYS-022) |
 | 1.2     | 2025-12-22 | System | Added code linting and static analysis requirements (REQ-LINT-001 through REQ-LINT-010) |
 | 1.3     | 2025-12-25 | System | Merged reactive data loading pattern requirements from data-loading-specs.md (REQ-FE-027 through REQ-FE-036) |
+| 1.4     | 2025-12-30 | System | Added JSON enum serialization requirements (REQ-API-007 through REQ-API-008) |
 
 ---
 

--- a/AnniversaryBirthdayReminder/src/AnniversaryBirthdayReminder.Api/Program.cs
+++ b/AnniversaryBirthdayReminder/src/AnniversaryBirthdayReminder.Api/Program.cs
@@ -4,6 +4,7 @@
 using AnniversaryBirthdayReminder.Api;
 using AnniversaryBirthdayReminder.Infrastructure;
 using Serilog;
+using System.Text.Json.Serialization;
 
 var builder = WebApplication.CreateBuilder(args);
 
@@ -20,7 +21,11 @@ builder.Host.UseSerilog((context, loggerConfig) =>
 });
 
 // Add services to the container.
-builder.Services.AddControllers();
+builder.Services.AddControllers()
+    .AddJsonOptions(options =>
+    {
+        options.JsonSerializerOptions.Converters.Add(new JsonStringEnumConverter());
+    });
 builder.Services.AddEndpointsApiExplorer();
 builder.Services.AddSwaggerGen(options =>
 {

--- a/AnnualHealthScreeningReminder/docs/specs/implementation-specs.md
+++ b/AnnualHealthScreeningReminder/docs/specs/implementation-specs.md
@@ -192,6 +192,21 @@ Id
 ### 5.5 CORS Configuration
 **REQ-API-006**: The API SHALL have a CORS policy defined. The origins allowed in the CORS policy SHALL be retrieved from configuration and SHALL include the URLs where the frontend(s) are hosted.
 
+### 5.6 JSON Serialization
+**REQ-API-007**: The API project Program.cs SHALL include the following using statement:
+```csharp
+using System.Text.Json.Serialization;
+```
+
+**REQ-API-008**: The API SHALL configure JSON serialization to handle enums as text strings. The `AddControllers()` call SHALL be configured with `JsonStringEnumConverter`:
+```csharp
+builder.Services.AddControllers()
+    .AddJsonOptions(options =>
+    {
+        options.JsonSerializerOptions.Converters.Add(new JsonStringEnumConverter());
+    });
+```
+
 ---
 
 ## 6. Frontend Requirements
@@ -470,6 +485,7 @@ All changes to this specification SHALL be tracked and versioned appropriately.
 | 1.1     | 2025-12-22 | System | Added structured logging requirements (REQ-SYS-013 through REQ-SYS-022) |
 | 1.2     | 2025-12-22 | System | Added code linting and static analysis requirements (REQ-LINT-001 through REQ-LINT-010) |
 | 1.3     | 2025-12-25 | System | Merged reactive data loading pattern requirements from data-loading-specs.md (REQ-FE-027 through REQ-FE-036) |
+| 1.4     | 2025-12-30 | System | Added JSON enum serialization requirements (REQ-API-007 through REQ-API-008) |
 
 ---
 

--- a/AnnualHealthScreeningReminder/src/AnnualHealthScreeningReminder.Api/Program.cs
+++ b/AnnualHealthScreeningReminder/src/AnnualHealthScreeningReminder.Api/Program.cs
@@ -2,6 +2,7 @@ using AnnualHealthScreeningReminder.Infrastructure;
 using FluentValidation;
 using Serilog;
 using System.Reflection;
+using System.Text.Json.Serialization;
 
 var builder = WebApplication.CreateBuilder(args);
 
@@ -14,7 +15,11 @@ builder.Host.UseSerilog((context, services, configuration) => configuration
     .WriteTo.File("logs/log-.txt", rollingInterval: RollingInterval.Day));
 
 // Add services to the container.
-builder.Services.AddControllers();
+builder.Services.AddControllers()
+    .AddJsonOptions(options =>
+    {
+        options.JsonSerializerOptions.Converters.Add(new JsonStringEnumConverter());
+    });
 builder.Services.AddEndpointsApiExplorer();
 builder.Services.AddSwaggerGen(c =>
 {

--- a/ApplianceWarrantyManualOrganizer/docs/specs/implementation-specs.md
+++ b/ApplianceWarrantyManualOrganizer/docs/specs/implementation-specs.md
@@ -192,6 +192,21 @@ Id
 ### 5.5 CORS Configuration
 **REQ-API-006**: The API SHALL have a CORS policy defined. The origins allowed in the CORS policy SHALL be retrieved from configuration and SHALL include the URLs where the frontend(s) are hosted.
 
+### 5.6 JSON Serialization
+**REQ-API-007**: The API project Program.cs SHALL include the following using statement:
+```csharp
+using System.Text.Json.Serialization;
+```
+
+**REQ-API-008**: The API SHALL configure JSON serialization to handle enums as text strings. The `AddControllers()` call SHALL be configured with `JsonStringEnumConverter`:
+```csharp
+builder.Services.AddControllers()
+    .AddJsonOptions(options =>
+    {
+        options.JsonSerializerOptions.Converters.Add(new JsonStringEnumConverter());
+    });
+```
+
 ---
 
 ## 6. Frontend Requirements
@@ -470,6 +485,7 @@ All changes to this specification SHALL be tracked and versioned appropriately.
 | 1.1     | 2025-12-22 | System | Added structured logging requirements (REQ-SYS-013 through REQ-SYS-022) |
 | 1.2     | 2025-12-22 | System | Added code linting and static analysis requirements (REQ-LINT-001 through REQ-LINT-010) |
 | 1.3     | 2025-12-25 | System | Merged reactive data loading pattern requirements from data-loading-specs.md (REQ-FE-027 through REQ-FE-036) |
+| 1.4     | 2025-12-30 | System | Added JSON enum serialization requirements (REQ-API-007 through REQ-API-008) |
 
 ---
 

--- a/ApplianceWarrantyManualOrganizer/src/ApplianceWarrantyManualOrganizer.Api/Program.cs
+++ b/ApplianceWarrantyManualOrganizer/src/ApplianceWarrantyManualOrganizer.Api/Program.cs
@@ -2,6 +2,7 @@ using ApplianceWarrantyManualOrganizer.Infrastructure;
 using FluentValidation;
 using Serilog;
 using System.Reflection;
+using System.Text.Json.Serialization;
 
 var builder = WebApplication.CreateBuilder(args);
 
@@ -12,7 +13,11 @@ builder.Host.UseSerilog((context, configuration) =>
 });
 
 // Add services to the container.
-builder.Services.AddControllers();
+builder.Services.AddControllers()
+    .AddJsonOptions(options =>
+    {
+        options.JsonSerializerOptions.Converters.Add(new JsonStringEnumConverter());
+    });
 builder.Services.AddEndpointsApiExplorer();
 builder.Services.AddSwaggerGen(c =>
 {

--- a/BBQGrillingRecipeBook/docs/specs/implementation-specs.md
+++ b/BBQGrillingRecipeBook/docs/specs/implementation-specs.md
@@ -192,6 +192,21 @@ Id
 ### 5.5 CORS Configuration
 **REQ-API-006**: The API SHALL have a CORS policy defined. The origins allowed in the CORS policy SHALL be retrieved from configuration and SHALL include the URLs where the frontend(s) are hosted.
 
+### 5.6 JSON Serialization
+**REQ-API-007**: The API project Program.cs SHALL include the following using statement:
+```csharp
+using System.Text.Json.Serialization;
+```
+
+**REQ-API-008**: The API SHALL configure JSON serialization to handle enums as text strings. The `AddControllers()` call SHALL be configured with `JsonStringEnumConverter`:
+```csharp
+builder.Services.AddControllers()
+    .AddJsonOptions(options =>
+    {
+        options.JsonSerializerOptions.Converters.Add(new JsonStringEnumConverter());
+    });
+```
+
 ---
 
 ## 6. Frontend Requirements
@@ -470,6 +485,7 @@ All changes to this specification SHALL be tracked and versioned appropriately.
 | 1.1     | 2025-12-22 | System | Added structured logging requirements (REQ-SYS-013 through REQ-SYS-022) |
 | 1.2     | 2025-12-22 | System | Added code linting and static analysis requirements (REQ-LINT-001 through REQ-LINT-010) |
 | 1.3     | 2025-12-25 | System | Merged reactive data loading pattern requirements from data-loading-specs.md (REQ-FE-027 through REQ-FE-036) |
+| 1.4     | 2025-12-30 | System | Added JSON enum serialization requirements (REQ-API-007 through REQ-API-008) |
 
 ---
 

--- a/BBQGrillingRecipeBook/src/BBQGrillingRecipeBook.Api/Program.cs
+++ b/BBQGrillingRecipeBook/src/BBQGrillingRecipeBook.Api/Program.cs
@@ -1,5 +1,6 @@
 using BBQGrillingRecipeBook.Infrastructure;
 using Serilog;
+using System.Text.Json.Serialization;
 
 var builder = WebApplication.CreateBuilder(args);
 
@@ -16,7 +17,11 @@ Log.Logger = new LoggerConfiguration()
 builder.Host.UseSerilog();
 
 // Add services to the container.
-builder.Services.AddControllers();
+builder.Services.AddControllers()
+    .AddJsonOptions(options =>
+    {
+        options.JsonSerializerOptions.Converters.Add(new JsonStringEnumConverter());
+    });
 builder.Services.AddEndpointsApiExplorer();
 builder.Services.AddSwaggerGen(c =>
 {

--- a/BillPaymentScheduler/docs/specs/implementation-specs.md
+++ b/BillPaymentScheduler/docs/specs/implementation-specs.md
@@ -192,6 +192,21 @@ Id
 ### 5.5 CORS Configuration
 **REQ-API-006**: The API SHALL have a CORS policy defined. The origins allowed in the CORS policy SHALL be retrieved from configuration and SHALL include the URLs where the frontend(s) are hosted.
 
+### 5.6 JSON Serialization
+**REQ-API-007**: The API project Program.cs SHALL include the following using statement:
+```csharp
+using System.Text.Json.Serialization;
+```
+
+**REQ-API-008**: The API SHALL configure JSON serialization to handle enums as text strings. The `AddControllers()` call SHALL be configured with `JsonStringEnumConverter`:
+```csharp
+builder.Services.AddControllers()
+    .AddJsonOptions(options =>
+    {
+        options.JsonSerializerOptions.Converters.Add(new JsonStringEnumConverter());
+    });
+```
+
 ---
 
 ## 6. Frontend Requirements
@@ -470,6 +485,7 @@ All changes to this specification SHALL be tracked and versioned appropriately.
 | 1.1     | 2025-12-22 | System | Added structured logging requirements (REQ-SYS-013 through REQ-SYS-022) |
 | 1.2     | 2025-12-22 | System | Added code linting and static analysis requirements (REQ-LINT-001 through REQ-LINT-010) |
 | 1.3     | 2025-12-25 | System | Merged reactive data loading pattern requirements from data-loading-specs.md (REQ-FE-027 through REQ-FE-036) |
+| 1.4     | 2025-12-30 | System | Added JSON enum serialization requirements (REQ-API-007 through REQ-API-008) |
 
 ---
 

--- a/BillPaymentScheduler/src/BillPaymentScheduler.Api/Program.cs
+++ b/BillPaymentScheduler/src/BillPaymentScheduler.Api/Program.cs
@@ -1,5 +1,6 @@
 using BillPaymentScheduler.Infrastructure;
 using Serilog;
+using System.Text.Json.Serialization;
 
 var builder = WebApplication.CreateBuilder(args);
 
@@ -11,7 +12,11 @@ Log.Logger = new LoggerConfiguration()
 builder.Host.UseSerilog();
 
 // Add services to the container.
-builder.Services.AddControllers();
+builder.Services.AddControllers()
+    .AddJsonOptions(options =>
+    {
+        options.JsonSerializerOptions.Converters.Add(new JsonStringEnumConverter());
+    });
 builder.Services.AddEndpointsApiExplorer();
 builder.Services.AddSwaggerGen();
 

--- a/BloodPressureMonitor/docs/specs/implementation-specs.md
+++ b/BloodPressureMonitor/docs/specs/implementation-specs.md
@@ -192,6 +192,21 @@ Id
 ### 5.5 CORS Configuration
 **REQ-API-006**: The API SHALL have a CORS policy defined. The origins allowed in the CORS policy SHALL be retrieved from configuration and SHALL include the URLs where the frontend(s) are hosted.
 
+### 5.6 JSON Serialization
+**REQ-API-007**: The API project Program.cs SHALL include the following using statement:
+```csharp
+using System.Text.Json.Serialization;
+```
+
+**REQ-API-008**: The API SHALL configure JSON serialization to handle enums as text strings. The `AddControllers()` call SHALL be configured with `JsonStringEnumConverter`:
+```csharp
+builder.Services.AddControllers()
+    .AddJsonOptions(options =>
+    {
+        options.JsonSerializerOptions.Converters.Add(new JsonStringEnumConverter());
+    });
+```
+
 ---
 
 ## 6. Frontend Requirements
@@ -470,6 +485,7 @@ All changes to this specification SHALL be tracked and versioned appropriately.
 | 1.1     | 2025-12-22 | System | Added structured logging requirements (REQ-SYS-013 through REQ-SYS-022) |
 | 1.2     | 2025-12-22 | System | Added code linting and static analysis requirements (REQ-LINT-001 through REQ-LINT-010) |
 | 1.3     | 2025-12-25 | System | Merged reactive data loading pattern requirements from data-loading-specs.md (REQ-FE-027 through REQ-FE-036) |
+| 1.4     | 2025-12-30 | System | Added JSON enum serialization requirements (REQ-API-007 through REQ-API-008) |
 
 ---
 

--- a/BloodPressureMonitor/src/BloodPressureMonitor.Api/Program.cs
+++ b/BloodPressureMonitor/src/BloodPressureMonitor.Api/Program.cs
@@ -3,6 +3,7 @@
 
 using BloodPressureMonitor.Infrastructure;
 using Serilog;
+using System.Text.Json.Serialization;
 
 var builder = WebApplication.CreateBuilder(args);
 
@@ -19,7 +20,11 @@ builder.Host.UseSerilog((context, loggerConfig) =>
 });
 
 // Add services to the container.
-builder.Services.AddControllers();
+builder.Services.AddControllers()
+    .AddJsonOptions(options =>
+    {
+        options.JsonSerializerOptions.Converters.Add(new JsonStringEnumConverter());
+    });
 builder.Services.AddEndpointsApiExplorer();
 builder.Services.AddSwaggerGen(options =>
 {

--- a/BookReadingTrackerLibrary/docs/specs/implementation-specs.md
+++ b/BookReadingTrackerLibrary/docs/specs/implementation-specs.md
@@ -192,6 +192,21 @@ Id
 ### 5.5 CORS Configuration
 **REQ-API-006**: The API SHALL have a CORS policy defined. The origins allowed in the CORS policy SHALL be retrieved from configuration and SHALL include the URLs where the frontend(s) are hosted.
 
+### 5.6 JSON Serialization
+**REQ-API-007**: The API project Program.cs SHALL include the following using statement:
+```csharp
+using System.Text.Json.Serialization;
+```
+
+**REQ-API-008**: The API SHALL configure JSON serialization to handle enums as text strings. The `AddControllers()` call SHALL be configured with `JsonStringEnumConverter`:
+```csharp
+builder.Services.AddControllers()
+    .AddJsonOptions(options =>
+    {
+        options.JsonSerializerOptions.Converters.Add(new JsonStringEnumConverter());
+    });
+```
+
 ---
 
 ## 6. Frontend Requirements
@@ -470,6 +485,7 @@ All changes to this specification SHALL be tracked and versioned appropriately.
 | 1.1     | 2025-12-22 | System | Added structured logging requirements (REQ-SYS-013 through REQ-SYS-022) |
 | 1.2     | 2025-12-22 | System | Added code linting and static analysis requirements (REQ-LINT-001 through REQ-LINT-010) |
 | 1.3     | 2025-12-25 | System | Merged reactive data loading pattern requirements from data-loading-specs.md (REQ-FE-027 through REQ-FE-036) |
+| 1.4     | 2025-12-30 | System | Added JSON enum serialization requirements (REQ-API-007 through REQ-API-008) |
 
 ---
 

--- a/BookReadingTrackerLibrary/src/BookReadingTrackerLibrary.Api/Program.cs
+++ b/BookReadingTrackerLibrary/src/BookReadingTrackerLibrary.Api/Program.cs
@@ -1,5 +1,6 @@
 using BookReadingTrackerLibrary.Infrastructure;
 using Serilog;
+using System.Text.Json.Serialization;
 
 var builder = WebApplication.CreateBuilder(args);
 
@@ -16,7 +17,11 @@ builder.Host.UseSerilog((context, loggerConfig) =>
 });
 
 // Add services to the container.
-builder.Services.AddControllers();
+builder.Services.AddControllers()
+    .AddJsonOptions(options =>
+    {
+        options.JsonSerializerOptions.Converters.Add(new JsonStringEnumConverter());
+    });
 builder.Services.AddEndpointsApiExplorer();
 builder.Services.AddSwaggerGen(options =>
 {

--- a/BucketListManager/docs/specs/implementation-specs.md
+++ b/BucketListManager/docs/specs/implementation-specs.md
@@ -192,6 +192,21 @@ Id
 ### 5.5 CORS Configuration
 **REQ-API-006**: The API SHALL have a CORS policy defined. The origins allowed in the CORS policy SHALL be retrieved from configuration and SHALL include the URLs where the frontend(s) are hosted.
 
+### 5.6 JSON Serialization
+**REQ-API-007**: The API project Program.cs SHALL include the following using statement:
+```csharp
+using System.Text.Json.Serialization;
+```
+
+**REQ-API-008**: The API SHALL configure JSON serialization to handle enums as text strings. The `AddControllers()` call SHALL be configured with `JsonStringEnumConverter`:
+```csharp
+builder.Services.AddControllers()
+    .AddJsonOptions(options =>
+    {
+        options.JsonSerializerOptions.Converters.Add(new JsonStringEnumConverter());
+    });
+```
+
 ---
 
 ## 6. Frontend Requirements
@@ -470,6 +485,7 @@ All changes to this specification SHALL be tracked and versioned appropriately.
 | 1.1     | 2025-12-22 | System | Added structured logging requirements (REQ-SYS-013 through REQ-SYS-022) |
 | 1.2     | 2025-12-22 | System | Added code linting and static analysis requirements (REQ-LINT-001 through REQ-LINT-010) |
 | 1.3     | 2025-12-25 | System | Merged reactive data loading pattern requirements from data-loading-specs.md (REQ-FE-027 through REQ-FE-036) |
+| 1.4     | 2025-12-30 | System | Added JSON enum serialization requirements (REQ-API-007 through REQ-API-008) |
 
 ---
 

--- a/BucketListManager/src/BucketListManager.Api/Program.cs
+++ b/BucketListManager/src/BucketListManager.Api/Program.cs
@@ -1,5 +1,6 @@
 using BucketListManager.Infrastructure;
 using Serilog;
+using System.Text.Json.Serialization;
 
 var builder = WebApplication.CreateBuilder(args);
 
@@ -16,7 +17,11 @@ builder.Host.UseSerilog((context, loggerConfig) =>
 });
 
 // Add services to the container.
-builder.Services.AddControllers();
+builder.Services.AddControllers()
+    .AddJsonOptions(options =>
+    {
+        options.JsonSerializerOptions.Converters.Add(new JsonStringEnumConverter());
+    });
 builder.Services.AddEndpointsApiExplorer();
 builder.Services.AddSwaggerGen(options =>
 {

--- a/CampingTripPlanner/docs/specs/implementation-specs.md
+++ b/CampingTripPlanner/docs/specs/implementation-specs.md
@@ -192,6 +192,21 @@ Id
 ### 5.5 CORS Configuration
 **REQ-API-006**: The API SHALL have a CORS policy defined. The origins allowed in the CORS policy SHALL be retrieved from configuration and SHALL include the URLs where the frontend(s) are hosted.
 
+### 5.6 JSON Serialization
+**REQ-API-007**: The API project Program.cs SHALL include the following using statement:
+```csharp
+using System.Text.Json.Serialization;
+```
+
+**REQ-API-008**: The API SHALL configure JSON serialization to handle enums as text strings. The `AddControllers()` call SHALL be configured with `JsonStringEnumConverter`:
+```csharp
+builder.Services.AddControllers()
+    .AddJsonOptions(options =>
+    {
+        options.JsonSerializerOptions.Converters.Add(new JsonStringEnumConverter());
+    });
+```
+
 ---
 
 ## 6. Frontend Requirements
@@ -470,6 +485,7 @@ All changes to this specification SHALL be tracked and versioned appropriately.
 | 1.1     | 2025-12-22 | System | Added structured logging requirements (REQ-SYS-013 through REQ-SYS-022) |
 | 1.2     | 2025-12-22 | System | Added code linting and static analysis requirements (REQ-LINT-001 through REQ-LINT-010) |
 | 1.3     | 2025-12-25 | System | Merged reactive data loading pattern requirements from data-loading-specs.md (REQ-FE-027 through REQ-FE-036) |
+| 1.4     | 2025-12-30 | System | Added JSON enum serialization requirements (REQ-API-007 through REQ-API-008) |
 
 ---
 

--- a/CampingTripPlanner/src/CampingTripPlanner.Api/Program.cs
+++ b/CampingTripPlanner/src/CampingTripPlanner.Api/Program.cs
@@ -1,5 +1,6 @@
 using CampingTripPlanner.Infrastructure;
 using Serilog;
+using System.Text.Json.Serialization;
 
 var builder = WebApplication.CreateBuilder(args);
 
@@ -16,7 +17,11 @@ builder.Host.UseSerilog((context, loggerConfig) =>
 });
 
 // Add services to the container.
-builder.Services.AddControllers();
+builder.Services.AddControllers()
+    .AddJsonOptions(options =>
+    {
+        options.JsonSerializerOptions.Converters.Add(new JsonStringEnumConverter());
+    });
 builder.Services.AddEndpointsApiExplorer();
 builder.Services.AddSwaggerGen(options =>
 {

--- a/CarModificationPartsDatabase/docs/specs/implementation-specs.md
+++ b/CarModificationPartsDatabase/docs/specs/implementation-specs.md
@@ -192,6 +192,21 @@ Id
 ### 5.5 CORS Configuration
 **REQ-API-006**: The API SHALL have a CORS policy defined. The origins allowed in the CORS policy SHALL be retrieved from configuration and SHALL include the URLs where the frontend(s) are hosted.
 
+### 5.6 JSON Serialization
+**REQ-API-007**: The API project Program.cs SHALL include the following using statement:
+```csharp
+using System.Text.Json.Serialization;
+```
+
+**REQ-API-008**: The API SHALL configure JSON serialization to handle enums as text strings. The `AddControllers()` call SHALL be configured with `JsonStringEnumConverter`:
+```csharp
+builder.Services.AddControllers()
+    .AddJsonOptions(options =>
+    {
+        options.JsonSerializerOptions.Converters.Add(new JsonStringEnumConverter());
+    });
+```
+
 ---
 
 ## 6. Frontend Requirements
@@ -470,6 +485,7 @@ All changes to this specification SHALL be tracked and versioned appropriately.
 | 1.1     | 2025-12-22 | System | Added structured logging requirements (REQ-SYS-013 through REQ-SYS-022) |
 | 1.2     | 2025-12-22 | System | Added code linting and static analysis requirements (REQ-LINT-001 through REQ-LINT-010) |
 | 1.3     | 2025-12-25 | System | Merged reactive data loading pattern requirements from data-loading-specs.md (REQ-FE-027 through REQ-FE-036) |
+| 1.4     | 2025-12-30 | System | Added JSON enum serialization requirements (REQ-API-007 through REQ-API-008) |
 
 ---
 

--- a/CarModificationPartsDatabase/src/CarModificationPartsDatabase.Api/Program.cs
+++ b/CarModificationPartsDatabase/src/CarModificationPartsDatabase.Api/Program.cs
@@ -4,6 +4,7 @@
 using CarModificationPartsDatabase.Api;
 using CarModificationPartsDatabase.Infrastructure;
 using Serilog;
+using System.Text.Json.Serialization;
 
 var builder = WebApplication.CreateBuilder(args);
 
@@ -20,7 +21,11 @@ builder.Host.UseSerilog((context, loggerConfig) =>
 });
 
 // Add services to the container.
-builder.Services.AddControllers();
+builder.Services.AddControllers()
+    .AddJsonOptions(options =>
+    {
+        options.JsonSerializerOptions.Converters.Add(new JsonStringEnumConverter());
+    });
 builder.Services.AddEndpointsApiExplorer();
 builder.Services.AddSwaggerGen(options =>
 {

--- a/CharitableGivingTracker/docs/specs/implementation-specs.md
+++ b/CharitableGivingTracker/docs/specs/implementation-specs.md
@@ -192,6 +192,21 @@ Id
 ### 5.5 CORS Configuration
 **REQ-API-006**: The API SHALL have a CORS policy defined. The origins allowed in the CORS policy SHALL be retrieved from configuration and SHALL include the URLs where the frontend(s) are hosted.
 
+### 5.6 JSON Serialization
+**REQ-API-007**: The API project Program.cs SHALL include the following using statement:
+```csharp
+using System.Text.Json.Serialization;
+```
+
+**REQ-API-008**: The API SHALL configure JSON serialization to handle enums as text strings. The `AddControllers()` call SHALL be configured with `JsonStringEnumConverter`:
+```csharp
+builder.Services.AddControllers()
+    .AddJsonOptions(options =>
+    {
+        options.JsonSerializerOptions.Converters.Add(new JsonStringEnumConverter());
+    });
+```
+
 ---
 
 ## 6. Frontend Requirements
@@ -470,6 +485,7 @@ All changes to this specification SHALL be tracked and versioned appropriately.
 | 1.1     | 2025-12-22 | System | Added structured logging requirements (REQ-SYS-013 through REQ-SYS-022) |
 | 1.2     | 2025-12-22 | System | Added code linting and static analysis requirements (REQ-LINT-001 through REQ-LINT-010) |
 | 1.3     | 2025-12-25 | System | Merged reactive data loading pattern requirements from data-loading-specs.md (REQ-FE-027 through REQ-FE-036) |
+| 1.4     | 2025-12-30 | System | Added JSON enum serialization requirements (REQ-API-007 through REQ-API-008) |
 
 ---
 

--- a/CharitableGivingTracker/src/CharitableGivingTracker.Api/Program.cs
+++ b/CharitableGivingTracker/src/CharitableGivingTracker.Api/Program.cs
@@ -1,5 +1,6 @@
 using CharitableGivingTracker.Infrastructure;
 using Serilog;
+using System.Text.Json.Serialization;
 
 var builder = WebApplication.CreateBuilder(args);
 
@@ -11,7 +12,11 @@ Log.Logger = new LoggerConfiguration()
 builder.Host.UseSerilog();
 
 // Add services to the container.
-builder.Services.AddControllers();
+builder.Services.AddControllers()
+    .AddJsonOptions(options =>
+    {
+        options.JsonSerializerOptions.Converters.Add(new JsonStringEnumConverter());
+    });
 builder.Services.AddEndpointsApiExplorer();
 builder.Services.AddSwaggerGen();
 

--- a/ChoreAssignmentTracker/docs/specs/implementation-specs.md
+++ b/ChoreAssignmentTracker/docs/specs/implementation-specs.md
@@ -192,6 +192,21 @@ Id
 ### 5.5 CORS Configuration
 **REQ-API-006**: The API SHALL have a CORS policy defined. The origins allowed in the CORS policy SHALL be retrieved from configuration and SHALL include the URLs where the frontend(s) are hosted.
 
+### 5.6 JSON Serialization
+**REQ-API-007**: The API project Program.cs SHALL include the following using statement:
+```csharp
+using System.Text.Json.Serialization;
+```
+
+**REQ-API-008**: The API SHALL configure JSON serialization to handle enums as text strings. The `AddControllers()` call SHALL be configured with `JsonStringEnumConverter`:
+```csharp
+builder.Services.AddControllers()
+    .AddJsonOptions(options =>
+    {
+        options.JsonSerializerOptions.Converters.Add(new JsonStringEnumConverter());
+    });
+```
+
 ---
 
 ## 6. Frontend Requirements
@@ -470,6 +485,7 @@ All changes to this specification SHALL be tracked and versioned appropriately.
 | 1.1     | 2025-12-22 | System | Added structured logging requirements (REQ-SYS-013 through REQ-SYS-022) |
 | 1.2     | 2025-12-22 | System | Added code linting and static analysis requirements (REQ-LINT-001 through REQ-LINT-010) |
 | 1.3     | 2025-12-25 | System | Merged reactive data loading pattern requirements from data-loading-specs.md (REQ-FE-027 through REQ-FE-036) |
+| 1.4     | 2025-12-30 | System | Added JSON enum serialization requirements (REQ-API-007 through REQ-API-008) |
 
 ---
 

--- a/ChoreAssignmentTracker/src/ChoreAssignmentTracker.Api/Program.cs
+++ b/ChoreAssignmentTracker/src/ChoreAssignmentTracker.Api/Program.cs
@@ -1,5 +1,6 @@
 using ChoreAssignmentTracker.Infrastructure;
 using Serilog;
+using System.Text.Json.Serialization;
 
 // Configure Serilog
 Log.Logger = new LoggerConfiguration()
@@ -18,7 +19,11 @@ try
     builder.Host.UseSerilog();
 
     // Add services to the container.
-    builder.Services.AddControllers();
+    builder.Services.AddControllers()
+        .AddJsonOptions(options =>
+        {
+            options.JsonSerializerOptions.Converters.Add(new JsonStringEnumConverter());
+        });
     builder.Services.AddEndpointsApiExplorer();
     builder.Services.AddSwaggerGen(c =>
     {

--- a/ClassicCarRestorationLog/docs/specs/implementation-specs.md
+++ b/ClassicCarRestorationLog/docs/specs/implementation-specs.md
@@ -192,6 +192,21 @@ Id
 ### 5.5 CORS Configuration
 **REQ-API-006**: The API SHALL have a CORS policy defined. The origins allowed in the CORS policy SHALL be retrieved from configuration and SHALL include the URLs where the frontend(s) are hosted.
 
+### 5.6 JSON Serialization
+**REQ-API-007**: The API project Program.cs SHALL include the following using statement:
+```csharp
+using System.Text.Json.Serialization;
+```
+
+**REQ-API-008**: The API SHALL configure JSON serialization to handle enums as text strings. The `AddControllers()` call SHALL be configured with `JsonStringEnumConverter`:
+```csharp
+builder.Services.AddControllers()
+    .AddJsonOptions(options =>
+    {
+        options.JsonSerializerOptions.Converters.Add(new JsonStringEnumConverter());
+    });
+```
+
 ---
 
 ## 6. Frontend Requirements
@@ -470,6 +485,7 @@ All changes to this specification SHALL be tracked and versioned appropriately.
 | 1.1     | 2025-12-22 | System | Added structured logging requirements (REQ-SYS-013 through REQ-SYS-022) |
 | 1.2     | 2025-12-22 | System | Added code linting and static analysis requirements (REQ-LINT-001 through REQ-LINT-010) |
 | 1.3     | 2025-12-25 | System | Merged reactive data loading pattern requirements from data-loading-specs.md (REQ-FE-027 through REQ-FE-036) |
+| 1.4     | 2025-12-30 | System | Added JSON enum serialization requirements (REQ-API-007 through REQ-API-008) |
 
 ---
 

--- a/ClassicCarRestorationLog/src/ClassicCarRestorationLog.Api/Program.cs
+++ b/ClassicCarRestorationLog/src/ClassicCarRestorationLog.Api/Program.cs
@@ -1,5 +1,6 @@
 using ClassicCarRestorationLog.Infrastructure;
 using Serilog;
+using System.Text.Json.Serialization;
 
 var builder = WebApplication.CreateBuilder(args);
 
@@ -11,7 +12,11 @@ Log.Logger = new LoggerConfiguration()
 builder.Host.UseSerilog();
 
 // Add services to the container.
-builder.Services.AddControllers();
+builder.Services.AddControllers()
+    .AddJsonOptions(options =>
+    {
+        options.JsonSerializerOptions.Converters.Add(new JsonStringEnumConverter());
+    });
 builder.Services.AddEndpointsApiExplorer();
 builder.Services.AddSwaggerGen();
 

--- a/CollegeSavingsPlanner/docs/specs/implementation-specs.md
+++ b/CollegeSavingsPlanner/docs/specs/implementation-specs.md
@@ -192,6 +192,21 @@ Id
 ### 5.5 CORS Configuration
 **REQ-API-006**: The API SHALL have a CORS policy defined. The origins allowed in the CORS policy SHALL be retrieved from configuration and SHALL include the URLs where the frontend(s) are hosted.
 
+### 5.6 JSON Serialization
+**REQ-API-007**: The API project Program.cs SHALL include the following using statement:
+```csharp
+using System.Text.Json.Serialization;
+```
+
+**REQ-API-008**: The API SHALL configure JSON serialization to handle enums as text strings. The `AddControllers()` call SHALL be configured with `JsonStringEnumConverter`:
+```csharp
+builder.Services.AddControllers()
+    .AddJsonOptions(options =>
+    {
+        options.JsonSerializerOptions.Converters.Add(new JsonStringEnumConverter());
+    });
+```
+
 ---
 
 ## 6. Frontend Requirements
@@ -470,6 +485,7 @@ All changes to this specification SHALL be tracked and versioned appropriately.
 | 1.1     | 2025-12-22 | System | Added structured logging requirements (REQ-SYS-013 through REQ-SYS-022) |
 | 1.2     | 2025-12-22 | System | Added code linting and static analysis requirements (REQ-LINT-001 through REQ-LINT-010) |
 | 1.3     | 2025-12-25 | System | Merged reactive data loading pattern requirements from data-loading-specs.md (REQ-FE-027 through REQ-FE-036) |
+| 1.4     | 2025-12-30 | System | Added JSON enum serialization requirements (REQ-API-007 through REQ-API-008) |
 
 ---
 

--- a/CollegeSavingsPlanner/src/CollegeSavingsPlanner.Api/Program.cs
+++ b/CollegeSavingsPlanner/src/CollegeSavingsPlanner.Api/Program.cs
@@ -1,5 +1,6 @@
 using CollegeSavingsPlanner.Infrastructure;
 using Serilog;
+using System.Text.Json.Serialization;
 
 var builder = WebApplication.CreateBuilder(args);
 
@@ -16,7 +17,11 @@ try
     Log.Information("Starting College Savings Planner API");
 
     // Add services to the container.
-    builder.Services.AddControllers();
+    builder.Services.AddControllers()
+        .AddJsonOptions(options =>
+        {
+            options.JsonSerializerOptions.Converters.Add(new JsonStringEnumConverter());
+        });
     builder.Services.AddEndpointsApiExplorer();
     builder.Services.AddSwaggerGen(c =>
     {

--- a/ConferenceEventManager/docs/specs/implementation-specs.md
+++ b/ConferenceEventManager/docs/specs/implementation-specs.md
@@ -192,6 +192,21 @@ Id
 ### 5.5 CORS Configuration
 **REQ-API-006**: The API SHALL have a CORS policy defined. The origins allowed in the CORS policy SHALL be retrieved from configuration and SHALL include the URLs where the frontend(s) are hosted.
 
+### 5.6 JSON Serialization
+**REQ-API-007**: The API project Program.cs SHALL include the following using statement:
+```csharp
+using System.Text.Json.Serialization;
+```
+
+**REQ-API-008**: The API SHALL configure JSON serialization to handle enums as text strings. The `AddControllers()` call SHALL be configured with `JsonStringEnumConverter`:
+```csharp
+builder.Services.AddControllers()
+    .AddJsonOptions(options =>
+    {
+        options.JsonSerializerOptions.Converters.Add(new JsonStringEnumConverter());
+    });
+```
+
 ---
 
 ## 6. Frontend Requirements
@@ -470,6 +485,7 @@ All changes to this specification SHALL be tracked and versioned appropriately.
 | 1.1     | 2025-12-22 | System | Added structured logging requirements (REQ-SYS-013 through REQ-SYS-022) |
 | 1.2     | 2025-12-22 | System | Added code linting and static analysis requirements (REQ-LINT-001 through REQ-LINT-010) |
 | 1.3     | 2025-12-25 | System | Merged reactive data loading pattern requirements from data-loading-specs.md (REQ-FE-027 through REQ-FE-036) |
+| 1.4     | 2025-12-30 | System | Added JSON enum serialization requirements (REQ-API-007 through REQ-API-008) |
 
 ---
 

--- a/ConferenceEventManager/src/ConferenceEventManager.Api/Program.cs
+++ b/ConferenceEventManager/src/ConferenceEventManager.Api/Program.cs
@@ -2,6 +2,7 @@ using ConferenceEventManager.Infrastructure;
 using FluentValidation;
 using Serilog;
 using System.Reflection;
+using System.Text.Json.Serialization;
 
 var builder = WebApplication.CreateBuilder(args);
 
@@ -17,7 +18,11 @@ try
     Log.Information("Starting ConferenceEventManager API");
 
     // Add services to the container.
-    builder.Services.AddControllers();
+    builder.Services.AddControllers()
+        .AddJsonOptions(options =>
+        {
+            options.JsonSerializerOptions.Converters.Add(new JsonStringEnumConverter());
+        });
     builder.Services.AddEndpointsApiExplorer();
     builder.Services.AddSwaggerGen(c =>
     {

--- a/ConversationStarterApp/docs/specs/implementation-specs.md
+++ b/ConversationStarterApp/docs/specs/implementation-specs.md
@@ -192,6 +192,21 @@ Id
 ### 5.5 CORS Configuration
 **REQ-API-006**: The API SHALL have a CORS policy defined. The origins allowed in the CORS policy SHALL be retrieved from configuration and SHALL include the URLs where the frontend(s) are hosted.
 
+### 5.6 JSON Serialization
+**REQ-API-007**: The API project Program.cs SHALL include the following using statement:
+```csharp
+using System.Text.Json.Serialization;
+```
+
+**REQ-API-008**: The API SHALL configure JSON serialization to handle enums as text strings. The `AddControllers()` call SHALL be configured with `JsonStringEnumConverter`:
+```csharp
+builder.Services.AddControllers()
+    .AddJsonOptions(options =>
+    {
+        options.JsonSerializerOptions.Converters.Add(new JsonStringEnumConverter());
+    });
+```
+
 ---
 
 ## 6. Frontend Requirements
@@ -470,6 +485,7 @@ All changes to this specification SHALL be tracked and versioned appropriately.
 | 1.1     | 2025-12-22 | System | Added structured logging requirements (REQ-SYS-013 through REQ-SYS-022) |
 | 1.2     | 2025-12-22 | System | Added code linting and static analysis requirements (REQ-LINT-001 through REQ-LINT-010) |
 | 1.3     | 2025-12-25 | System | Merged reactive data loading pattern requirements from data-loading-specs.md (REQ-FE-027 through REQ-FE-036) |
+| 1.4     | 2025-12-30 | System | Added JSON enum serialization requirements (REQ-API-007 through REQ-API-008) |
 
 ---
 

--- a/ConversationStarterApp/src/ConversationStarterApp.Api/Program.cs
+++ b/ConversationStarterApp/src/ConversationStarterApp.Api/Program.cs
@@ -5,6 +5,7 @@ using ConversationStarterApp.Api;
 using ConversationStarterApp.Infrastructure;
 using ConversationStarterApp.Infrastructure.Data;
 using Serilog;
+using System.Text.Json.Serialization;
 
 var builder = WebApplication.CreateBuilder(args);
 
@@ -21,7 +22,11 @@ builder.Host.UseSerilog((context, loggerConfig) =>
 });
 
 // Add services to the container.
-builder.Services.AddControllers();
+builder.Services.AddControllers()
+    .AddJsonOptions(options =>
+    {
+        options.JsonSerializerOptions.Converters.Add(new JsonStringEnumConverter());
+    });
 builder.Services.AddEndpointsApiExplorer();
 builder.Services.AddSwaggerGen(options =>
 {

--- a/CouplesGoalTracker/docs/specs/implementation-specs.md
+++ b/CouplesGoalTracker/docs/specs/implementation-specs.md
@@ -192,6 +192,21 @@ Id
 ### 5.5 CORS Configuration
 **REQ-API-006**: The API SHALL have a CORS policy defined. The origins allowed in the CORS policy SHALL be retrieved from configuration and SHALL include the URLs where the frontend(s) are hosted.
 
+### 5.6 JSON Serialization
+**REQ-API-007**: The API project Program.cs SHALL include the following using statement:
+```csharp
+using System.Text.Json.Serialization;
+```
+
+**REQ-API-008**: The API SHALL configure JSON serialization to handle enums as text strings. The `AddControllers()` call SHALL be configured with `JsonStringEnumConverter`:
+```csharp
+builder.Services.AddControllers()
+    .AddJsonOptions(options =>
+    {
+        options.JsonSerializerOptions.Converters.Add(new JsonStringEnumConverter());
+    });
+```
+
 ---
 
 ## 6. Frontend Requirements
@@ -470,6 +485,7 @@ All changes to this specification SHALL be tracked and versioned appropriately.
 | 1.1     | 2025-12-22 | System | Added structured logging requirements (REQ-SYS-013 through REQ-SYS-022) |
 | 1.2     | 2025-12-22 | System | Added code linting and static analysis requirements (REQ-LINT-001 through REQ-LINT-010) |
 | 1.3     | 2025-12-25 | System | Merged reactive data loading pattern requirements from data-loading-specs.md (REQ-FE-027 through REQ-FE-036) |
+| 1.4     | 2025-12-30 | System | Added JSON enum serialization requirements (REQ-API-007 through REQ-API-008) |
 
 ---
 

--- a/CouplesGoalTracker/src/CouplesGoalTracker.Api/Program.cs
+++ b/CouplesGoalTracker/src/CouplesGoalTracker.Api/Program.cs
@@ -1,5 +1,6 @@
 using CouplesGoalTracker.Infrastructure;
 using Serilog;
+using System.Text.Json.Serialization;
 
 var builder = WebApplication.CreateBuilder(args);
 
@@ -16,7 +17,11 @@ Log.Logger = new LoggerConfiguration()
 builder.Host.UseSerilog();
 
 // Add services to the container.
-builder.Services.AddControllers();
+builder.Services.AddControllers()
+    .AddJsonOptions(options =>
+    {
+        options.JsonSerializerOptions.Converters.Add(new JsonStringEnumConverter());
+    });
 builder.Services.AddEndpointsApiExplorer();
 builder.Services.AddSwaggerGen(c =>
 {

--- a/CryptoPortfolioManager/docs/specs/implementation-specs.md
+++ b/CryptoPortfolioManager/docs/specs/implementation-specs.md
@@ -192,6 +192,21 @@ Id
 ### 5.5 CORS Configuration
 **REQ-API-006**: The API SHALL have a CORS policy defined. The origins allowed in the CORS policy SHALL be retrieved from configuration and SHALL include the URLs where the frontend(s) are hosted.
 
+### 5.6 JSON Serialization
+**REQ-API-007**: The API project Program.cs SHALL include the following using statement:
+```csharp
+using System.Text.Json.Serialization;
+```
+
+**REQ-API-008**: The API SHALL configure JSON serialization to handle enums as text strings. The `AddControllers()` call SHALL be configured with `JsonStringEnumConverter`:
+```csharp
+builder.Services.AddControllers()
+    .AddJsonOptions(options =>
+    {
+        options.JsonSerializerOptions.Converters.Add(new JsonStringEnumConverter());
+    });
+```
+
 ---
 
 ## 6. Frontend Requirements
@@ -470,6 +485,7 @@ All changes to this specification SHALL be tracked and versioned appropriately.
 | 1.1     | 2025-12-22 | System | Added structured logging requirements (REQ-SYS-013 through REQ-SYS-022) |
 | 1.2     | 2025-12-22 | System | Added code linting and static analysis requirements (REQ-LINT-001 through REQ-LINT-010) |
 | 1.3     | 2025-12-25 | System | Merged reactive data loading pattern requirements from data-loading-specs.md (REQ-FE-027 through REQ-FE-036) |
+| 1.4     | 2025-12-30 | System | Added JSON enum serialization requirements (REQ-API-007 through REQ-API-008) |
 
 ---
 

--- a/CryptoPortfolioManager/src/CryptoPortfolioManager.Api/Program.cs
+++ b/CryptoPortfolioManager/src/CryptoPortfolioManager.Api/Program.cs
@@ -1,5 +1,6 @@
 using CryptoPortfolioManager.Infrastructure;
 using Serilog;
+using System.Text.Json.Serialization;
 
 var builder = WebApplication.CreateBuilder(args);
 
@@ -11,7 +12,11 @@ Log.Logger = new LoggerConfiguration()
 builder.Host.UseSerilog();
 
 // Add services to the container.
-builder.Services.AddControllers();
+builder.Services.AddControllers()
+    .AddJsonOptions(options =>
+    {
+        options.JsonSerializerOptions.Converters.Add(new JsonStringEnumConverter());
+    });
 builder.Services.AddEndpointsApiExplorer();
 builder.Services.AddSwaggerGen(c =>
 {

--- a/DailyJournalingApp/docs/specs/implementation-specs.md
+++ b/DailyJournalingApp/docs/specs/implementation-specs.md
@@ -192,6 +192,21 @@ Id
 ### 5.5 CORS Configuration
 **REQ-API-006**: The API SHALL have a CORS policy defined. The origins allowed in the CORS policy SHALL be retrieved from configuration and SHALL include the URLs where the frontend(s) are hosted.
 
+### 5.6 JSON Serialization
+**REQ-API-007**: The API project Program.cs SHALL include the following using statement:
+```csharp
+using System.Text.Json.Serialization;
+```
+
+**REQ-API-008**: The API SHALL configure JSON serialization to handle enums as text strings. The `AddControllers()` call SHALL be configured with `JsonStringEnumConverter`:
+```csharp
+builder.Services.AddControllers()
+    .AddJsonOptions(options =>
+    {
+        options.JsonSerializerOptions.Converters.Add(new JsonStringEnumConverter());
+    });
+```
+
 ---
 
 ## 6. Frontend Requirements
@@ -470,6 +485,7 @@ All changes to this specification SHALL be tracked and versioned appropriately.
 | 1.1     | 2025-12-22 | System | Added structured logging requirements (REQ-SYS-013 through REQ-SYS-022) |
 | 1.2     | 2025-12-22 | System | Added code linting and static analysis requirements (REQ-LINT-001 through REQ-LINT-010) |
 | 1.3     | 2025-12-25 | System | Merged reactive data loading pattern requirements from data-loading-specs.md (REQ-FE-027 through REQ-FE-036) |
+| 1.4     | 2025-12-30 | System | Added JSON enum serialization requirements (REQ-API-007 through REQ-API-008) |
 
 ---
 

--- a/DailyJournalingApp/src/DailyJournalingApp.Api/Program.cs
+++ b/DailyJournalingApp/src/DailyJournalingApp.Api/Program.cs
@@ -1,5 +1,6 @@
 using DailyJournalingApp.Infrastructure;
 using Serilog;
+using System.Text.Json.Serialization;
 
 var builder = WebApplication.CreateBuilder(args);
 
@@ -16,7 +17,11 @@ builder.Host.UseSerilog((context, loggerConfig) =>
 });
 
 // Add services to the container.
-builder.Services.AddControllers();
+builder.Services.AddControllers()
+    .AddJsonOptions(options =>
+    {
+        options.JsonSerializerOptions.Converters.Add(new JsonStringEnumConverter());
+    });
 builder.Services.AddEndpointsApiExplorer();
 builder.Services.AddSwaggerGen(options =>
 {

--- a/DateNightIdeaGenerator/docs/specs/implementation-specs.md
+++ b/DateNightIdeaGenerator/docs/specs/implementation-specs.md
@@ -192,6 +192,21 @@ Id
 ### 5.5 CORS Configuration
 **REQ-API-006**: The API SHALL have a CORS policy defined. The origins allowed in the CORS policy SHALL be retrieved from configuration and SHALL include the URLs where the frontend(s) are hosted.
 
+### 5.6 JSON Serialization
+**REQ-API-007**: The API project Program.cs SHALL include the following using statement:
+```csharp
+using System.Text.Json.Serialization;
+```
+
+**REQ-API-008**: The API SHALL configure JSON serialization to handle enums as text strings. The `AddControllers()` call SHALL be configured with `JsonStringEnumConverter`:
+```csharp
+builder.Services.AddControllers()
+    .AddJsonOptions(options =>
+    {
+        options.JsonSerializerOptions.Converters.Add(new JsonStringEnumConverter());
+    });
+```
+
 ---
 
 ## 6. Frontend Requirements
@@ -470,6 +485,7 @@ All changes to this specification SHALL be tracked and versioned appropriately.
 | 1.1     | 2025-12-22 | System | Added structured logging requirements (REQ-SYS-013 through REQ-SYS-022) |
 | 1.2     | 2025-12-22 | System | Added code linting and static analysis requirements (REQ-LINT-001 through REQ-LINT-010) |
 | 1.3     | 2025-12-25 | System | Merged reactive data loading pattern requirements from data-loading-specs.md (REQ-FE-027 through REQ-FE-036) |
+| 1.4     | 2025-12-30 | System | Added JSON enum serialization requirements (REQ-API-007 through REQ-API-008) |
 
 ---
 

--- a/DateNightIdeaGenerator/src/DateNightIdeaGenerator.Api/Program.cs
+++ b/DateNightIdeaGenerator/src/DateNightIdeaGenerator.Api/Program.cs
@@ -1,5 +1,6 @@
 using DateNightIdeaGenerator.Infrastructure;
 using Serilog;
+using System.Text.Json.Serialization;
 
 var builder = WebApplication.CreateBuilder(args);
 
@@ -15,7 +16,11 @@ try
     Log.Information("Starting DateNightIdeaGenerator API");
 
     // Add services to the container.
-    builder.Services.AddControllers();
+    builder.Services.AddControllers()
+        .AddJsonOptions(options =>
+        {
+            options.JsonSerializerOptions.Converters.Add(new JsonStringEnumConverter());
+        });
     builder.Services.AddEndpointsApiExplorer();
     builder.Services.AddSwaggerGen(options =>
     {

--- a/DigitalLegacyPlanner/docs/specs/implementation-specs.md
+++ b/DigitalLegacyPlanner/docs/specs/implementation-specs.md
@@ -192,6 +192,21 @@ Id
 ### 5.5 CORS Configuration
 **REQ-API-006**: The API SHALL have a CORS policy defined. The origins allowed in the CORS policy SHALL be retrieved from configuration and SHALL include the URLs where the frontend(s) are hosted.
 
+### 5.6 JSON Serialization
+**REQ-API-007**: The API project Program.cs SHALL include the following using statement:
+```csharp
+using System.Text.Json.Serialization;
+```
+
+**REQ-API-008**: The API SHALL configure JSON serialization to handle enums as text strings. The `AddControllers()` call SHALL be configured with `JsonStringEnumConverter`:
+```csharp
+builder.Services.AddControllers()
+    .AddJsonOptions(options =>
+    {
+        options.JsonSerializerOptions.Converters.Add(new JsonStringEnumConverter());
+    });
+```
+
 ---
 
 ## 6. Frontend Requirements
@@ -470,6 +485,7 @@ All changes to this specification SHALL be tracked and versioned appropriately.
 | 1.1     | 2025-12-22 | System | Added structured logging requirements (REQ-SYS-013 through REQ-SYS-022) |
 | 1.2     | 2025-12-22 | System | Added code linting and static analysis requirements (REQ-LINT-001 through REQ-LINT-010) |
 | 1.3     | 2025-12-25 | System | Merged reactive data loading pattern requirements from data-loading-specs.md (REQ-FE-027 through REQ-FE-036) |
+| 1.4     | 2025-12-30 | System | Added JSON enum serialization requirements (REQ-API-007 through REQ-API-008) |
 
 ---
 

--- a/DigitalLegacyPlanner/src/DigitalLegacyPlanner.Api/Program.cs
+++ b/DigitalLegacyPlanner/src/DigitalLegacyPlanner.Api/Program.cs
@@ -1,5 +1,6 @@
 using DigitalLegacyPlanner.Infrastructure;
 using Serilog;
+using System.Text.Json.Serialization;
 
 var builder = WebApplication.CreateBuilder(args);
 
@@ -11,7 +12,11 @@ Log.Logger = new LoggerConfiguration()
 builder.Host.UseSerilog();
 
 // Add services to the container.
-builder.Services.AddControllers();
+builder.Services.AddControllers()
+    .AddJsonOptions(options =>
+    {
+        options.JsonSerializerOptions.Converters.Add(new JsonStringEnumConverter());
+    });
 builder.Services.AddEndpointsApiExplorer();
 builder.Services.AddSwaggerGen(c =>
 {

--- a/DocumentVaultOrganizer/docs/specs/implementation-specs.md
+++ b/DocumentVaultOrganizer/docs/specs/implementation-specs.md
@@ -192,6 +192,21 @@ Id
 ### 5.5 CORS Configuration
 **REQ-API-006**: The API SHALL have a CORS policy defined. The origins allowed in the CORS policy SHALL be retrieved from configuration and SHALL include the URLs where the frontend(s) are hosted.
 
+### 5.6 JSON Serialization
+**REQ-API-007**: The API project Program.cs SHALL include the following using statement:
+```csharp
+using System.Text.Json.Serialization;
+```
+
+**REQ-API-008**: The API SHALL configure JSON serialization to handle enums as text strings. The `AddControllers()` call SHALL be configured with `JsonStringEnumConverter`:
+```csharp
+builder.Services.AddControllers()
+    .AddJsonOptions(options =>
+    {
+        options.JsonSerializerOptions.Converters.Add(new JsonStringEnumConverter());
+    });
+```
+
 ---
 
 ## 6. Frontend Requirements
@@ -470,6 +485,7 @@ All changes to this specification SHALL be tracked and versioned appropriately.
 | 1.1     | 2025-12-22 | System | Added structured logging requirements (REQ-SYS-013 through REQ-SYS-022) |
 | 1.2     | 2025-12-22 | System | Added code linting and static analysis requirements (REQ-LINT-001 through REQ-LINT-010) |
 | 1.3     | 2025-12-25 | System | Merged reactive data loading pattern requirements from data-loading-specs.md (REQ-FE-027 through REQ-FE-036) |
+| 1.4     | 2025-12-30 | System | Added JSON enum serialization requirements (REQ-API-007 through REQ-API-008) |
 
 ---
 

--- a/DocumentVaultOrganizer/src/DocumentVaultOrganizer.Api/Program.cs
+++ b/DocumentVaultOrganizer/src/DocumentVaultOrganizer.Api/Program.cs
@@ -1,6 +1,7 @@
 using DocumentVaultOrganizer.Infrastructure;
 using Serilog;
 using System.Reflection;
+using System.Text.Json.Serialization;
 
 var builder = WebApplication.CreateBuilder(args);
 
@@ -13,7 +14,11 @@ builder.Host.UseSerilog((context, services, configuration) => configuration
     .WriteTo.File("Logs/log-.txt", rollingInterval: RollingInterval.Day));
 
 // Add services to the container.
-builder.Services.AddControllers();
+builder.Services.AddControllers()
+    .AddJsonOptions(options =>
+    {
+        options.JsonSerializerOptions.Converters.Add(new JsonStringEnumConverter());
+    });
 builder.Services.AddEndpointsApiExplorer();
 builder.Services.AddSwaggerGen();
 

--- a/FamilyCalendarEventPlanner/docs/specs/implementation-specs.md
+++ b/FamilyCalendarEventPlanner/docs/specs/implementation-specs.md
@@ -192,6 +192,21 @@ Id
 ### 5.5 CORS Configuration
 **REQ-API-006**: The API SHALL have a CORS policy defined. The origins allowed in the CORS policy SHALL be retrieved from configuration and SHALL include the URLs where the frontend(s) are hosted.
 
+### 5.6 JSON Serialization
+**REQ-API-007**: The API project Program.cs SHALL include the following using statement:
+```csharp
+using System.Text.Json.Serialization;
+```
+
+**REQ-API-008**: The API SHALL configure JSON serialization to handle enums as text strings. The `AddControllers()` call SHALL be configured with `JsonStringEnumConverter`:
+```csharp
+builder.Services.AddControllers()
+    .AddJsonOptions(options =>
+    {
+        options.JsonSerializerOptions.Converters.Add(new JsonStringEnumConverter());
+    });
+```
+
 ---
 
 ## 6. Frontend Requirements
@@ -470,6 +485,7 @@ All changes to this specification SHALL be tracked and versioned appropriately.
 | 1.1     | 2025-12-22 | System | Added structured logging requirements (REQ-SYS-013 through REQ-SYS-022) |
 | 1.2     | 2025-12-22 | System | Added code linting and static analysis requirements (REQ-LINT-001 through REQ-LINT-010) |
 | 1.3     | 2025-12-25 | System | Merged reactive data loading pattern requirements from data-loading-specs.md (REQ-FE-027 through REQ-FE-036) |
+| 1.4     | 2025-12-30 | System | Added JSON enum serialization requirements (REQ-API-007 through REQ-API-008) |
 
 ---
 

--- a/FamilyCalendarEventPlanner/src/FamilyCalendarEventPlanner.Api/Program.cs
+++ b/FamilyCalendarEventPlanner/src/FamilyCalendarEventPlanner.Api/Program.cs
@@ -23,7 +23,6 @@ builder.Services.AddControllers()
     {
         options.JsonSerializerOptions.Converters.Add(new JsonStringEnumConverter());
     });
-
 builder.Services.AddEndpointsApiExplorer();
 builder.Services.AddSwaggerGen(options =>
 {

--- a/FamilyPhotoAlbumOrganizer/docs/specs/implementation-specs.md
+++ b/FamilyPhotoAlbumOrganizer/docs/specs/implementation-specs.md
@@ -192,6 +192,21 @@ Id
 ### 5.5 CORS Configuration
 **REQ-API-006**: The API SHALL have a CORS policy defined. The origins allowed in the CORS policy SHALL be retrieved from configuration and SHALL include the URLs where the frontend(s) are hosted.
 
+### 5.6 JSON Serialization
+**REQ-API-007**: The API project Program.cs SHALL include the following using statement:
+```csharp
+using System.Text.Json.Serialization;
+```
+
+**REQ-API-008**: The API SHALL configure JSON serialization to handle enums as text strings. The `AddControllers()` call SHALL be configured with `JsonStringEnumConverter`:
+```csharp
+builder.Services.AddControllers()
+    .AddJsonOptions(options =>
+    {
+        options.JsonSerializerOptions.Converters.Add(new JsonStringEnumConverter());
+    });
+```
+
 ---
 
 ## 6. Frontend Requirements
@@ -470,6 +485,7 @@ All changes to this specification SHALL be tracked and versioned appropriately.
 | 1.1     | 2025-12-22 | System | Added structured logging requirements (REQ-SYS-013 through REQ-SYS-022) |
 | 1.2     | 2025-12-22 | System | Added code linting and static analysis requirements (REQ-LINT-001 through REQ-LINT-010) |
 | 1.3     | 2025-12-25 | System | Merged reactive data loading pattern requirements from data-loading-specs.md (REQ-FE-027 through REQ-FE-036) |
+| 1.4     | 2025-12-30 | System | Added JSON enum serialization requirements (REQ-API-007 through REQ-API-008) |
 
 ---
 

--- a/FamilyPhotoAlbumOrganizer/src/FamilyPhotoAlbumOrganizer.Api/Program.cs
+++ b/FamilyPhotoAlbumOrganizer/src/FamilyPhotoAlbumOrganizer.Api/Program.cs
@@ -2,6 +2,7 @@ using FamilyPhotoAlbumOrganizer.Infrastructure;
 using FluentValidation;
 using Serilog;
 using System.Reflection;
+using System.Text.Json.Serialization;
 
 var builder = WebApplication.CreateBuilder(args);
 
@@ -17,7 +18,11 @@ try
     Log.Information("Starting FamilyPhotoAlbumOrganizer API");
 
     // Add services to the container.
-    builder.Services.AddControllers();
+    builder.Services.AddControllers()
+        .AddJsonOptions(options =>
+        {
+            options.JsonSerializerOptions.Converters.Add(new JsonStringEnumConverter());
+        });
     builder.Services.AddEndpointsApiExplorer();
     builder.Services.AddSwaggerGen(c =>
     {

--- a/FamilyTreeBuilder/docs/specs/implementation-specs.md
+++ b/FamilyTreeBuilder/docs/specs/implementation-specs.md
@@ -192,6 +192,21 @@ Id
 ### 5.5 CORS Configuration
 **REQ-API-006**: The API SHALL have a CORS policy defined. The origins allowed in the CORS policy SHALL be retrieved from configuration and SHALL include the URLs where the frontend(s) are hosted.
 
+### 5.6 JSON Serialization
+**REQ-API-007**: The API project Program.cs SHALL include the following using statement:
+```csharp
+using System.Text.Json.Serialization;
+```
+
+**REQ-API-008**: The API SHALL configure JSON serialization to handle enums as text strings. The `AddControllers()` call SHALL be configured with `JsonStringEnumConverter`:
+```csharp
+builder.Services.AddControllers()
+    .AddJsonOptions(options =>
+    {
+        options.JsonSerializerOptions.Converters.Add(new JsonStringEnumConverter());
+    });
+```
+
 ---
 
 ## 6. Frontend Requirements
@@ -470,6 +485,7 @@ All changes to this specification SHALL be tracked and versioned appropriately.
 | 1.1     | 2025-12-22 | System | Added structured logging requirements (REQ-SYS-013 through REQ-SYS-022) |
 | 1.2     | 2025-12-22 | System | Added code linting and static analysis requirements (REQ-LINT-001 through REQ-LINT-010) |
 | 1.3     | 2025-12-25 | System | Merged reactive data loading pattern requirements from data-loading-specs.md (REQ-FE-027 through REQ-FE-036) |
+| 1.4     | 2025-12-30 | System | Added JSON enum serialization requirements (REQ-API-007 through REQ-API-008) |
 
 ---
 

--- a/FamilyTreeBuilder/src/FamilyTreeBuilder.Api/Program.cs
+++ b/FamilyTreeBuilder/src/FamilyTreeBuilder.Api/Program.cs
@@ -1,5 +1,6 @@
 using FamilyTreeBuilder.Infrastructure;
 using Serilog;
+using System.Text.Json.Serialization;
 
 var builder = WebApplication.CreateBuilder(args);
 
@@ -11,7 +12,11 @@ Log.Logger = new LoggerConfiguration()
 builder.Host.UseSerilog();
 
 // Add services to the container.
-builder.Services.AddControllers();
+builder.Services.AddControllers()
+    .AddJsonOptions(options =>
+    {
+        options.JsonSerializerOptions.Converters.Add(new JsonStringEnumConverter());
+    });
 builder.Services.AddEndpointsApiExplorer();
 builder.Services.AddSwaggerGen();
 

--- a/FamilyVacationPlanner/docs/specs/implementation-specs.md
+++ b/FamilyVacationPlanner/docs/specs/implementation-specs.md
@@ -192,6 +192,21 @@ Id
 ### 5.5 CORS Configuration
 **REQ-API-006**: The API SHALL have a CORS policy defined. The origins allowed in the CORS policy SHALL be retrieved from configuration and SHALL include the URLs where the frontend(s) are hosted.
 
+### 5.6 JSON Serialization
+**REQ-API-007**: The API project Program.cs SHALL include the following using statement:
+```csharp
+using System.Text.Json.Serialization;
+```
+
+**REQ-API-008**: The API SHALL configure JSON serialization to handle enums as text strings. The `AddControllers()` call SHALL be configured with `JsonStringEnumConverter`:
+```csharp
+builder.Services.AddControllers()
+    .AddJsonOptions(options =>
+    {
+        options.JsonSerializerOptions.Converters.Add(new JsonStringEnumConverter());
+    });
+```
+
 ---
 
 ## 6. Frontend Requirements
@@ -470,6 +485,7 @@ All changes to this specification SHALL be tracked and versioned appropriately.
 | 1.1     | 2025-12-22 | System | Added structured logging requirements (REQ-SYS-013 through REQ-SYS-022) |
 | 1.2     | 2025-12-22 | System | Added code linting and static analysis requirements (REQ-LINT-001 through REQ-LINT-010) |
 | 1.3     | 2025-12-25 | System | Merged reactive data loading pattern requirements from data-loading-specs.md (REQ-FE-027 through REQ-FE-036) |
+| 1.4     | 2025-12-30 | System | Added JSON enum serialization requirements (REQ-API-007 through REQ-API-008) |
 
 ---
 

--- a/FamilyVacationPlanner/src/FamilyVacationPlanner.Api/Program.cs
+++ b/FamilyVacationPlanner/src/FamilyVacationPlanner.Api/Program.cs
@@ -1,5 +1,6 @@
 using FamilyVacationPlanner.Infrastructure;
 using Serilog;
+using System.Text.Json.Serialization;
 
 var builder = WebApplication.CreateBuilder(args);
 
@@ -16,7 +17,11 @@ builder.Host.UseSerilog((context, loggerConfig) =>
 });
 
 // Add services to the container.
-builder.Services.AddControllers();
+builder.Services.AddControllers()
+    .AddJsonOptions(options =>
+    {
+        options.JsonSerializerOptions.Converters.Add(new JsonStringEnumConverter());
+    });
 builder.Services.AddEndpointsApiExplorer();
 builder.Services.AddSwaggerGen(options =>
 {

--- a/FinancialGoalTracker/docs/specs/implementation-specs.md
+++ b/FinancialGoalTracker/docs/specs/implementation-specs.md
@@ -192,6 +192,21 @@ Id
 ### 5.5 CORS Configuration
 **REQ-API-006**: The API SHALL have a CORS policy defined. The origins allowed in the CORS policy SHALL be retrieved from configuration and SHALL include the URLs where the frontend(s) are hosted.
 
+### 5.6 JSON Serialization
+**REQ-API-007**: The API project Program.cs SHALL include the following using statement:
+```csharp
+using System.Text.Json.Serialization;
+```
+
+**REQ-API-008**: The API SHALL configure JSON serialization to handle enums as text strings. The `AddControllers()` call SHALL be configured with `JsonStringEnumConverter`:
+```csharp
+builder.Services.AddControllers()
+    .AddJsonOptions(options =>
+    {
+        options.JsonSerializerOptions.Converters.Add(new JsonStringEnumConverter());
+    });
+```
+
 ---
 
 ## 6. Frontend Requirements
@@ -470,6 +485,7 @@ All changes to this specification SHALL be tracked and versioned appropriately.
 | 1.1     | 2025-12-22 | System | Added structured logging requirements (REQ-SYS-013 through REQ-SYS-022) |
 | 1.2     | 2025-12-22 | System | Added code linting and static analysis requirements (REQ-LINT-001 through REQ-LINT-010) |
 | 1.3     | 2025-12-25 | System | Merged reactive data loading pattern requirements from data-loading-specs.md (REQ-FE-027 through REQ-FE-036) |
+| 1.4     | 2025-12-30 | System | Added JSON enum serialization requirements (REQ-API-007 through REQ-API-008) |
 
 ---
 

--- a/FinancialGoalTracker/src/FinancialGoalTracker.Api/Program.cs
+++ b/FinancialGoalTracker/src/FinancialGoalTracker.Api/Program.cs
@@ -1,5 +1,6 @@
 using FinancialGoalTracker.Infrastructure;
 using Serilog;
+using System.Text.Json.Serialization;
 
 var builder = WebApplication.CreateBuilder(args);
 
@@ -16,7 +17,11 @@ builder.Host.UseSerilog((context, loggerConfig) =>
 });
 
 // Add services to the container.
-builder.Services.AddControllers();
+builder.Services.AddControllers()
+    .AddJsonOptions(options =>
+    {
+        options.JsonSerializerOptions.Converters.Add(new JsonStringEnumConverter());
+    });
 builder.Services.AddEndpointsApiExplorer();
 builder.Services.AddSwaggerGen(options =>
 {

--- a/FishingLogSpotTracker/docs/specs/implementation-specs.md
+++ b/FishingLogSpotTracker/docs/specs/implementation-specs.md
@@ -192,6 +192,21 @@ Id
 ### 5.5 CORS Configuration
 **REQ-API-006**: The API SHALL have a CORS policy defined. The origins allowed in the CORS policy SHALL be retrieved from configuration and SHALL include the URLs where the frontend(s) are hosted.
 
+### 5.6 JSON Serialization
+**REQ-API-007**: The API project Program.cs SHALL include the following using statement:
+```csharp
+using System.Text.Json.Serialization;
+```
+
+**REQ-API-008**: The API SHALL configure JSON serialization to handle enums as text strings. The `AddControllers()` call SHALL be configured with `JsonStringEnumConverter`:
+```csharp
+builder.Services.AddControllers()
+    .AddJsonOptions(options =>
+    {
+        options.JsonSerializerOptions.Converters.Add(new JsonStringEnumConverter());
+    });
+```
+
 ---
 
 ## 6. Frontend Requirements
@@ -470,6 +485,7 @@ All changes to this specification SHALL be tracked and versioned appropriately.
 | 1.1     | 2025-12-22 | System | Added structured logging requirements (REQ-SYS-013 through REQ-SYS-022) |
 | 1.2     | 2025-12-22 | System | Added code linting and static analysis requirements (REQ-LINT-001 through REQ-LINT-010) |
 | 1.3     | 2025-12-25 | System | Merged reactive data loading pattern requirements from data-loading-specs.md (REQ-FE-027 through REQ-FE-036) |
+| 1.4     | 2025-12-30 | System | Added JSON enum serialization requirements (REQ-API-007 through REQ-API-008) |
 
 ---
 

--- a/FishingLogSpotTracker/src/FishingLogSpotTracker.Api/Program.cs
+++ b/FishingLogSpotTracker/src/FishingLogSpotTracker.Api/Program.cs
@@ -2,6 +2,7 @@ using FluentValidation;
 using FishingLogSpotTracker.Infrastructure;
 using Serilog;
 using System.Reflection;
+using System.Text.Json.Serialization;
 
 // Configure Serilog
 Log.Logger = new LoggerConfiguration()
@@ -22,7 +23,11 @@ try
     builder.Host.UseSerilog();
 
     // Add services to the container.
-    builder.Services.AddControllers();
+    builder.Services.AddControllers()
+        .AddJsonOptions(options =>
+        {
+            options.JsonSerializerOptions.Converters.Add(new JsonStringEnumConverter());
+        });
     builder.Services.AddEndpointsApiExplorer();
     builder.Services.AddSwaggerGen(options =>
     {

--- a/FocusSessionTracker/docs/specs/implementation-specs.md
+++ b/FocusSessionTracker/docs/specs/implementation-specs.md
@@ -192,6 +192,21 @@ Id
 ### 5.5 CORS Configuration
 **REQ-API-006**: The API SHALL have a CORS policy defined. The origins allowed in the CORS policy SHALL be retrieved from configuration and SHALL include the URLs where the frontend(s) are hosted.
 
+### 5.6 JSON Serialization
+**REQ-API-007**: The API project Program.cs SHALL include the following using statement:
+```csharp
+using System.Text.Json.Serialization;
+```
+
+**REQ-API-008**: The API SHALL configure JSON serialization to handle enums as text strings. The `AddControllers()` call SHALL be configured with `JsonStringEnumConverter`:
+```csharp
+builder.Services.AddControllers()
+    .AddJsonOptions(options =>
+    {
+        options.JsonSerializerOptions.Converters.Add(new JsonStringEnumConverter());
+    });
+```
+
 ---
 
 ## 6. Frontend Requirements
@@ -470,6 +485,7 @@ All changes to this specification SHALL be tracked and versioned appropriately.
 | 1.1     | 2025-12-22 | System | Added structured logging requirements (REQ-SYS-013 through REQ-SYS-022) |
 | 1.2     | 2025-12-22 | System | Added code linting and static analysis requirements (REQ-LINT-001 through REQ-LINT-010) |
 | 1.3     | 2025-12-25 | System | Merged reactive data loading pattern requirements from data-loading-specs.md (REQ-FE-027 through REQ-FE-036) |
+| 1.4     | 2025-12-30 | System | Added JSON enum serialization requirements (REQ-API-007 through REQ-API-008) |
 
 ---
 

--- a/FocusSessionTracker/src/FocusSessionTracker.Api/Program.cs
+++ b/FocusSessionTracker/src/FocusSessionTracker.Api/Program.cs
@@ -1,5 +1,6 @@
 using FocusSessionTracker.Infrastructure;
 using Serilog;
+using System.Text.Json.Serialization;
 
 var builder = WebApplication.CreateBuilder(args);
 
@@ -11,7 +12,11 @@ Log.Logger = new LoggerConfiguration()
 builder.Host.UseSerilog();
 
 // Add services to the container.
-builder.Services.AddControllers();
+builder.Services.AddControllers()
+    .AddJsonOptions(options =>
+    {
+        options.JsonSerializerOptions.Converters.Add(new JsonStringEnumConverter());
+    });
 builder.Services.AddEndpointsApiExplorer();
 builder.Services.AddSwaggerGen(options =>
 {

--- a/FreelanceProjectManager/docs/specs/implementation-specs.md
+++ b/FreelanceProjectManager/docs/specs/implementation-specs.md
@@ -192,6 +192,21 @@ Id
 ### 5.5 CORS Configuration
 **REQ-API-006**: The API SHALL have a CORS policy defined. The origins allowed in the CORS policy SHALL be retrieved from configuration and SHALL include the URLs where the frontend(s) are hosted.
 
+### 5.6 JSON Serialization
+**REQ-API-007**: The API project Program.cs SHALL include the following using statement:
+```csharp
+using System.Text.Json.Serialization;
+```
+
+**REQ-API-008**: The API SHALL configure JSON serialization to handle enums as text strings. The `AddControllers()` call SHALL be configured with `JsonStringEnumConverter`:
+```csharp
+builder.Services.AddControllers()
+    .AddJsonOptions(options =>
+    {
+        options.JsonSerializerOptions.Converters.Add(new JsonStringEnumConverter());
+    });
+```
+
 ---
 
 ## 6. Frontend Requirements
@@ -470,6 +485,7 @@ All changes to this specification SHALL be tracked and versioned appropriately.
 | 1.1     | 2025-12-22 | System | Added structured logging requirements (REQ-SYS-013 through REQ-SYS-022) |
 | 1.2     | 2025-12-22 | System | Added code linting and static analysis requirements (REQ-LINT-001 through REQ-LINT-010) |
 | 1.3     | 2025-12-25 | System | Merged reactive data loading pattern requirements from data-loading-specs.md (REQ-FE-027 through REQ-FE-036) |
+| 1.4     | 2025-12-30 | System | Added JSON enum serialization requirements (REQ-API-007 through REQ-API-008) |
 
 ---
 

--- a/FreelanceProjectManager/src/FreelanceProjectManager.Api/Program.cs
+++ b/FreelanceProjectManager/src/FreelanceProjectManager.Api/Program.cs
@@ -2,6 +2,7 @@ using FreelanceProjectManager.Core;
 using FreelanceProjectManager.Infrastructure;
 using Microsoft.EntityFrameworkCore;
 using Serilog;
+using System.Text.Json.Serialization;
 
 var builder = WebApplication.CreateBuilder(args);
 
@@ -13,7 +14,11 @@ Log.Logger = new LoggerConfiguration()
 builder.Host.UseSerilog();
 
 // Add services to the container.
-builder.Services.AddControllers();
+builder.Services.AddControllers()
+    .AddJsonOptions(options =>
+    {
+        options.JsonSerializerOptions.Converters.Add(new JsonStringEnumConverter());
+    });
 builder.Services.AddEndpointsApiExplorer();
 builder.Services.AddSwaggerGen(c =>
 {

--- a/FriendGroupEventCoordinator/docs/specs/implementation-specs.md
+++ b/FriendGroupEventCoordinator/docs/specs/implementation-specs.md
@@ -192,6 +192,21 @@ Id
 ### 5.5 CORS Configuration
 **REQ-API-006**: The API SHALL have a CORS policy defined. The origins allowed in the CORS policy SHALL be retrieved from configuration and SHALL include the URLs where the frontend(s) are hosted.
 
+### 5.6 JSON Serialization
+**REQ-API-007**: The API project Program.cs SHALL include the following using statement:
+```csharp
+using System.Text.Json.Serialization;
+```
+
+**REQ-API-008**: The API SHALL configure JSON serialization to handle enums as text strings. The `AddControllers()` call SHALL be configured with `JsonStringEnumConverter`:
+```csharp
+builder.Services.AddControllers()
+    .AddJsonOptions(options =>
+    {
+        options.JsonSerializerOptions.Converters.Add(new JsonStringEnumConverter());
+    });
+```
+
 ---
 
 ## 6. Frontend Requirements
@@ -470,6 +485,7 @@ All changes to this specification SHALL be tracked and versioned appropriately.
 | 1.1     | 2025-12-22 | System | Added structured logging requirements (REQ-SYS-013 through REQ-SYS-022) |
 | 1.2     | 2025-12-22 | System | Added code linting and static analysis requirements (REQ-LINT-001 through REQ-LINT-010) |
 | 1.3     | 2025-12-25 | System | Merged reactive data loading pattern requirements from data-loading-specs.md (REQ-FE-027 through REQ-FE-036) |
+| 1.4     | 2025-12-30 | System | Added JSON enum serialization requirements (REQ-API-007 through REQ-API-008) |
 
 ---
 

--- a/FriendGroupEventCoordinator/src/FriendGroupEventCoordinator.Api/Program.cs
+++ b/FriendGroupEventCoordinator/src/FriendGroupEventCoordinator.Api/Program.cs
@@ -1,5 +1,6 @@
 using FriendGroupEventCoordinator.Infrastructure;
 using Serilog;
+using System.Text.Json.Serialization;
 
 var builder = WebApplication.CreateBuilder(args);
 
@@ -11,7 +12,11 @@ Log.Logger = new LoggerConfiguration()
 builder.Host.UseSerilog();
 
 // Add services to the container.
-builder.Services.AddControllers();
+builder.Services.AddControllers()
+    .AddJsonOptions(options =>
+    {
+        options.JsonSerializerOptions.Converters.Add(new JsonStringEnumConverter());
+    });
 builder.Services.AddEndpointsApiExplorer();
 builder.Services.AddSwaggerGen(c =>
 {

--- a/FuelEconomyTracker/docs/specs/implementation-specs.md
+++ b/FuelEconomyTracker/docs/specs/implementation-specs.md
@@ -192,6 +192,21 @@ Id
 ### 5.5 CORS Configuration
 **REQ-API-006**: The API SHALL have a CORS policy defined. The origins allowed in the CORS policy SHALL be retrieved from configuration and SHALL include the URLs where the frontend(s) are hosted.
 
+### 5.6 JSON Serialization
+**REQ-API-007**: The API project Program.cs SHALL include the following using statement:
+```csharp
+using System.Text.Json.Serialization;
+```
+
+**REQ-API-008**: The API SHALL configure JSON serialization to handle enums as text strings. The `AddControllers()` call SHALL be configured with `JsonStringEnumConverter`:
+```csharp
+builder.Services.AddControllers()
+    .AddJsonOptions(options =>
+    {
+        options.JsonSerializerOptions.Converters.Add(new JsonStringEnumConverter());
+    });
+```
+
 ---
 
 ## 6. Frontend Requirements
@@ -470,6 +485,7 @@ All changes to this specification SHALL be tracked and versioned appropriately.
 | 1.1     | 2025-12-22 | System | Added structured logging requirements (REQ-SYS-013 through REQ-SYS-022) |
 | 1.2     | 2025-12-22 | System | Added code linting and static analysis requirements (REQ-LINT-001 through REQ-LINT-010) |
 | 1.3     | 2025-12-25 | System | Merged reactive data loading pattern requirements from data-loading-specs.md (REQ-FE-027 through REQ-FE-036) |
+| 1.4     | 2025-12-30 | System | Added JSON enum serialization requirements (REQ-API-007 through REQ-API-008) |
 
 ---
 

--- a/FuelEconomyTracker/src/FuelEconomyTracker.Api/Program.cs
+++ b/FuelEconomyTracker/src/FuelEconomyTracker.Api/Program.cs
@@ -1,5 +1,6 @@
 using FuelEconomyTracker.Infrastructure;
 using Serilog;
+using System.Text.Json.Serialization;
 
 var builder = WebApplication.CreateBuilder(args);
 
@@ -15,7 +16,11 @@ try
     Log.Information("Starting FuelEconomyTracker API");
 
     // Add services to the container.
-    builder.Services.AddControllers();
+    builder.Services.AddControllers()
+        .AddJsonOptions(options =>
+        {
+            options.JsonSerializerOptions.Converters.Add(new JsonStringEnumConverter());
+        });
     builder.Services.AddEndpointsApiExplorer();
     builder.Services.AddSwaggerGen(c =>
     {

--- a/GiftIdeaTracker/docs/specs/implementation-specs.md
+++ b/GiftIdeaTracker/docs/specs/implementation-specs.md
@@ -192,6 +192,21 @@ Id
 ### 5.5 CORS Configuration
 **REQ-API-006**: The API SHALL have a CORS policy defined. The origins allowed in the CORS policy SHALL be retrieved from configuration and SHALL include the URLs where the frontend(s) are hosted.
 
+### 5.6 JSON Serialization
+**REQ-API-007**: The API project Program.cs SHALL include the following using statement:
+```csharp
+using System.Text.Json.Serialization;
+```
+
+**REQ-API-008**: The API SHALL configure JSON serialization to handle enums as text strings. The `AddControllers()` call SHALL be configured with `JsonStringEnumConverter`:
+```csharp
+builder.Services.AddControllers()
+    .AddJsonOptions(options =>
+    {
+        options.JsonSerializerOptions.Converters.Add(new JsonStringEnumConverter());
+    });
+```
+
 ---
 
 ## 6. Frontend Requirements
@@ -470,6 +485,7 @@ All changes to this specification SHALL be tracked and versioned appropriately.
 | 1.1     | 2025-12-22 | System | Added structured logging requirements (REQ-SYS-013 through REQ-SYS-022) |
 | 1.2     | 2025-12-22 | System | Added code linting and static analysis requirements (REQ-LINT-001 through REQ-LINT-010) |
 | 1.3     | 2025-12-25 | System | Merged reactive data loading pattern requirements from data-loading-specs.md (REQ-FE-027 through REQ-FE-036) |
+| 1.4     | 2025-12-30 | System | Added JSON enum serialization requirements (REQ-API-007 through REQ-API-008) |
 
 ---
 

--- a/GiftIdeaTracker/src/GiftIdeaTracker.Api/Program.cs
+++ b/GiftIdeaTracker/src/GiftIdeaTracker.Api/Program.cs
@@ -1,5 +1,6 @@
 using GiftIdeaTracker.Infrastructure;
 using Serilog;
+using System.Text.Json.Serialization;
 
 var builder = WebApplication.CreateBuilder(args);
 
@@ -16,7 +17,11 @@ builder.Host.UseSerilog((context, loggerConfig) =>
 });
 
 // Add services to the container.
-builder.Services.AddControllers();
+builder.Services.AddControllers()
+    .AddJsonOptions(options =>
+    {
+        options.JsonSerializerOptions.Converters.Add(new JsonStringEnumConverter());
+    });
 builder.Services.AddEndpointsApiExplorer();
 builder.Services.AddSwaggerGen(options =>
 {

--- a/GolfScoreTracker/docs/specs/implementation-specs.md
+++ b/GolfScoreTracker/docs/specs/implementation-specs.md
@@ -192,6 +192,21 @@ Id
 ### 5.5 CORS Configuration
 **REQ-API-006**: The API SHALL have a CORS policy defined. The origins allowed in the CORS policy SHALL be retrieved from configuration and SHALL include the URLs where the frontend(s) are hosted.
 
+### 5.6 JSON Serialization
+**REQ-API-007**: The API project Program.cs SHALL include the following using statement:
+```csharp
+using System.Text.Json.Serialization;
+```
+
+**REQ-API-008**: The API SHALL configure JSON serialization to handle enums as text strings. The `AddControllers()` call SHALL be configured with `JsonStringEnumConverter`:
+```csharp
+builder.Services.AddControllers()
+    .AddJsonOptions(options =>
+    {
+        options.JsonSerializerOptions.Converters.Add(new JsonStringEnumConverter());
+    });
+```
+
 ---
 
 ## 6. Frontend Requirements
@@ -470,6 +485,7 @@ All changes to this specification SHALL be tracked and versioned appropriately.
 | 1.1     | 2025-12-22 | System | Added structured logging requirements (REQ-SYS-013 through REQ-SYS-022) |
 | 1.2     | 2025-12-22 | System | Added code linting and static analysis requirements (REQ-LINT-001 through REQ-LINT-010) |
 | 1.3     | 2025-12-25 | System | Merged reactive data loading pattern requirements from data-loading-specs.md (REQ-FE-027 through REQ-FE-036) |
+| 1.4     | 2025-12-30 | System | Added JSON enum serialization requirements (REQ-API-007 through REQ-API-008) |
 
 ---
 

--- a/GolfScoreTracker/src/GolfScoreTracker.Api/Program.cs
+++ b/GolfScoreTracker/src/GolfScoreTracker.Api/Program.cs
@@ -2,6 +2,7 @@ using FluentValidation;
 using GolfScoreTracker.Infrastructure;
 using Serilog;
 using System.Reflection;
+using System.Text.Json.Serialization;
 
 // Configure Serilog
 Log.Logger = new LoggerConfiguration()
@@ -20,7 +21,11 @@ try
     builder.Host.UseSerilog();
 
     // Add services to the container.
-    builder.Services.AddControllers();
+    builder.Services.AddControllers()
+        .AddJsonOptions(options =>
+        {
+            options.JsonSerializerOptions.Converters.Add(new JsonStringEnumConverter());
+        });
     builder.Services.AddEndpointsApiExplorer();
     builder.Services.AddSwaggerGen(c =>
     {

--- a/GroceryShoppingListApp/docs/specs/implementation-specs.md
+++ b/GroceryShoppingListApp/docs/specs/implementation-specs.md
@@ -192,6 +192,21 @@ Id
 ### 5.5 CORS Configuration
 **REQ-API-006**: The API SHALL have a CORS policy defined. The origins allowed in the CORS policy SHALL be retrieved from configuration and SHALL include the URLs where the frontend(s) are hosted.
 
+### 5.6 JSON Serialization
+**REQ-API-007**: The API project Program.cs SHALL include the following using statement:
+```csharp
+using System.Text.Json.Serialization;
+```
+
+**REQ-API-008**: The API SHALL configure JSON serialization to handle enums as text strings. The `AddControllers()` call SHALL be configured with `JsonStringEnumConverter`:
+```csharp
+builder.Services.AddControllers()
+    .AddJsonOptions(options =>
+    {
+        options.JsonSerializerOptions.Converters.Add(new JsonStringEnumConverter());
+    });
+```
+
 ---
 
 ## 6. Frontend Requirements
@@ -470,6 +485,7 @@ All changes to this specification SHALL be tracked and versioned appropriately.
 | 1.1     | 2025-12-22 | System | Added structured logging requirements (REQ-SYS-013 through REQ-SYS-022) |
 | 1.2     | 2025-12-22 | System | Added code linting and static analysis requirements (REQ-LINT-001 through REQ-LINT-010) |
 | 1.3     | 2025-12-25 | System | Merged reactive data loading pattern requirements from data-loading-specs.md (REQ-FE-027 through REQ-FE-036) |
+| 1.4     | 2025-12-30 | System | Added JSON enum serialization requirements (REQ-API-007 through REQ-API-008) |
 
 ---
 

--- a/GroceryShoppingListApp/src/GroceryShoppingListApp.Api/Program.cs
+++ b/GroceryShoppingListApp/src/GroceryShoppingListApp.Api/Program.cs
@@ -1,5 +1,6 @@
 using GroceryShoppingListApp.Infrastructure;
 using Serilog;
+using System.Text.Json.Serialization;
 
 // Configure Serilog
 Log.Logger = new LoggerConfiguration()
@@ -18,7 +19,11 @@ try
     builder.Host.UseSerilog();
 
     // Add services to the container.
-    builder.Services.AddControllers();
+    builder.Services.AddControllers()
+        .AddJsonOptions(options =>
+        {
+            options.JsonSerializerOptions.Converters.Add(new JsonStringEnumConverter());
+        });
     builder.Services.AddEndpointsApiExplorer();
     builder.Services.AddSwaggerGen();
 

--- a/HabitFormationApp/docs/specs/implementation-specs.md
+++ b/HabitFormationApp/docs/specs/implementation-specs.md
@@ -192,6 +192,21 @@ Id
 ### 5.5 CORS Configuration
 **REQ-API-006**: The API SHALL have a CORS policy defined. The origins allowed in the CORS policy SHALL be retrieved from configuration and SHALL include the URLs where the frontend(s) are hosted.
 
+### 5.6 JSON Serialization
+**REQ-API-007**: The API project Program.cs SHALL include the following using statement:
+```csharp
+using System.Text.Json.Serialization;
+```
+
+**REQ-API-008**: The API SHALL configure JSON serialization to handle enums as text strings. The `AddControllers()` call SHALL be configured with `JsonStringEnumConverter`:
+```csharp
+builder.Services.AddControllers()
+    .AddJsonOptions(options =>
+    {
+        options.JsonSerializerOptions.Converters.Add(new JsonStringEnumConverter());
+    });
+```
+
 ---
 
 ## 6. Frontend Requirements
@@ -470,6 +485,7 @@ All changes to this specification SHALL be tracked and versioned appropriately.
 | 1.1     | 2025-12-22 | System | Added structured logging requirements (REQ-SYS-013 through REQ-SYS-022) |
 | 1.2     | 2025-12-22 | System | Added code linting and static analysis requirements (REQ-LINT-001 through REQ-LINT-010) |
 | 1.3     | 2025-12-25 | System | Merged reactive data loading pattern requirements from data-loading-specs.md (REQ-FE-027 through REQ-FE-036) |
+| 1.4     | 2025-12-30 | System | Added JSON enum serialization requirements (REQ-API-007 through REQ-API-008) |
 
 ---
 

--- a/HabitFormationApp/src/HabitFormationApp.Api/Program.cs
+++ b/HabitFormationApp/src/HabitFormationApp.Api/Program.cs
@@ -1,5 +1,6 @@
 using HabitFormationApp.Infrastructure;
 using Serilog;
+using System.Text.Json.Serialization;
 
 var builder = WebApplication.CreateBuilder(args);
 
@@ -16,7 +17,11 @@ builder.Host.UseSerilog((context, loggerConfig) =>
 });
 
 // Add services to the container.
-builder.Services.AddControllers();
+builder.Services.AddControllers()
+    .AddJsonOptions(options =>
+    {
+        options.JsonSerializerOptions.Converters.Add(new JsonStringEnumConverter());
+    });
 builder.Services.AddEndpointsApiExplorer();
 builder.Services.AddSwaggerGen(options =>
 {

--- a/HomeBrewingTracker/docs/specs/implementation-specs.md
+++ b/HomeBrewingTracker/docs/specs/implementation-specs.md
@@ -192,6 +192,21 @@ Id
 ### 5.5 CORS Configuration
 **REQ-API-006**: The API SHALL have a CORS policy defined. The origins allowed in the CORS policy SHALL be retrieved from configuration and SHALL include the URLs where the frontend(s) are hosted.
 
+### 5.6 JSON Serialization
+**REQ-API-007**: The API project Program.cs SHALL include the following using statement:
+```csharp
+using System.Text.Json.Serialization;
+```
+
+**REQ-API-008**: The API SHALL configure JSON serialization to handle enums as text strings. The `AddControllers()` call SHALL be configured with `JsonStringEnumConverter`:
+```csharp
+builder.Services.AddControllers()
+    .AddJsonOptions(options =>
+    {
+        options.JsonSerializerOptions.Converters.Add(new JsonStringEnumConverter());
+    });
+```
+
 ---
 
 ## 6. Frontend Requirements
@@ -470,6 +485,7 @@ All changes to this specification SHALL be tracked and versioned appropriately.
 | 1.1     | 2025-12-22 | System | Added structured logging requirements (REQ-SYS-013 through REQ-SYS-022) |
 | 1.2     | 2025-12-22 | System | Added code linting and static analysis requirements (REQ-LINT-001 through REQ-LINT-010) |
 | 1.3     | 2025-12-25 | System | Merged reactive data loading pattern requirements from data-loading-specs.md (REQ-FE-027 through REQ-FE-036) |
+| 1.4     | 2025-12-30 | System | Added JSON enum serialization requirements (REQ-API-007 through REQ-API-008) |
 
 ---
 

--- a/HomeBrewingTracker/src/HomeBrewingTracker.Api/Program.cs
+++ b/HomeBrewingTracker/src/HomeBrewingTracker.Api/Program.cs
@@ -1,5 +1,6 @@
 using HomeBrewingTracker.Infrastructure;
 using Serilog;
+using System.Text.Json.Serialization;
 
 var builder = WebApplication.CreateBuilder(args);
 
@@ -16,7 +17,11 @@ try
     Log.Information("Starting HomeBrewingTracker API");
 
     // Add services to the container.
-    builder.Services.AddControllers();
+    builder.Services.AddControllers()
+        .AddJsonOptions(options =>
+        {
+            options.JsonSerializerOptions.Converters.Add(new JsonStringEnumConverter());
+        });
     builder.Services.AddEndpointsApiExplorer();
     builder.Services.AddSwaggerGen();
 

--- a/HomeEnergyUsageTracker/docs/specs/implementation-specs.md
+++ b/HomeEnergyUsageTracker/docs/specs/implementation-specs.md
@@ -192,6 +192,21 @@ Id
 ### 5.5 CORS Configuration
 **REQ-API-006**: The API SHALL have a CORS policy defined. The origins allowed in the CORS policy SHALL be retrieved from configuration and SHALL include the URLs where the frontend(s) are hosted.
 
+### 5.6 JSON Serialization
+**REQ-API-007**: The API project Program.cs SHALL include the following using statement:
+```csharp
+using System.Text.Json.Serialization;
+```
+
+**REQ-API-008**: The API SHALL configure JSON serialization to handle enums as text strings. The `AddControllers()` call SHALL be configured with `JsonStringEnumConverter`:
+```csharp
+builder.Services.AddControllers()
+    .AddJsonOptions(options =>
+    {
+        options.JsonSerializerOptions.Converters.Add(new JsonStringEnumConverter());
+    });
+```
+
 ---
 
 ## 6. Frontend Requirements
@@ -470,6 +485,7 @@ All changes to this specification SHALL be tracked and versioned appropriately.
 | 1.1     | 2025-12-22 | System | Added structured logging requirements (REQ-SYS-013 through REQ-SYS-022) |
 | 1.2     | 2025-12-22 | System | Added code linting and static analysis requirements (REQ-LINT-001 through REQ-LINT-010) |
 | 1.3     | 2025-12-25 | System | Merged reactive data loading pattern requirements from data-loading-specs.md (REQ-FE-027 through REQ-FE-036) |
+| 1.4     | 2025-12-30 | System | Added JSON enum serialization requirements (REQ-API-007 through REQ-API-008) |
 
 ---
 

--- a/HomeEnergyUsageTracker/src/HomeEnergyUsageTracker.Api/Program.cs
+++ b/HomeEnergyUsageTracker/src/HomeEnergyUsageTracker.Api/Program.cs
@@ -1,5 +1,6 @@
 using HomeEnergyUsageTracker.Infrastructure;
 using Serilog;
+using System.Text.Json.Serialization;
 
 var builder = WebApplication.CreateBuilder(args);
 
@@ -15,7 +16,11 @@ try
     Log.Information("Starting HomeEnergyUsageTracker API");
 
     // Add services to the container.
-    builder.Services.AddControllers();
+    builder.Services.AddControllers()
+        .AddJsonOptions(options =>
+        {
+            options.JsonSerializerOptions.Converters.Add(new JsonStringEnumConverter());
+        });
     builder.Services.AddEndpointsApiExplorer();
     builder.Services.AddSwaggerGen();
 

--- a/HomeGymEquipmentManager/docs/specs/implementation-specs.md
+++ b/HomeGymEquipmentManager/docs/specs/implementation-specs.md
@@ -192,6 +192,21 @@ Id
 ### 5.5 CORS Configuration
 **REQ-API-006**: The API SHALL have a CORS policy defined. The origins allowed in the CORS policy SHALL be retrieved from configuration and SHALL include the URLs where the frontend(s) are hosted.
 
+### 5.6 JSON Serialization
+**REQ-API-007**: The API project Program.cs SHALL include the following using statement:
+```csharp
+using System.Text.Json.Serialization;
+```
+
+**REQ-API-008**: The API SHALL configure JSON serialization to handle enums as text strings. The `AddControllers()` call SHALL be configured with `JsonStringEnumConverter`:
+```csharp
+builder.Services.AddControllers()
+    .AddJsonOptions(options =>
+    {
+        options.JsonSerializerOptions.Converters.Add(new JsonStringEnumConverter());
+    });
+```
+
 ---
 
 ## 6. Frontend Requirements
@@ -470,6 +485,7 @@ All changes to this specification SHALL be tracked and versioned appropriately.
 | 1.1     | 2025-12-22 | System | Added structured logging requirements (REQ-SYS-013 through REQ-SYS-022) |
 | 1.2     | 2025-12-22 | System | Added code linting and static analysis requirements (REQ-LINT-001 through REQ-LINT-010) |
 | 1.3     | 2025-12-25 | System | Merged reactive data loading pattern requirements from data-loading-specs.md (REQ-FE-027 through REQ-FE-036) |
+| 1.4     | 2025-12-30 | System | Added JSON enum serialization requirements (REQ-API-007 through REQ-API-008) |
 
 ---
 

--- a/HomeGymEquipmentManager/src/HomeGymEquipmentManager.Api/Program.cs
+++ b/HomeGymEquipmentManager/src/HomeGymEquipmentManager.Api/Program.cs
@@ -1,5 +1,6 @@
 using HomeGymEquipmentManager.Infrastructure;
 using Serilog;
+using System.Text.Json.Serialization;
 
 var builder = WebApplication.CreateBuilder(args);
 
@@ -14,7 +15,11 @@ Log.Logger = new LoggerConfiguration()
 builder.Host.UseSerilog();
 
 // Add services to the container.
-builder.Services.AddControllers();
+builder.Services.AddControllers()
+    .AddJsonOptions(options =>
+    {
+        options.JsonSerializerOptions.Converters.Add(new JsonStringEnumConverter());
+    });
 builder.Services.AddEndpointsApiExplorer();
 builder.Services.AddSwaggerGen();
 

--- a/HomeImprovementProjectManager/docs/specs/implementation-specs.md
+++ b/HomeImprovementProjectManager/docs/specs/implementation-specs.md
@@ -192,6 +192,21 @@ Id
 ### 5.5 CORS Configuration
 **REQ-API-006**: The API SHALL have a CORS policy defined. The origins allowed in the CORS policy SHALL be retrieved from configuration and SHALL include the URLs where the frontend(s) are hosted.
 
+### 5.6 JSON Serialization
+**REQ-API-007**: The API project Program.cs SHALL include the following using statement:
+```csharp
+using System.Text.Json.Serialization;
+```
+
+**REQ-API-008**: The API SHALL configure JSON serialization to handle enums as text strings. The `AddControllers()` call SHALL be configured with `JsonStringEnumConverter`:
+```csharp
+builder.Services.AddControllers()
+    .AddJsonOptions(options =>
+    {
+        options.JsonSerializerOptions.Converters.Add(new JsonStringEnumConverter());
+    });
+```
+
 ---
 
 ## 6. Frontend Requirements
@@ -470,6 +485,7 @@ All changes to this specification SHALL be tracked and versioned appropriately.
 | 1.1     | 2025-12-22 | System | Added structured logging requirements (REQ-SYS-013 through REQ-SYS-022) |
 | 1.2     | 2025-12-22 | System | Added code linting and static analysis requirements (REQ-LINT-001 through REQ-LINT-010) |
 | 1.3     | 2025-12-25 | System | Merged reactive data loading pattern requirements from data-loading-specs.md (REQ-FE-027 through REQ-FE-036) |
+| 1.4     | 2025-12-30 | System | Added JSON enum serialization requirements (REQ-API-007 through REQ-API-008) |
 
 ---
 

--- a/HomeImprovementProjectManager/src/HomeImprovementProjectManager.Api/Program.cs
+++ b/HomeImprovementProjectManager/src/HomeImprovementProjectManager.Api/Program.cs
@@ -4,6 +4,7 @@
 using HomeImprovementProjectManager.Api;
 using HomeImprovementProjectManager.Infrastructure;
 using Serilog;
+using System.Text.Json.Serialization;
 
 var builder = WebApplication.CreateBuilder(args);
 
@@ -20,7 +21,11 @@ builder.Host.UseSerilog((context, loggerConfig) =>
 });
 
 // Add services to the container.
-builder.Services.AddControllers();
+builder.Services.AddControllers()
+    .AddJsonOptions(options =>
+    {
+        options.JsonSerializerOptions.Converters.Add(new JsonStringEnumConverter());
+    });
 builder.Services.AddEndpointsApiExplorer();
 builder.Services.AddSwaggerGen(options =>
 {

--- a/HomeInventoryManager/docs/specs/implementation-specs.md
+++ b/HomeInventoryManager/docs/specs/implementation-specs.md
@@ -192,6 +192,21 @@ Id
 ### 5.5 CORS Configuration
 **REQ-API-006**: The API SHALL have a CORS policy defined. The origins allowed in the CORS policy SHALL be retrieved from configuration and SHALL include the URLs where the frontend(s) are hosted.
 
+### 5.6 JSON Serialization
+**REQ-API-007**: The API project Program.cs SHALL include the following using statement:
+```csharp
+using System.Text.Json.Serialization;
+```
+
+**REQ-API-008**: The API SHALL configure JSON serialization to handle enums as text strings. The `AddControllers()` call SHALL be configured with `JsonStringEnumConverter`:
+```csharp
+builder.Services.AddControllers()
+    .AddJsonOptions(options =>
+    {
+        options.JsonSerializerOptions.Converters.Add(new JsonStringEnumConverter());
+    });
+```
+
 ---
 
 ## 6. Frontend Requirements
@@ -470,6 +485,7 @@ All changes to this specification SHALL be tracked and versioned appropriately.
 | 1.1     | 2025-12-22 | System | Added structured logging requirements (REQ-SYS-013 through REQ-SYS-022) |
 | 1.2     | 2025-12-22 | System | Added code linting and static analysis requirements (REQ-LINT-001 through REQ-LINT-010) |
 | 1.3     | 2025-12-25 | System | Merged reactive data loading pattern requirements from data-loading-specs.md (REQ-FE-027 through REQ-FE-036) |
+| 1.4     | 2025-12-30 | System | Added JSON enum serialization requirements (REQ-API-007 through REQ-API-008) |
 
 ---
 

--- a/HomeInventoryManager/src/HomeInventoryManager.Api/Program.cs
+++ b/HomeInventoryManager/src/HomeInventoryManager.Api/Program.cs
@@ -1,5 +1,6 @@
 using HomeInventoryManager.Infrastructure;
 using Serilog;
+using System.Text.Json.Serialization;
 
 var builder = WebApplication.CreateBuilder(args);
 
@@ -16,7 +17,11 @@ builder.Host.UseSerilog((context, loggerConfig) =>
 });
 
 // Add services to the container.
-builder.Services.AddControllers();
+builder.Services.AddControllers()
+    .AddJsonOptions(options =>
+    {
+        options.JsonSerializerOptions.Converters.Add(new JsonStringEnumConverter());
+    });
 builder.Services.AddEndpointsApiExplorer();
 builder.Services.AddSwaggerGen(options =>
 {

--- a/HomeMaintenanceSchedule/docs/specs/implementation-specs.md
+++ b/HomeMaintenanceSchedule/docs/specs/implementation-specs.md
@@ -192,6 +192,21 @@ Id
 ### 5.5 CORS Configuration
 **REQ-API-006**: The API SHALL have a CORS policy defined. The origins allowed in the CORS policy SHALL be retrieved from configuration and SHALL include the URLs where the frontend(s) are hosted.
 
+### 5.6 JSON Serialization
+**REQ-API-007**: The API project Program.cs SHALL include the following using statement:
+```csharp
+using System.Text.Json.Serialization;
+```
+
+**REQ-API-008**: The API SHALL configure JSON serialization to handle enums as text strings. The `AddControllers()` call SHALL be configured with `JsonStringEnumConverter`:
+```csharp
+builder.Services.AddControllers()
+    .AddJsonOptions(options =>
+    {
+        options.JsonSerializerOptions.Converters.Add(new JsonStringEnumConverter());
+    });
+```
+
 ---
 
 ## 6. Frontend Requirements
@@ -470,6 +485,7 @@ All changes to this specification SHALL be tracked and versioned appropriately.
 | 1.1     | 2025-12-22 | System | Added structured logging requirements (REQ-SYS-013 through REQ-SYS-022) |
 | 1.2     | 2025-12-22 | System | Added code linting and static analysis requirements (REQ-LINT-001 through REQ-LINT-010) |
 | 1.3     | 2025-12-25 | System | Merged reactive data loading pattern requirements from data-loading-specs.md (REQ-FE-027 through REQ-FE-036) |
+| 1.4     | 2025-12-30 | System | Added JSON enum serialization requirements (REQ-API-007 through REQ-API-008) |
 
 ---
 

--- a/HomeMaintenanceSchedule/src/HomeMaintenanceSchedule.Api/Program.cs
+++ b/HomeMaintenanceSchedule/src/HomeMaintenanceSchedule.Api/Program.cs
@@ -1,5 +1,6 @@
 using HomeMaintenanceSchedule.Infrastructure;
 using Serilog;
+using System.Text.Json.Serialization;
 
 var builder = WebApplication.CreateBuilder(args);
 
@@ -16,7 +17,11 @@ builder.Host.UseSerilog((context, loggerConfig) =>
 });
 
 // Add services to the container.
-builder.Services.AddControllers();
+builder.Services.AddControllers()
+    .AddJsonOptions(options =>
+    {
+        options.JsonSerializerOptions.Converters.Add(new JsonStringEnumConverter());
+    });
 builder.Services.AddEndpointsApiExplorer();
 builder.Services.AddSwaggerGen(options =>
 {

--- a/HouseholdBudgetManager/docs/specs/implementation-specs.md
+++ b/HouseholdBudgetManager/docs/specs/implementation-specs.md
@@ -192,6 +192,21 @@ Id
 ### 5.5 CORS Configuration
 **REQ-API-006**: The API SHALL have a CORS policy defined. The origins allowed in the CORS policy SHALL be retrieved from configuration and SHALL include the URLs where the frontend(s) are hosted.
 
+### 5.6 JSON Serialization
+**REQ-API-007**: The API project Program.cs SHALL include the following using statement:
+```csharp
+using System.Text.Json.Serialization;
+```
+
+**REQ-API-008**: The API SHALL configure JSON serialization to handle enums as text strings. The `AddControllers()` call SHALL be configured with `JsonStringEnumConverter`:
+```csharp
+builder.Services.AddControllers()
+    .AddJsonOptions(options =>
+    {
+        options.JsonSerializerOptions.Converters.Add(new JsonStringEnumConverter());
+    });
+```
+
 ---
 
 ## 6. Frontend Requirements
@@ -470,6 +485,7 @@ All changes to this specification SHALL be tracked and versioned appropriately.
 | 1.1     | 2025-12-22 | System | Added structured logging requirements (REQ-SYS-013 through REQ-SYS-022) |
 | 1.2     | 2025-12-22 | System | Added code linting and static analysis requirements (REQ-LINT-001 through REQ-LINT-010) |
 | 1.3     | 2025-12-25 | System | Merged reactive data loading pattern requirements from data-loading-specs.md (REQ-FE-027 through REQ-FE-036) |
+| 1.4     | 2025-12-30 | System | Added JSON enum serialization requirements (REQ-API-007 through REQ-API-008) |
 
 ---
 

--- a/HouseholdBudgetManager/src/HouseholdBudgetManager.Api/Program.cs
+++ b/HouseholdBudgetManager/src/HouseholdBudgetManager.Api/Program.cs
@@ -4,6 +4,7 @@
 using HouseholdBudgetManager.Api;
 using HouseholdBudgetManager.Infrastructure;
 using Serilog;
+using System.Text.Json.Serialization;
 
 var builder = WebApplication.CreateBuilder(args);
 
@@ -20,7 +21,11 @@ builder.Host.UseSerilog((context, loggerConfig) =>
 });
 
 // Add services to the container.
-builder.Services.AddControllers();
+builder.Services.AddControllers()
+    .AddJsonOptions(options =>
+    {
+        options.JsonSerializerOptions.Converters.Add(new JsonStringEnumConverter());
+    });
 builder.Services.AddEndpointsApiExplorer();
 builder.Services.AddSwaggerGen(options =>
 {

--- a/HydrationTracker/docs/specs/implementation-specs.md
+++ b/HydrationTracker/docs/specs/implementation-specs.md
@@ -192,6 +192,21 @@ Id
 ### 5.5 CORS Configuration
 **REQ-API-006**: The API SHALL have a CORS policy defined. The origins allowed in the CORS policy SHALL be retrieved from configuration and SHALL include the URLs where the frontend(s) are hosted.
 
+### 5.6 JSON Serialization
+**REQ-API-007**: The API project Program.cs SHALL include the following using statement:
+```csharp
+using System.Text.Json.Serialization;
+```
+
+**REQ-API-008**: The API SHALL configure JSON serialization to handle enums as text strings. The `AddControllers()` call SHALL be configured with `JsonStringEnumConverter`:
+```csharp
+builder.Services.AddControllers()
+    .AddJsonOptions(options =>
+    {
+        options.JsonSerializerOptions.Converters.Add(new JsonStringEnumConverter());
+    });
+```
+
 ---
 
 ## 6. Frontend Requirements
@@ -470,6 +485,7 @@ All changes to this specification SHALL be tracked and versioned appropriately.
 | 1.1     | 2025-12-22 | System | Added structured logging requirements (REQ-SYS-013 through REQ-SYS-022) |
 | 1.2     | 2025-12-22 | System | Added code linting and static analysis requirements (REQ-LINT-001 through REQ-LINT-010) |
 | 1.3     | 2025-12-25 | System | Merged reactive data loading pattern requirements from data-loading-specs.md (REQ-FE-027 through REQ-FE-036) |
+| 1.4     | 2025-12-30 | System | Added JSON enum serialization requirements (REQ-API-007 through REQ-API-008) |
 
 ---
 

--- a/HydrationTracker/src/HydrationTracker.Api/Program.cs
+++ b/HydrationTracker/src/HydrationTracker.Api/Program.cs
@@ -3,6 +3,7 @@ using HydrationTracker.Infrastructure;
 using Microsoft.EntityFrameworkCore;
 using Serilog;
 using Serilog.Events;
+using System.Text.Json.Serialization;
 
 // Configure Serilog
 Log.Logger = new LoggerConfiguration()
@@ -25,7 +26,11 @@ try
     builder.Host.UseSerilog();
 
     // Add services to the container
-    builder.Services.AddControllers();
+    builder.Services.AddControllers()
+        .AddJsonOptions(options =>
+        {
+            options.JsonSerializerOptions.Converters.Add(new JsonStringEnumConverter());
+        });
     builder.Services.AddEndpointsApiExplorer();
     builder.Services.AddSwaggerGen();
 

--- a/InjuryPreventionRecoveryTracker/docs/specs/implementation-specs.md
+++ b/InjuryPreventionRecoveryTracker/docs/specs/implementation-specs.md
@@ -192,6 +192,21 @@ Id
 ### 5.5 CORS Configuration
 **REQ-API-006**: The API SHALL have a CORS policy defined. The origins allowed in the CORS policy SHALL be retrieved from configuration and SHALL include the URLs where the frontend(s) are hosted.
 
+### 5.6 JSON Serialization
+**REQ-API-007**: The API project Program.cs SHALL include the following using statement:
+```csharp
+using System.Text.Json.Serialization;
+```
+
+**REQ-API-008**: The API SHALL configure JSON serialization to handle enums as text strings. The `AddControllers()` call SHALL be configured with `JsonStringEnumConverter`:
+```csharp
+builder.Services.AddControllers()
+    .AddJsonOptions(options =>
+    {
+        options.JsonSerializerOptions.Converters.Add(new JsonStringEnumConverter());
+    });
+```
+
 ---
 
 ## 6. Frontend Requirements
@@ -470,6 +485,7 @@ All changes to this specification SHALL be tracked and versioned appropriately.
 | 1.1     | 2025-12-22 | System | Added structured logging requirements (REQ-SYS-013 through REQ-SYS-022) |
 | 1.2     | 2025-12-22 | System | Added code linting and static analysis requirements (REQ-LINT-001 through REQ-LINT-010) |
 | 1.3     | 2025-12-25 | System | Merged reactive data loading pattern requirements from data-loading-specs.md (REQ-FE-027 through REQ-FE-036) |
+| 1.4     | 2025-12-30 | System | Added JSON enum serialization requirements (REQ-API-007 through REQ-API-008) |
 
 ---
 

--- a/InjuryPreventionRecoveryTracker/src/InjuryPreventionRecoveryTracker.Api/Program.cs
+++ b/InjuryPreventionRecoveryTracker/src/InjuryPreventionRecoveryTracker.Api/Program.cs
@@ -4,6 +4,7 @@
 using InjuryPreventionRecoveryTracker.Api;
 using InjuryPreventionRecoveryTracker.Infrastructure;
 using Serilog;
+using System.Text.Json.Serialization;
 
 var builder = WebApplication.CreateBuilder(args);
 
@@ -20,7 +21,11 @@ builder.Host.UseSerilog((context, loggerConfig) =>
 });
 
 // Add services to the container.
-builder.Services.AddControllers();
+builder.Services.AddControllers()
+    .AddJsonOptions(options =>
+    {
+        options.JsonSerializerOptions.Converters.Add(new JsonStringEnumConverter());
+    });
 builder.Services.AddEndpointsApiExplorer();
 builder.Services.AddSwaggerGen(options =>
 {

--- a/InvestmentPortfolioTracker/docs/specs/implementation-specs.md
+++ b/InvestmentPortfolioTracker/docs/specs/implementation-specs.md
@@ -192,6 +192,21 @@ Id
 ### 5.5 CORS Configuration
 **REQ-API-006**: The API SHALL have a CORS policy defined. The origins allowed in the CORS policy SHALL be retrieved from configuration and SHALL include the URLs where the frontend(s) are hosted.
 
+### 5.6 JSON Serialization
+**REQ-API-007**: The API project Program.cs SHALL include the following using statement:
+```csharp
+using System.Text.Json.Serialization;
+```
+
+**REQ-API-008**: The API SHALL configure JSON serialization to handle enums as text strings. The `AddControllers()` call SHALL be configured with `JsonStringEnumConverter`:
+```csharp
+builder.Services.AddControllers()
+    .AddJsonOptions(options =>
+    {
+        options.JsonSerializerOptions.Converters.Add(new JsonStringEnumConverter());
+    });
+```
+
 ---
 
 ## 6. Frontend Requirements
@@ -470,6 +485,7 @@ All changes to this specification SHALL be tracked and versioned appropriately.
 | 1.1     | 2025-12-22 | System | Added structured logging requirements (REQ-SYS-013 through REQ-SYS-022) |
 | 1.2     | 2025-12-22 | System | Added code linting and static analysis requirements (REQ-LINT-001 through REQ-LINT-010) |
 | 1.3     | 2025-12-25 | System | Merged reactive data loading pattern requirements from data-loading-specs.md (REQ-FE-027 through REQ-FE-036) |
+| 1.4     | 2025-12-30 | System | Added JSON enum serialization requirements (REQ-API-007 through REQ-API-008) |
 
 ---
 

--- a/InvestmentPortfolioTracker/src/InvestmentPortfolioTracker.Api/Program.cs
+++ b/InvestmentPortfolioTracker/src/InvestmentPortfolioTracker.Api/Program.cs
@@ -3,6 +3,7 @@ using InvestmentPortfolioTracker.Infrastructure;
 using Microsoft.EntityFrameworkCore;
 using Serilog;
 using Serilog.Events;
+using System.Text.Json.Serialization;
 
 // Configure Serilog
 Log.Logger = new LoggerConfiguration()
@@ -26,7 +27,11 @@ try
     builder.Host.UseSerilog();
 
     // Add services to the container
-    builder.Services.AddControllers();
+    builder.Services.AddControllers()
+        .AddJsonOptions(options =>
+        {
+            options.JsonSerializerOptions.Converters.Add(new JsonStringEnumConverter());
+        });
     builder.Services.AddEndpointsApiExplorer();
     builder.Services.AddSwaggerGen(c =>
     {

--- a/JobSearchOrganizer/docs/specs/implementation-specs.md
+++ b/JobSearchOrganizer/docs/specs/implementation-specs.md
@@ -192,6 +192,21 @@ Id
 ### 5.5 CORS Configuration
 **REQ-API-006**: The API SHALL have a CORS policy defined. The origins allowed in the CORS policy SHALL be retrieved from configuration and SHALL include the URLs where the frontend(s) are hosted.
 
+### 5.6 JSON Serialization
+**REQ-API-007**: The API project Program.cs SHALL include the following using statement:
+```csharp
+using System.Text.Json.Serialization;
+```
+
+**REQ-API-008**: The API SHALL configure JSON serialization to handle enums as text strings. The `AddControllers()` call SHALL be configured with `JsonStringEnumConverter`:
+```csharp
+builder.Services.AddControllers()
+    .AddJsonOptions(options =>
+    {
+        options.JsonSerializerOptions.Converters.Add(new JsonStringEnumConverter());
+    });
+```
+
 ---
 
 ## 6. Frontend Requirements
@@ -470,6 +485,7 @@ All changes to this specification SHALL be tracked and versioned appropriately.
 | 1.1     | 2025-12-22 | System | Added structured logging requirements (REQ-SYS-013 through REQ-SYS-022) |
 | 1.2     | 2025-12-22 | System | Added code linting and static analysis requirements (REQ-LINT-001 through REQ-LINT-010) |
 | 1.3     | 2025-12-25 | System | Merged reactive data loading pattern requirements from data-loading-specs.md (REQ-FE-027 through REQ-FE-036) |
+| 1.4     | 2025-12-30 | System | Added JSON enum serialization requirements (REQ-API-007 through REQ-API-008) |
 
 ---
 

--- a/JobSearchOrganizer/src/JobSearchOrganizer.Api/Program.cs
+++ b/JobSearchOrganizer/src/JobSearchOrganizer.Api/Program.cs
@@ -1,5 +1,6 @@
 using JobSearchOrganizer.Infrastructure;
 using Serilog;
+using System.Text.Json.Serialization;
 
 var builder = WebApplication.CreateBuilder(args);
 
@@ -16,7 +17,11 @@ builder.Host.UseSerilog((context, loggerConfig) =>
 });
 
 // Add services to the container.
-builder.Services.AddControllers();
+builder.Services.AddControllers()
+    .AddJsonOptions(options =>
+    {
+        options.JsonSerializerOptions.Converters.Add(new JsonStringEnumConverter());
+    });
 builder.Services.AddEndpointsApiExplorer();
 builder.Services.AddSwaggerGen(options =>
 {

--- a/KidsActivitySportsTracker/docs/specs/implementation-specs.md
+++ b/KidsActivitySportsTracker/docs/specs/implementation-specs.md
@@ -192,6 +192,21 @@ Id
 ### 5.5 CORS Configuration
 **REQ-API-006**: The API SHALL have a CORS policy defined. The origins allowed in the CORS policy SHALL be retrieved from configuration and SHALL include the URLs where the frontend(s) are hosted.
 
+### 5.6 JSON Serialization
+**REQ-API-007**: The API project Program.cs SHALL include the following using statement:
+```csharp
+using System.Text.Json.Serialization;
+```
+
+**REQ-API-008**: The API SHALL configure JSON serialization to handle enums as text strings. The `AddControllers()` call SHALL be configured with `JsonStringEnumConverter`:
+```csharp
+builder.Services.AddControllers()
+    .AddJsonOptions(options =>
+    {
+        options.JsonSerializerOptions.Converters.Add(new JsonStringEnumConverter());
+    });
+```
+
 ---
 
 ## 6. Frontend Requirements
@@ -470,6 +485,7 @@ All changes to this specification SHALL be tracked and versioned appropriately.
 | 1.1     | 2025-12-22 | System | Added structured logging requirements (REQ-SYS-013 through REQ-SYS-022) |
 | 1.2     | 2025-12-22 | System | Added code linting and static analysis requirements (REQ-LINT-001 through REQ-LINT-010) |
 | 1.3     | 2025-12-25 | System | Merged reactive data loading pattern requirements from data-loading-specs.md (REQ-FE-027 through REQ-FE-036) |
+| 1.4     | 2025-12-30 | System | Added JSON enum serialization requirements (REQ-API-007 through REQ-API-008) |
 
 ---
 

--- a/KidsActivitySportsTracker/src/KidsActivitySportsTracker.Api/Program.cs
+++ b/KidsActivitySportsTracker/src/KidsActivitySportsTracker.Api/Program.cs
@@ -1,6 +1,7 @@
 using KidsActivitySportsTracker.Infrastructure;
 using Serilog;
 using Serilog.Events;
+using System.Text.Json.Serialization;
 
 // Configure Serilog
 Log.Logger = new LoggerConfiguration()
@@ -24,7 +25,11 @@ try
     builder.Host.UseSerilog();
 
     // Add services to the container.
-    builder.Services.AddControllers();
+    builder.Services.AddControllers()
+        .AddJsonOptions(options =>
+        {
+            options.JsonSerializerOptions.Converters.Add(new JsonStringEnumConverter());
+        });
     builder.Services.AddEndpointsApiExplorer();
     builder.Services.AddSwaggerGen(c =>
     {

--- a/KnowledgeBaseSecondBrain/docs/specs/implementation-specs.md
+++ b/KnowledgeBaseSecondBrain/docs/specs/implementation-specs.md
@@ -192,6 +192,21 @@ Id
 ### 5.5 CORS Configuration
 **REQ-API-006**: The API SHALL have a CORS policy defined. The origins allowed in the CORS policy SHALL be retrieved from configuration and SHALL include the URLs where the frontend(s) are hosted.
 
+### 5.6 JSON Serialization
+**REQ-API-007**: The API project Program.cs SHALL include the following using statement:
+```csharp
+using System.Text.Json.Serialization;
+```
+
+**REQ-API-008**: The API SHALL configure JSON serialization to handle enums as text strings. The `AddControllers()` call SHALL be configured with `JsonStringEnumConverter`:
+```csharp
+builder.Services.AddControllers()
+    .AddJsonOptions(options =>
+    {
+        options.JsonSerializerOptions.Converters.Add(new JsonStringEnumConverter());
+    });
+```
+
 ---
 
 ## 6. Frontend Requirements
@@ -470,6 +485,7 @@ All changes to this specification SHALL be tracked and versioned appropriately.
 | 1.1     | 2025-12-22 | System | Added structured logging requirements (REQ-SYS-013 through REQ-SYS-022) |
 | 1.2     | 2025-12-22 | System | Added code linting and static analysis requirements (REQ-LINT-001 through REQ-LINT-010) |
 | 1.3     | 2025-12-25 | System | Merged reactive data loading pattern requirements from data-loading-specs.md (REQ-FE-027 through REQ-FE-036) |
+| 1.4     | 2025-12-30 | System | Added JSON enum serialization requirements (REQ-API-007 through REQ-API-008) |
 
 ---
 

--- a/KnowledgeBaseSecondBrain/src/KnowledgeBaseSecondBrain.Api/Program.cs
+++ b/KnowledgeBaseSecondBrain/src/KnowledgeBaseSecondBrain.Api/Program.cs
@@ -1,5 +1,6 @@
 using KnowledgeBaseSecondBrain.Infrastructure;
 using Serilog;
+using System.Text.Json.Serialization;
 
 var builder = WebApplication.CreateBuilder(args);
 
@@ -16,7 +17,11 @@ builder.Host.UseSerilog((context, loggerConfig) =>
 });
 
 // Add services to the container.
-builder.Services.AddControllers();
+builder.Services.AddControllers()
+    .AddJsonOptions(options =>
+    {
+        options.JsonSerializerOptions.Converters.Add(new JsonStringEnumConverter());
+    });
 builder.Services.AddEndpointsApiExplorer();
 builder.Services.AddSwaggerGen(options =>
 {

--- a/LetterToFutureSelf/docs/specs/implementation-specs.md
+++ b/LetterToFutureSelf/docs/specs/implementation-specs.md
@@ -192,6 +192,21 @@ Id
 ### 5.5 CORS Configuration
 **REQ-API-006**: The API SHALL have a CORS policy defined. The origins allowed in the CORS policy SHALL be retrieved from configuration and SHALL include the URLs where the frontend(s) are hosted.
 
+### 5.6 JSON Serialization
+**REQ-API-007**: The API project Program.cs SHALL include the following using statement:
+```csharp
+using System.Text.Json.Serialization;
+```
+
+**REQ-API-008**: The API SHALL configure JSON serialization to handle enums as text strings. The `AddControllers()` call SHALL be configured with `JsonStringEnumConverter`:
+```csharp
+builder.Services.AddControllers()
+    .AddJsonOptions(options =>
+    {
+        options.JsonSerializerOptions.Converters.Add(new JsonStringEnumConverter());
+    });
+```
+
 ---
 
 ## 6. Frontend Requirements
@@ -470,6 +485,7 @@ All changes to this specification SHALL be tracked and versioned appropriately.
 | 1.1     | 2025-12-22 | System | Added structured logging requirements (REQ-SYS-013 through REQ-SYS-022) |
 | 1.2     | 2025-12-22 | System | Added code linting and static analysis requirements (REQ-LINT-001 through REQ-LINT-010) |
 | 1.3     | 2025-12-25 | System | Merged reactive data loading pattern requirements from data-loading-specs.md (REQ-FE-027 through REQ-FE-036) |
+| 1.4     | 2025-12-30 | System | Added JSON enum serialization requirements (REQ-API-007 through REQ-API-008) |
 
 ---
 

--- a/LetterToFutureSelf/src/LetterToFutureSelf.Api/Program.cs
+++ b/LetterToFutureSelf/src/LetterToFutureSelf.Api/Program.cs
@@ -4,6 +4,7 @@
 using LetterToFutureSelf.Api;
 using LetterToFutureSelf.Infrastructure;
 using Serilog;
+using System.Text.Json.Serialization;
 
 var builder = WebApplication.CreateBuilder(args);
 
@@ -20,7 +21,11 @@ builder.Host.UseSerilog((context, loggerConfig) =>
 });
 
 // Add services to the container.
-builder.Services.AddControllers();
+builder.Services.AddControllers()
+    .AddJsonOptions(options =>
+    {
+        options.JsonSerializerOptions.Converters.Add(new JsonStringEnumConverter());
+    });
 builder.Services.AddEndpointsApiExplorer();
 builder.Services.AddSwaggerGen(options =>
 {

--- a/LifeAdminDashboard/docs/specs/implementation-specs.md
+++ b/LifeAdminDashboard/docs/specs/implementation-specs.md
@@ -192,6 +192,21 @@ Id
 ### 5.5 CORS Configuration
 **REQ-API-006**: The API SHALL have a CORS policy defined. The origins allowed in the CORS policy SHALL be retrieved from configuration and SHALL include the URLs where the frontend(s) are hosted.
 
+### 5.6 JSON Serialization
+**REQ-API-007**: The API project Program.cs SHALL include the following using statement:
+```csharp
+using System.Text.Json.Serialization;
+```
+
+**REQ-API-008**: The API SHALL configure JSON serialization to handle enums as text strings. The `AddControllers()` call SHALL be configured with `JsonStringEnumConverter`:
+```csharp
+builder.Services.AddControllers()
+    .AddJsonOptions(options =>
+    {
+        options.JsonSerializerOptions.Converters.Add(new JsonStringEnumConverter());
+    });
+```
+
 ---
 
 ## 6. Frontend Requirements
@@ -470,6 +485,7 @@ All changes to this specification SHALL be tracked and versioned appropriately.
 | 1.1     | 2025-12-22 | System | Added structured logging requirements (REQ-SYS-013 through REQ-SYS-022) |
 | 1.2     | 2025-12-22 | System | Added code linting and static analysis requirements (REQ-LINT-001 through REQ-LINT-010) |
 | 1.3     | 2025-12-25 | System | Merged reactive data loading pattern requirements from data-loading-specs.md (REQ-FE-027 through REQ-FE-036) |
+| 1.4     | 2025-12-30 | System | Added JSON enum serialization requirements (REQ-API-007 through REQ-API-008) |
 
 ---
 

--- a/LifeAdminDashboard/src/LifeAdminDashboard.Api/Program.cs
+++ b/LifeAdminDashboard/src/LifeAdminDashboard.Api/Program.cs
@@ -1,5 +1,6 @@
 using LifeAdminDashboard.Infrastructure;
 using Serilog;
+using System.Text.Json.Serialization;
 
 var builder = WebApplication.CreateBuilder(args);
 
@@ -16,7 +17,11 @@ builder.Host.UseSerilog((context, loggerConfig) =>
 });
 
 // Add services to the container.
-builder.Services.AddControllers();
+builder.Services.AddControllers()
+    .AddJsonOptions(options =>
+    {
+        options.JsonSerializerOptions.Converters.Add(new JsonStringEnumConverter());
+    });
 builder.Services.AddEndpointsApiExplorer();
 builder.Services.AddSwaggerGen(options =>
 {

--- a/MarriageEnrichmentJournal/docs/specs/implementation-specs.md
+++ b/MarriageEnrichmentJournal/docs/specs/implementation-specs.md
@@ -192,6 +192,21 @@ Id
 ### 5.5 CORS Configuration
 **REQ-API-006**: The API SHALL have a CORS policy defined. The origins allowed in the CORS policy SHALL be retrieved from configuration and SHALL include the URLs where the frontend(s) are hosted.
 
+### 5.6 JSON Serialization
+**REQ-API-007**: The API project Program.cs SHALL include the following using statement:
+```csharp
+using System.Text.Json.Serialization;
+```
+
+**REQ-API-008**: The API SHALL configure JSON serialization to handle enums as text strings. The `AddControllers()` call SHALL be configured with `JsonStringEnumConverter`:
+```csharp
+builder.Services.AddControllers()
+    .AddJsonOptions(options =>
+    {
+        options.JsonSerializerOptions.Converters.Add(new JsonStringEnumConverter());
+    });
+```
+
 ---
 
 ## 6. Frontend Requirements
@@ -470,6 +485,7 @@ All changes to this specification SHALL be tracked and versioned appropriately.
 | 1.1     | 2025-12-22 | System | Added structured logging requirements (REQ-SYS-013 through REQ-SYS-022) |
 | 1.2     | 2025-12-22 | System | Added code linting and static analysis requirements (REQ-LINT-001 through REQ-LINT-010) |
 | 1.3     | 2025-12-25 | System | Merged reactive data loading pattern requirements from data-loading-specs.md (REQ-FE-027 through REQ-FE-036) |
+| 1.4     | 2025-12-30 | System | Added JSON enum serialization requirements (REQ-API-007 through REQ-API-008) |
 
 ---
 

--- a/MarriageEnrichmentJournal/src/MarriageEnrichmentJournal.Api/Program.cs
+++ b/MarriageEnrichmentJournal/src/MarriageEnrichmentJournal.Api/Program.cs
@@ -1,5 +1,6 @@
 using MarriageEnrichmentJournal.Infrastructure;
 using Serilog;
+using System.Text.Json.Serialization;
 
 var builder = WebApplication.CreateBuilder(args);
 
@@ -16,7 +17,11 @@ builder.Host.UseSerilog((context, loggerConfig) =>
 });
 
 // Add services to the container.
-builder.Services.AddControllers();
+builder.Services.AddControllers()
+    .AddJsonOptions(options =>
+    {
+        options.JsonSerializerOptions.Converters.Add(new JsonStringEnumConverter());
+    });
 builder.Services.AddEndpointsApiExplorer();
 builder.Services.AddSwaggerGen(options =>
 {

--- a/MealPrepPlanner/docs/specs/implementation-specs.md
+++ b/MealPrepPlanner/docs/specs/implementation-specs.md
@@ -192,6 +192,21 @@ Id
 ### 5.5 CORS Configuration
 **REQ-API-006**: The API SHALL have a CORS policy defined. The origins allowed in the CORS policy SHALL be retrieved from configuration and SHALL include the URLs where the frontend(s) are hosted.
 
+### 5.6 JSON Serialization
+**REQ-API-007**: The API project Program.cs SHALL include the following using statement:
+```csharp
+using System.Text.Json.Serialization;
+```
+
+**REQ-API-008**: The API SHALL configure JSON serialization to handle enums as text strings. The `AddControllers()` call SHALL be configured with `JsonStringEnumConverter`:
+```csharp
+builder.Services.AddControllers()
+    .AddJsonOptions(options =>
+    {
+        options.JsonSerializerOptions.Converters.Add(new JsonStringEnumConverter());
+    });
+```
+
 ---
 
 ## 6. Frontend Requirements
@@ -470,6 +485,7 @@ All changes to this specification SHALL be tracked and versioned appropriately.
 | 1.1     | 2025-12-22 | System | Added structured logging requirements (REQ-SYS-013 through REQ-SYS-022) |
 | 1.2     | 2025-12-22 | System | Added code linting and static analysis requirements (REQ-LINT-001 through REQ-LINT-010) |
 | 1.3     | 2025-12-25 | System | Merged reactive data loading pattern requirements from data-loading-specs.md (REQ-FE-027 through REQ-FE-036) |
+| 1.4     | 2025-12-30 | System | Added JSON enum serialization requirements (REQ-API-007 through REQ-API-008) |
 
 ---
 

--- a/MealPrepPlanner/src/MealPrepPlanner.Api/Program.cs
+++ b/MealPrepPlanner/src/MealPrepPlanner.Api/Program.cs
@@ -1,5 +1,6 @@
 using MealPrepPlanner.Infrastructure;
 using Serilog;
+using System.Text.Json.Serialization;
 
 var builder = WebApplication.CreateBuilder(args);
 
@@ -16,7 +17,11 @@ builder.Host.UseSerilog((context, loggerConfig) =>
 });
 
 // Add services to the container.
-builder.Services.AddControllers();
+builder.Services.AddControllers()
+    .AddJsonOptions(options =>
+    {
+        options.JsonSerializerOptions.Converters.Add(new JsonStringEnumConverter());
+    });
 builder.Services.AddEndpointsApiExplorer();
 builder.Services.AddSwaggerGen(options =>
 {

--- a/MedicationReminderSystem/docs/specs/implementation-specs.md
+++ b/MedicationReminderSystem/docs/specs/implementation-specs.md
@@ -192,6 +192,21 @@ Id
 ### 5.5 CORS Configuration
 **REQ-API-006**: The API SHALL have a CORS policy defined. The origins allowed in the CORS policy SHALL be retrieved from configuration and SHALL include the URLs where the frontend(s) are hosted.
 
+### 5.6 JSON Serialization
+**REQ-API-007**: The API project Program.cs SHALL include the following using statement:
+```csharp
+using System.Text.Json.Serialization;
+```
+
+**REQ-API-008**: The API SHALL configure JSON serialization to handle enums as text strings. The `AddControllers()` call SHALL be configured with `JsonStringEnumConverter`:
+```csharp
+builder.Services.AddControllers()
+    .AddJsonOptions(options =>
+    {
+        options.JsonSerializerOptions.Converters.Add(new JsonStringEnumConverter());
+    });
+```
+
 ---
 
 ## 6. Frontend Requirements
@@ -470,6 +485,7 @@ All changes to this specification SHALL be tracked and versioned appropriately.
 | 1.1     | 2025-12-22 | System | Added structured logging requirements (REQ-SYS-013 through REQ-SYS-022) |
 | 1.2     | 2025-12-22 | System | Added code linting and static analysis requirements (REQ-LINT-001 through REQ-LINT-010) |
 | 1.3     | 2025-12-25 | System | Merged reactive data loading pattern requirements from data-loading-specs.md (REQ-FE-027 through REQ-FE-036) |
+| 1.4     | 2025-12-30 | System | Added JSON enum serialization requirements (REQ-API-007 through REQ-API-008) |
 
 ---
 

--- a/MedicationReminderSystem/src/MedicationReminderSystem.Api/Program.cs
+++ b/MedicationReminderSystem/src/MedicationReminderSystem.Api/Program.cs
@@ -1,6 +1,7 @@
 using MedicationReminderSystem.Infrastructure;
 using Serilog;
 using Serilog.Events;
+using System.Text.Json.Serialization;
 
 // Configure Serilog
 Log.Logger = new LoggerConfiguration()
@@ -27,7 +28,11 @@ try
         .WriteTo.Console());
 
     // Add services to the container.
-    builder.Services.AddControllers();
+    builder.Services.AddControllers()
+        .AddJsonOptions(options =>
+        {
+            options.JsonSerializerOptions.Converters.Add(new JsonStringEnumConverter());
+        });
     builder.Services.AddEndpointsApiExplorer();
     builder.Services.AddSwaggerGen();
 

--- a/MeetingNotesActionItemTracker/docs/specs/implementation-specs.md
+++ b/MeetingNotesActionItemTracker/docs/specs/implementation-specs.md
@@ -192,6 +192,21 @@ Id
 ### 5.5 CORS Configuration
 **REQ-API-006**: The API SHALL have a CORS policy defined. The origins allowed in the CORS policy SHALL be retrieved from configuration and SHALL include the URLs where the frontend(s) are hosted.
 
+### 5.6 JSON Serialization
+**REQ-API-007**: The API project Program.cs SHALL include the following using statement:
+```csharp
+using System.Text.Json.Serialization;
+```
+
+**REQ-API-008**: The API SHALL configure JSON serialization to handle enums as text strings. The `AddControllers()` call SHALL be configured with `JsonStringEnumConverter`:
+```csharp
+builder.Services.AddControllers()
+    .AddJsonOptions(options =>
+    {
+        options.JsonSerializerOptions.Converters.Add(new JsonStringEnumConverter());
+    });
+```
+
 ---
 
 ## 6. Frontend Requirements
@@ -470,6 +485,7 @@ All changes to this specification SHALL be tracked and versioned appropriately.
 | 1.1     | 2025-12-22 | System | Added structured logging requirements (REQ-SYS-013 through REQ-SYS-022) |
 | 1.2     | 2025-12-22 | System | Added code linting and static analysis requirements (REQ-LINT-001 through REQ-LINT-010) |
 | 1.3     | 2025-12-25 | System | Merged reactive data loading pattern requirements from data-loading-specs.md (REQ-FE-027 through REQ-FE-036) |
+| 1.4     | 2025-12-30 | System | Added JSON enum serialization requirements (REQ-API-007 through REQ-API-008) |
 
 ---
 

--- a/MeetingNotesActionItemTracker/src/MeetingNotesActionItemTracker.Api/Program.cs
+++ b/MeetingNotesActionItemTracker/src/MeetingNotesActionItemTracker.Api/Program.cs
@@ -1,6 +1,7 @@
 using MeetingNotesActionItemTracker.Infrastructure;
 using Serilog;
 using Serilog.Events;
+using System.Text.Json.Serialization;
 
 Log.Logger = new LoggerConfiguration()
     .MinimumLevel.Debug()
@@ -20,7 +21,11 @@ try
     builder.Host.UseSerilog();
 
     // Add services to the container.
-    builder.Services.AddControllers();
+    builder.Services.AddControllers()
+        .AddJsonOptions(options =>
+        {
+            options.JsonSerializerOptions.Converters.Add(new JsonStringEnumConverter());
+        });
     builder.Services.AddEndpointsApiExplorer();
     builder.Services.AddSwaggerGen(c =>
     {

--- a/MensGroupDiscussionTracker/docs/specs/implementation-specs.md
+++ b/MensGroupDiscussionTracker/docs/specs/implementation-specs.md
@@ -192,6 +192,21 @@ Id
 ### 5.5 CORS Configuration
 **REQ-API-006**: The API SHALL have a CORS policy defined. The origins allowed in the CORS policy SHALL be retrieved from configuration and SHALL include the URLs where the frontend(s) are hosted.
 
+### 5.6 JSON Serialization
+**REQ-API-007**: The API project Program.cs SHALL include the following using statement:
+```csharp
+using System.Text.Json.Serialization;
+```
+
+**REQ-API-008**: The API SHALL configure JSON serialization to handle enums as text strings. The `AddControllers()` call SHALL be configured with `JsonStringEnumConverter`:
+```csharp
+builder.Services.AddControllers()
+    .AddJsonOptions(options =>
+    {
+        options.JsonSerializerOptions.Converters.Add(new JsonStringEnumConverter());
+    });
+```
+
 ---
 
 ## 6. Frontend Requirements
@@ -470,6 +485,7 @@ All changes to this specification SHALL be tracked and versioned appropriately.
 | 1.1     | 2025-12-22 | System | Added structured logging requirements (REQ-SYS-013 through REQ-SYS-022) |
 | 1.2     | 2025-12-22 | System | Added code linting and static analysis requirements (REQ-LINT-001 through REQ-LINT-010) |
 | 1.3     | 2025-12-25 | System | Merged reactive data loading pattern requirements from data-loading-specs.md (REQ-FE-027 through REQ-FE-036) |
+| 1.4     | 2025-12-30 | System | Added JSON enum serialization requirements (REQ-API-007 through REQ-API-008) |
 
 ---
 

--- a/MensGroupDiscussionTracker/src/MensGroupDiscussionTracker.Api/Program.cs
+++ b/MensGroupDiscussionTracker/src/MensGroupDiscussionTracker.Api/Program.cs
@@ -1,5 +1,6 @@
 using MensGroupDiscussionTracker.Infrastructure;
 using Serilog;
+using System.Text.Json.Serialization;
 
 var builder = WebApplication.CreateBuilder(args);
 
@@ -16,7 +17,11 @@ builder.Host.UseSerilog((context, loggerConfig) =>
 });
 
 // Add services to the container.
-builder.Services.AddControllers();
+builder.Services.AddControllers()
+    .AddJsonOptions(options =>
+    {
+        options.JsonSerializerOptions.Converters.Add(new JsonStringEnumConverter());
+    });
 builder.Services.AddEndpointsApiExplorer();
 builder.Services.AddSwaggerGen(options =>
 {

--- a/MorningRoutineBuilder/docs/specs/implementation-specs.md
+++ b/MorningRoutineBuilder/docs/specs/implementation-specs.md
@@ -192,6 +192,21 @@ Id
 ### 5.5 CORS Configuration
 **REQ-API-006**: The API SHALL have a CORS policy defined. The origins allowed in the CORS policy SHALL be retrieved from configuration and SHALL include the URLs where the frontend(s) are hosted.
 
+### 5.6 JSON Serialization
+**REQ-API-007**: The API project Program.cs SHALL include the following using statement:
+```csharp
+using System.Text.Json.Serialization;
+```
+
+**REQ-API-008**: The API SHALL configure JSON serialization to handle enums as text strings. The `AddControllers()` call SHALL be configured with `JsonStringEnumConverter`:
+```csharp
+builder.Services.AddControllers()
+    .AddJsonOptions(options =>
+    {
+        options.JsonSerializerOptions.Converters.Add(new JsonStringEnumConverter());
+    });
+```
+
 ---
 
 ## 6. Frontend Requirements
@@ -470,6 +485,7 @@ All changes to this specification SHALL be tracked and versioned appropriately.
 | 1.1     | 2025-12-22 | System | Added structured logging requirements (REQ-SYS-013 through REQ-SYS-022) |
 | 1.2     | 2025-12-22 | System | Added code linting and static analysis requirements (REQ-LINT-001 through REQ-LINT-010) |
 | 1.3     | 2025-12-25 | System | Merged reactive data loading pattern requirements from data-loading-specs.md (REQ-FE-027 through REQ-FE-036) |
+| 1.4     | 2025-12-30 | System | Added JSON enum serialization requirements (REQ-API-007 through REQ-API-008) |
 
 ---
 

--- a/MorningRoutineBuilder/src/MorningRoutineBuilder.Api/Program.cs
+++ b/MorningRoutineBuilder/src/MorningRoutineBuilder.Api/Program.cs
@@ -1,5 +1,6 @@
 using MorningRoutineBuilder.Infrastructure;
 using Serilog;
+using System.Text.Json.Serialization;
 
 var builder = WebApplication.CreateBuilder(args);
 
@@ -15,7 +16,11 @@ try
     Log.Information("Starting MorningRoutineBuilder API");
 
     // Add services to the container.
-    builder.Services.AddControllers();
+    builder.Services.AddControllers()
+        .AddJsonOptions(options =>
+        {
+            options.JsonSerializerOptions.Converters.Add(new JsonStringEnumConverter());
+        });
     builder.Services.AddEndpointsApiExplorer();
     builder.Services.AddSwaggerGen(c =>
     {

--- a/MortgagePayoffOptimizer/docs/specs/implementation-specs.md
+++ b/MortgagePayoffOptimizer/docs/specs/implementation-specs.md
@@ -192,6 +192,21 @@ Id
 ### 5.5 CORS Configuration
 **REQ-API-006**: The API SHALL have a CORS policy defined. The origins allowed in the CORS policy SHALL be retrieved from configuration and SHALL include the URLs where the frontend(s) are hosted.
 
+### 5.6 JSON Serialization
+**REQ-API-007**: The API project Program.cs SHALL include the following using statement:
+```csharp
+using System.Text.Json.Serialization;
+```
+
+**REQ-API-008**: The API SHALL configure JSON serialization to handle enums as text strings. The `AddControllers()` call SHALL be configured with `JsonStringEnumConverter`:
+```csharp
+builder.Services.AddControllers()
+    .AddJsonOptions(options =>
+    {
+        options.JsonSerializerOptions.Converters.Add(new JsonStringEnumConverter());
+    });
+```
+
 ---
 
 ## 6. Frontend Requirements
@@ -470,6 +485,7 @@ All changes to this specification SHALL be tracked and versioned appropriately.
 | 1.1     | 2025-12-22 | System | Added structured logging requirements (REQ-SYS-013 through REQ-SYS-022) |
 | 1.2     | 2025-12-22 | System | Added code linting and static analysis requirements (REQ-LINT-001 through REQ-LINT-010) |
 | 1.3     | 2025-12-25 | System | Merged reactive data loading pattern requirements from data-loading-specs.md (REQ-FE-027 through REQ-FE-036) |
+| 1.4     | 2025-12-30 | System | Added JSON enum serialization requirements (REQ-API-007 through REQ-API-008) |
 
 ---
 

--- a/MortgagePayoffOptimizer/src/MortgagePayoffOptimizer.Api/Program.cs
+++ b/MortgagePayoffOptimizer/src/MortgagePayoffOptimizer.Api/Program.cs
@@ -4,6 +4,7 @@
 using MortgagePayoffOptimizer.Infrastructure;
 using Serilog;
 using Serilog.Events;
+using System.Text.Json.Serialization;
 
 var builder = WebApplication.CreateBuilder(args);
 
@@ -22,7 +23,11 @@ Log.Logger = new LoggerConfiguration()
 builder.Host.UseSerilog();
 
 // Add services to the container.
-builder.Services.AddControllers();
+builder.Services.AddControllers()
+    .AddJsonOptions(options =>
+    {
+        options.JsonSerializerOptions.Converters.Add(new JsonStringEnumConverter());
+    });
 builder.Services.AddEndpointsApiExplorer();
 builder.Services.AddSwaggerGen();
 

--- a/MovieTVShowWatchlist/docs/specs/implementation-specs.md
+++ b/MovieTVShowWatchlist/docs/specs/implementation-specs.md
@@ -192,6 +192,21 @@ Id
 ### 5.5 CORS Configuration
 **REQ-API-006**: The API SHALL have a CORS policy defined. The origins allowed in the CORS policy SHALL be retrieved from configuration and SHALL include the URLs where the frontend(s) are hosted.
 
+### 5.6 JSON Serialization
+**REQ-API-007**: The API project Program.cs SHALL include the following using statement:
+```csharp
+using System.Text.Json.Serialization;
+```
+
+**REQ-API-008**: The API SHALL configure JSON serialization to handle enums as text strings. The `AddControllers()` call SHALL be configured with `JsonStringEnumConverter`:
+```csharp
+builder.Services.AddControllers()
+    .AddJsonOptions(options =>
+    {
+        options.JsonSerializerOptions.Converters.Add(new JsonStringEnumConverter());
+    });
+```
+
 ---
 
 ## 6. Frontend Requirements
@@ -470,6 +485,7 @@ All changes to this specification SHALL be tracked and versioned appropriately.
 | 1.1     | 2025-12-22 | System | Added structured logging requirements (REQ-SYS-013 through REQ-SYS-022) |
 | 1.2     | 2025-12-22 | System | Added code linting and static analysis requirements (REQ-LINT-001 through REQ-LINT-010) |
 | 1.3     | 2025-12-25 | System | Merged reactive data loading pattern requirements from data-loading-specs.md (REQ-FE-027 through REQ-FE-036) |
+| 1.4     | 2025-12-30 | System | Added JSON enum serialization requirements (REQ-API-007 through REQ-API-008) |
 
 ---
 

--- a/MovieTVShowWatchlist/src/MovieTVShowWatchlist.Api/Program.cs
+++ b/MovieTVShowWatchlist/src/MovieTVShowWatchlist.Api/Program.cs
@@ -2,6 +2,7 @@ using Microsoft.EntityFrameworkCore;
 using MovieTVShowWatchlist.Core;
 using MovieTVShowWatchlist.Infrastructure;
 using Serilog;
+using System.Text.Json.Serialization;
 
 var builder = WebApplication.CreateBuilder(args);
 
@@ -17,7 +18,11 @@ Log.Logger = new LoggerConfiguration()
 builder.Host.UseSerilog();
 
 // Add services to the container.
-builder.Services.AddControllers();
+builder.Services.AddControllers()
+    .AddJsonOptions(options =>
+    {
+        options.JsonSerializerOptions.Converters.Add(new JsonStringEnumConverter());
+    });
 builder.Services.AddEndpointsApiExplorer();
 builder.Services.AddSwaggerGen();
 

--- a/MusicCollectionOrganizer/docs/specs/implementation-specs.md
+++ b/MusicCollectionOrganizer/docs/specs/implementation-specs.md
@@ -192,6 +192,21 @@ Id
 ### 5.5 CORS Configuration
 **REQ-API-006**: The API SHALL have a CORS policy defined. The origins allowed in the CORS policy SHALL be retrieved from configuration and SHALL include the URLs where the frontend(s) are hosted.
 
+### 5.6 JSON Serialization
+**REQ-API-007**: The API project Program.cs SHALL include the following using statement:
+```csharp
+using System.Text.Json.Serialization;
+```
+
+**REQ-API-008**: The API SHALL configure JSON serialization to handle enums as text strings. The `AddControllers()` call SHALL be configured with `JsonStringEnumConverter`:
+```csharp
+builder.Services.AddControllers()
+    .AddJsonOptions(options =>
+    {
+        options.JsonSerializerOptions.Converters.Add(new JsonStringEnumConverter());
+    });
+```
+
 ---
 
 ## 6. Frontend Requirements
@@ -470,6 +485,7 @@ All changes to this specification SHALL be tracked and versioned appropriately.
 | 1.1     | 2025-12-22 | System | Added structured logging requirements (REQ-SYS-013 through REQ-SYS-022) |
 | 1.2     | 2025-12-22 | System | Added code linting and static analysis requirements (REQ-LINT-001 through REQ-LINT-010) |
 | 1.3     | 2025-12-25 | System | Merged reactive data loading pattern requirements from data-loading-specs.md (REQ-FE-027 through REQ-FE-036) |
+| 1.4     | 2025-12-30 | System | Added JSON enum serialization requirements (REQ-API-007 through REQ-API-008) |
 
 ---
 

--- a/MusicCollectionOrganizer/src/MusicCollectionOrganizer.Api/Program.cs
+++ b/MusicCollectionOrganizer/src/MusicCollectionOrganizer.Api/Program.cs
@@ -1,5 +1,6 @@
 using MusicCollectionOrganizer.Infrastructure;
 using Serilog;
+using System.Text.Json.Serialization;
 
 var builder = WebApplication.CreateBuilder(args);
 
@@ -16,7 +17,11 @@ builder.Host.UseSerilog((context, loggerConfig) =>
 });
 
 // Add services to the container.
-builder.Services.AddControllers();
+builder.Services.AddControllers()
+    .AddJsonOptions(options =>
+    {
+        options.JsonSerializerOptions.Converters.Add(new JsonStringEnumConverter());
+    });
 builder.Services.AddEndpointsApiExplorer();
 builder.Services.AddSwaggerGen(options =>
 {

--- a/NeighborhoodSocialNetwork/docs/specs/implementation-specs.md
+++ b/NeighborhoodSocialNetwork/docs/specs/implementation-specs.md
@@ -192,6 +192,21 @@ Id
 ### 5.5 CORS Configuration
 **REQ-API-006**: The API SHALL have a CORS policy defined. The origins allowed in the CORS policy SHALL be retrieved from configuration and SHALL include the URLs where the frontend(s) are hosted.
 
+### 5.6 JSON Serialization
+**REQ-API-007**: The API project Program.cs SHALL include the following using statement:
+```csharp
+using System.Text.Json.Serialization;
+```
+
+**REQ-API-008**: The API SHALL configure JSON serialization to handle enums as text strings. The `AddControllers()` call SHALL be configured with `JsonStringEnumConverter`:
+```csharp
+builder.Services.AddControllers()
+    .AddJsonOptions(options =>
+    {
+        options.JsonSerializerOptions.Converters.Add(new JsonStringEnumConverter());
+    });
+```
+
 ---
 
 ## 6. Frontend Requirements
@@ -470,6 +485,7 @@ All changes to this specification SHALL be tracked and versioned appropriately.
 | 1.1     | 2025-12-22 | System | Added structured logging requirements (REQ-SYS-013 through REQ-SYS-022) |
 | 1.2     | 2025-12-22 | System | Added code linting and static analysis requirements (REQ-LINT-001 through REQ-LINT-010) |
 | 1.3     | 2025-12-25 | System | Merged reactive data loading pattern requirements from data-loading-specs.md (REQ-FE-027 through REQ-FE-036) |
+| 1.4     | 2025-12-30 | System | Added JSON enum serialization requirements (REQ-API-007 through REQ-API-008) |
 
 ---
 

--- a/NeighborhoodSocialNetwork/src/NeighborhoodSocialNetwork.Api/Program.cs
+++ b/NeighborhoodSocialNetwork/src/NeighborhoodSocialNetwork.Api/Program.cs
@@ -1,5 +1,6 @@
 using NeighborhoodSocialNetwork.Infrastructure;
 using Serilog;
+using System.Text.Json.Serialization;
 
 var builder = WebApplication.CreateBuilder(args);
 
@@ -16,7 +17,11 @@ builder.Host.UseSerilog((context, loggerConfig) =>
 });
 
 // Add services to the container.
-builder.Services.AddControllers();
+builder.Services.AddControllers()
+    .AddJsonOptions(options =>
+    {
+        options.JsonSerializerOptions.Converters.Add(new JsonStringEnumConverter());
+    });
 builder.Services.AddEndpointsApiExplorer();
 builder.Services.AddSwaggerGen(options =>
 {

--- a/NutritionLabelScanner/docs/specs/implementation-specs.md
+++ b/NutritionLabelScanner/docs/specs/implementation-specs.md
@@ -192,6 +192,21 @@ Id
 ### 5.5 CORS Configuration
 **REQ-API-006**: The API SHALL have a CORS policy defined. The origins allowed in the CORS policy SHALL be retrieved from configuration and SHALL include the URLs where the frontend(s) are hosted.
 
+### 5.6 JSON Serialization
+**REQ-API-007**: The API project Program.cs SHALL include the following using statement:
+```csharp
+using System.Text.Json.Serialization;
+```
+
+**REQ-API-008**: The API SHALL configure JSON serialization to handle enums as text strings. The `AddControllers()` call SHALL be configured with `JsonStringEnumConverter`:
+```csharp
+builder.Services.AddControllers()
+    .AddJsonOptions(options =>
+    {
+        options.JsonSerializerOptions.Converters.Add(new JsonStringEnumConverter());
+    });
+```
+
 ---
 
 ## 6. Frontend Requirements
@@ -470,6 +485,7 @@ All changes to this specification SHALL be tracked and versioned appropriately.
 | 1.1     | 2025-12-22 | System | Added structured logging requirements (REQ-SYS-013 through REQ-SYS-022) |
 | 1.2     | 2025-12-22 | System | Added code linting and static analysis requirements (REQ-LINT-001 through REQ-LINT-010) |
 | 1.3     | 2025-12-25 | System | Merged reactive data loading pattern requirements from data-loading-specs.md (REQ-FE-027 through REQ-FE-036) |
+| 1.4     | 2025-12-30 | System | Added JSON enum serialization requirements (REQ-API-007 through REQ-API-008) |
 
 ---
 

--- a/NutritionLabelScanner/src/NutritionLabelScanner.Api/Program.cs
+++ b/NutritionLabelScanner/src/NutritionLabelScanner.Api/Program.cs
@@ -3,6 +3,7 @@ using NutritionLabelScanner.Infrastructure;
 using Microsoft.EntityFrameworkCore;
 using Serilog;
 using Serilog.Events;
+using System.Text.Json.Serialization;
 
 // Configure Serilog
 Log.Logger = new LoggerConfiguration()
@@ -25,7 +26,11 @@ try
     builder.Host.UseSerilog();
 
     // Add services to the container
-    builder.Services.AddControllers();
+    builder.Services.AddControllers()
+        .AddJsonOptions(options =>
+        {
+            options.JsonSerializerOptions.Converters.Add(new JsonStringEnumConverter());
+        });
     builder.Services.AddEndpointsApiExplorer();
     builder.Services.AddSwaggerGen();
 

--- a/PasswordAccountAuditor/docs/specs/implementation-specs.md
+++ b/PasswordAccountAuditor/docs/specs/implementation-specs.md
@@ -192,6 +192,21 @@ Id
 ### 5.5 CORS Configuration
 **REQ-API-006**: The API SHALL have a CORS policy defined. The origins allowed in the CORS policy SHALL be retrieved from configuration and SHALL include the URLs where the frontend(s) are hosted.
 
+### 5.6 JSON Serialization
+**REQ-API-007**: The API project Program.cs SHALL include the following using statement:
+```csharp
+using System.Text.Json.Serialization;
+```
+
+**REQ-API-008**: The API SHALL configure JSON serialization to handle enums as text strings. The `AddControllers()` call SHALL be configured with `JsonStringEnumConverter`:
+```csharp
+builder.Services.AddControllers()
+    .AddJsonOptions(options =>
+    {
+        options.JsonSerializerOptions.Converters.Add(new JsonStringEnumConverter());
+    });
+```
+
 ---
 
 ## 6. Frontend Requirements
@@ -470,6 +485,7 @@ All changes to this specification SHALL be tracked and versioned appropriately.
 | 1.1     | 2025-12-22 | System | Added structured logging requirements (REQ-SYS-013 through REQ-SYS-022) |
 | 1.2     | 2025-12-22 | System | Added code linting and static analysis requirements (REQ-LINT-001 through REQ-LINT-010) |
 | 1.3     | 2025-12-25 | System | Merged reactive data loading pattern requirements from data-loading-specs.md (REQ-FE-027 through REQ-FE-036) |
+| 1.4     | 2025-12-30 | System | Added JSON enum serialization requirements (REQ-API-007 through REQ-API-008) |
 
 ---
 

--- a/PasswordAccountAuditor/src/PasswordAccountAuditor.Api/Program.cs
+++ b/PasswordAccountAuditor/src/PasswordAccountAuditor.Api/Program.cs
@@ -4,6 +4,7 @@
 using PasswordAccountAuditor.Infrastructure;
 using Serilog;
 using Serilog.Events;
+using System.Text.Json.Serialization;
 
 var builder = WebApplication.CreateBuilder(args);
 
@@ -22,7 +23,11 @@ Log.Logger = new LoggerConfiguration()
 builder.Host.UseSerilog();
 
 // Add services to the container
-builder.Services.AddControllers();
+builder.Services.AddControllers()
+    .AddJsonOptions(options =>
+    {
+        options.JsonSerializerOptions.Converters.Add(new JsonStringEnumConverter());
+    });
 builder.Services.AddEndpointsApiExplorer();
 builder.Services.AddSwaggerGen(options =>
 {

--- a/PerformanceReviewPrepTool/docs/specs/implementation-specs.md
+++ b/PerformanceReviewPrepTool/docs/specs/implementation-specs.md
@@ -192,6 +192,21 @@ Id
 ### 5.5 CORS Configuration
 **REQ-API-006**: The API SHALL have a CORS policy defined. The origins allowed in the CORS policy SHALL be retrieved from configuration and SHALL include the URLs where the frontend(s) are hosted.
 
+### 5.6 JSON Serialization
+**REQ-API-007**: The API project Program.cs SHALL include the following using statement:
+```csharp
+using System.Text.Json.Serialization;
+```
+
+**REQ-API-008**: The API SHALL configure JSON serialization to handle enums as text strings. The `AddControllers()` call SHALL be configured with `JsonStringEnumConverter`:
+```csharp
+builder.Services.AddControllers()
+    .AddJsonOptions(options =>
+    {
+        options.JsonSerializerOptions.Converters.Add(new JsonStringEnumConverter());
+    });
+```
+
 ---
 
 ## 6. Frontend Requirements
@@ -470,6 +485,7 @@ All changes to this specification SHALL be tracked and versioned appropriately.
 | 1.1     | 2025-12-22 | System | Added structured logging requirements (REQ-SYS-013 through REQ-SYS-022) |
 | 1.2     | 2025-12-22 | System | Added code linting and static analysis requirements (REQ-LINT-001 through REQ-LINT-010) |
 | 1.3     | 2025-12-25 | System | Merged reactive data loading pattern requirements from data-loading-specs.md (REQ-FE-027 through REQ-FE-036) |
+| 1.4     | 2025-12-30 | System | Added JSON enum serialization requirements (REQ-API-007 through REQ-API-008) |
 
 ---
 

--- a/PerformanceReviewPrepTool/src/PerformanceReviewPrepTool.Api/Program.cs
+++ b/PerformanceReviewPrepTool/src/PerformanceReviewPrepTool.Api/Program.cs
@@ -1,5 +1,6 @@
 using PerformanceReviewPrepTool.Infrastructure;
 using Serilog;
+using System.Text.Json.Serialization;
 
 var builder = WebApplication.CreateBuilder(args);
 
@@ -16,7 +17,11 @@ builder.Host.UseSerilog((context, loggerConfig) =>
 });
 
 // Add services to the container.
-builder.Services.AddControllers();
+builder.Services.AddControllers()
+    .AddJsonOptions(options =>
+    {
+        options.JsonSerializerOptions.Converters.Add(new JsonStringEnumConverter());
+    });
 builder.Services.AddEndpointsApiExplorer();
 builder.Services.AddSwaggerGen(options =>
 {

--- a/PersonalHealthDashboard/docs/specs/implementation-specs.md
+++ b/PersonalHealthDashboard/docs/specs/implementation-specs.md
@@ -192,6 +192,21 @@ Id
 ### 5.5 CORS Configuration
 **REQ-API-006**: The API SHALL have a CORS policy defined. The origins allowed in the CORS policy SHALL be retrieved from configuration and SHALL include the URLs where the frontend(s) are hosted.
 
+### 5.6 JSON Serialization
+**REQ-API-007**: The API project Program.cs SHALL include the following using statement:
+```csharp
+using System.Text.Json.Serialization;
+```
+
+**REQ-API-008**: The API SHALL configure JSON serialization to handle enums as text strings. The `AddControllers()` call SHALL be configured with `JsonStringEnumConverter`:
+```csharp
+builder.Services.AddControllers()
+    .AddJsonOptions(options =>
+    {
+        options.JsonSerializerOptions.Converters.Add(new JsonStringEnumConverter());
+    });
+```
+
 ---
 
 ## 6. Frontend Requirements
@@ -470,6 +485,7 @@ All changes to this specification SHALL be tracked and versioned appropriately.
 | 1.1     | 2025-12-22 | System | Added structured logging requirements (REQ-SYS-013 through REQ-SYS-022) |
 | 1.2     | 2025-12-22 | System | Added code linting and static analysis requirements (REQ-LINT-001 through REQ-LINT-010) |
 | 1.3     | 2025-12-25 | System | Merged reactive data loading pattern requirements from data-loading-specs.md (REQ-FE-027 through REQ-FE-036) |
+| 1.4     | 2025-12-30 | System | Added JSON enum serialization requirements (REQ-API-007 through REQ-API-008) |
 
 ---
 

--- a/PersonalHealthDashboard/src/PersonalHealthDashboard.Api/Program.cs
+++ b/PersonalHealthDashboard/src/PersonalHealthDashboard.Api/Program.cs
@@ -1,5 +1,6 @@
 using PersonalHealthDashboard.Infrastructure;
 using Serilog;
+using System.Text.Json.Serialization;
 
 var builder = WebApplication.CreateBuilder(args);
 
@@ -16,7 +17,11 @@ builder.Host.UseSerilog((context, loggerConfig) =>
 });
 
 // Add services to the container.
-builder.Services.AddControllers();
+builder.Services.AddControllers()
+    .AddJsonOptions(options =>
+    {
+        options.JsonSerializerOptions.Converters.Add(new JsonStringEnumConverter());
+    });
 builder.Services.AddEndpointsApiExplorer();
 builder.Services.AddSwaggerGen(options =>
 {

--- a/PersonalLibraryLessonsLearned/docs/specs/implementation-specs.md
+++ b/PersonalLibraryLessonsLearned/docs/specs/implementation-specs.md
@@ -192,6 +192,21 @@ Id
 ### 5.5 CORS Configuration
 **REQ-API-006**: The API SHALL have a CORS policy defined. The origins allowed in the CORS policy SHALL be retrieved from configuration and SHALL include the URLs where the frontend(s) are hosted.
 
+### 5.6 JSON Serialization
+**REQ-API-007**: The API project Program.cs SHALL include the following using statement:
+```csharp
+using System.Text.Json.Serialization;
+```
+
+**REQ-API-008**: The API SHALL configure JSON serialization to handle enums as text strings. The `AddControllers()` call SHALL be configured with `JsonStringEnumConverter`:
+```csharp
+builder.Services.AddControllers()
+    .AddJsonOptions(options =>
+    {
+        options.JsonSerializerOptions.Converters.Add(new JsonStringEnumConverter());
+    });
+```
+
 ---
 
 ## 6. Frontend Requirements
@@ -470,6 +485,7 @@ All changes to this specification SHALL be tracked and versioned appropriately.
 | 1.1     | 2025-12-22 | System | Added structured logging requirements (REQ-SYS-013 through REQ-SYS-022) |
 | 1.2     | 2025-12-22 | System | Added code linting and static analysis requirements (REQ-LINT-001 through REQ-LINT-010) |
 | 1.3     | 2025-12-25 | System | Merged reactive data loading pattern requirements from data-loading-specs.md (REQ-FE-027 through REQ-FE-036) |
+| 1.4     | 2025-12-30 | System | Added JSON enum serialization requirements (REQ-API-007 through REQ-API-008) |
 
 ---
 

--- a/PersonalLibraryLessonsLearned/src/PersonalLibraryLessonsLearned.Api/Program.cs
+++ b/PersonalLibraryLessonsLearned/src/PersonalLibraryLessonsLearned.Api/Program.cs
@@ -1,5 +1,6 @@
 using PersonalLibraryLessonsLearned.Infrastructure;
 using Serilog;
+using System.Text.Json.Serialization;
 
 var builder = WebApplication.CreateBuilder(args);
 
@@ -16,7 +17,11 @@ builder.Host.UseSerilog((context, loggerConfig) =>
 });
 
 // Add services to the container.
-builder.Services.AddControllers();
+builder.Services.AddControllers()
+    .AddJsonOptions(options =>
+    {
+        options.JsonSerializerOptions.Converters.Add(new JsonStringEnumConverter());
+    });
 builder.Services.AddEndpointsApiExplorer();
 builder.Services.AddSwaggerGen(options =>
 {

--- a/PersonalLoanComparisonTool/docs/specs/implementation-specs.md
+++ b/PersonalLoanComparisonTool/docs/specs/implementation-specs.md
@@ -192,6 +192,21 @@ Id
 ### 5.5 CORS Configuration
 **REQ-API-006**: The API SHALL have a CORS policy defined. The origins allowed in the CORS policy SHALL be retrieved from configuration and SHALL include the URLs where the frontend(s) are hosted.
 
+### 5.6 JSON Serialization
+**REQ-API-007**: The API project Program.cs SHALL include the following using statement:
+```csharp
+using System.Text.Json.Serialization;
+```
+
+**REQ-API-008**: The API SHALL configure JSON serialization to handle enums as text strings. The `AddControllers()` call SHALL be configured with `JsonStringEnumConverter`:
+```csharp
+builder.Services.AddControllers()
+    .AddJsonOptions(options =>
+    {
+        options.JsonSerializerOptions.Converters.Add(new JsonStringEnumConverter());
+    });
+```
+
 ---
 
 ## 6. Frontend Requirements
@@ -470,6 +485,7 @@ All changes to this specification SHALL be tracked and versioned appropriately.
 | 1.1     | 2025-12-22 | System | Added structured logging requirements (REQ-SYS-013 through REQ-SYS-022) |
 | 1.2     | 2025-12-22 | System | Added code linting and static analysis requirements (REQ-LINT-001 through REQ-LINT-010) |
 | 1.3     | 2025-12-25 | System | Merged reactive data loading pattern requirements from data-loading-specs.md (REQ-FE-027 through REQ-FE-036) |
+| 1.4     | 2025-12-30 | System | Added JSON enum serialization requirements (REQ-API-007 through REQ-API-008) |
 
 ---
 

--- a/PersonalLoanComparisonTool/src/PersonalLoanComparisonTool.Api/Program.cs
+++ b/PersonalLoanComparisonTool/src/PersonalLoanComparisonTool.Api/Program.cs
@@ -1,6 +1,7 @@
 using Serilog;
 using Serilog.Events;
 using PersonalLoanComparisonTool.Infrastructure;
+using System.Text.Json.Serialization;
 
 Log.Logger = new LoggerConfiguration()
     .MinimumLevel.Override("Microsoft", LogEventLevel.Information)
@@ -23,7 +24,11 @@ try
         .WriteTo.Console());
 
     // Add services to the container.
-    builder.Services.AddControllers();
+    builder.Services.AddControllers()
+        .AddJsonOptions(options =>
+        {
+            options.JsonSerializerOptions.Converters.Add(new JsonStringEnumConverter());
+        });
     builder.Services.AddEndpointsApiExplorer();
     builder.Services.AddSwaggerGen();
 

--- a/PersonalMissionStatementBuilder/docs/specs/implementation-specs.md
+++ b/PersonalMissionStatementBuilder/docs/specs/implementation-specs.md
@@ -192,6 +192,21 @@ Id
 ### 5.5 CORS Configuration
 **REQ-API-006**: The API SHALL have a CORS policy defined. The origins allowed in the CORS policy SHALL be retrieved from configuration and SHALL include the URLs where the frontend(s) are hosted.
 
+### 5.6 JSON Serialization
+**REQ-API-007**: The API project Program.cs SHALL include the following using statement:
+```csharp
+using System.Text.Json.Serialization;
+```
+
+**REQ-API-008**: The API SHALL configure JSON serialization to handle enums as text strings. The `AddControllers()` call SHALL be configured with `JsonStringEnumConverter`:
+```csharp
+builder.Services.AddControllers()
+    .AddJsonOptions(options =>
+    {
+        options.JsonSerializerOptions.Converters.Add(new JsonStringEnumConverter());
+    });
+```
+
 ---
 
 ## 6. Frontend Requirements
@@ -470,6 +485,7 @@ All changes to this specification SHALL be tracked and versioned appropriately.
 | 1.1     | 2025-12-22 | System | Added structured logging requirements (REQ-SYS-013 through REQ-SYS-022) |
 | 1.2     | 2025-12-22 | System | Added code linting and static analysis requirements (REQ-LINT-001 through REQ-LINT-010) |
 | 1.3     | 2025-12-25 | System | Merged reactive data loading pattern requirements from data-loading-specs.md (REQ-FE-027 through REQ-FE-036) |
+| 1.4     | 2025-12-30 | System | Added JSON enum serialization requirements (REQ-API-007 through REQ-API-008) |
 
 ---
 

--- a/PersonalMissionStatementBuilder/src/PersonalMissionStatementBuilder.Api/Program.cs
+++ b/PersonalMissionStatementBuilder/src/PersonalMissionStatementBuilder.Api/Program.cs
@@ -1,6 +1,7 @@
 using PersonalMissionStatementBuilder.Infrastructure;
 using PersonalMissionStatementBuilder.Infrastructure.Data;
 using Serilog;
+using System.Text.Json.Serialization;
 
 var builder = WebApplication.CreateBuilder(args);
 
@@ -17,7 +18,11 @@ builder.Host.UseSerilog((context, loggerConfig) =>
 });
 
 // Add services to the container.
-builder.Services.AddControllers();
+builder.Services.AddControllers()
+    .AddJsonOptions(options =>
+    {
+        options.JsonSerializerOptions.Converters.Add(new JsonStringEnumConverter());
+    });
 builder.Services.AddEndpointsApiExplorer();
 builder.Services.AddSwaggerGen(options =>
 {

--- a/PersonalNetWorthDashboard/docs/specs/implementation-specs.md
+++ b/PersonalNetWorthDashboard/docs/specs/implementation-specs.md
@@ -192,6 +192,21 @@ Id
 ### 5.5 CORS Configuration
 **REQ-API-006**: The API SHALL have a CORS policy defined. The origins allowed in the CORS policy SHALL be retrieved from configuration and SHALL include the URLs where the frontend(s) are hosted.
 
+### 5.6 JSON Serialization
+**REQ-API-007**: The API project Program.cs SHALL include the following using statement:
+```csharp
+using System.Text.Json.Serialization;
+```
+
+**REQ-API-008**: The API SHALL configure JSON serialization to handle enums as text strings. The `AddControllers()` call SHALL be configured with `JsonStringEnumConverter`:
+```csharp
+builder.Services.AddControllers()
+    .AddJsonOptions(options =>
+    {
+        options.JsonSerializerOptions.Converters.Add(new JsonStringEnumConverter());
+    });
+```
+
 ---
 
 ## 6. Frontend Requirements
@@ -470,6 +485,7 @@ All changes to this specification SHALL be tracked and versioned appropriately.
 | 1.1     | 2025-12-22 | System | Added structured logging requirements (REQ-SYS-013 through REQ-SYS-022) |
 | 1.2     | 2025-12-22 | System | Added code linting and static analysis requirements (REQ-LINT-001 through REQ-LINT-010) |
 | 1.3     | 2025-12-25 | System | Merged reactive data loading pattern requirements from data-loading-specs.md (REQ-FE-027 through REQ-FE-036) |
+| 1.4     | 2025-12-30 | System | Added JSON enum serialization requirements (REQ-API-007 through REQ-API-008) |
 
 ---
 

--- a/PersonalNetWorthDashboard/src/PersonalNetWorthDashboard.Api/Program.cs
+++ b/PersonalNetWorthDashboard/src/PersonalNetWorthDashboard.Api/Program.cs
@@ -3,6 +3,7 @@ using PersonalNetWorthDashboard.Infrastructure;
 using Microsoft.EntityFrameworkCore;
 using Serilog;
 using Serilog.Events;
+using System.Text.Json.Serialization;
 
 // Configure Serilog
 Log.Logger = new LoggerConfiguration()
@@ -25,7 +26,11 @@ try
     builder.Host.UseSerilog();
 
     // Add services to the container
-    builder.Services.AddControllers();
+    builder.Services.AddControllers()
+        .AddJsonOptions(options =>
+        {
+            options.JsonSerializerOptions.Converters.Add(new JsonStringEnumConverter());
+        });
     builder.Services.AddEndpointsApiExplorer();
     builder.Services.AddSwaggerGen();
 

--- a/PersonalProjectPipeline/docs/specs/implementation-specs.md
+++ b/PersonalProjectPipeline/docs/specs/implementation-specs.md
@@ -192,6 +192,21 @@ Id
 ### 5.5 CORS Configuration
 **REQ-API-006**: The API SHALL have a CORS policy defined. The origins allowed in the CORS policy SHALL be retrieved from configuration and SHALL include the URLs where the frontend(s) are hosted.
 
+### 5.6 JSON Serialization
+**REQ-API-007**: The API project Program.cs SHALL include the following using statement:
+```csharp
+using System.Text.Json.Serialization;
+```
+
+**REQ-API-008**: The API SHALL configure JSON serialization to handle enums as text strings. The `AddControllers()` call SHALL be configured with `JsonStringEnumConverter`:
+```csharp
+builder.Services.AddControllers()
+    .AddJsonOptions(options =>
+    {
+        options.JsonSerializerOptions.Converters.Add(new JsonStringEnumConverter());
+    });
+```
+
 ---
 
 ## 6. Frontend Requirements
@@ -470,6 +485,7 @@ All changes to this specification SHALL be tracked and versioned appropriately.
 | 1.1     | 2025-12-22 | System | Added structured logging requirements (REQ-SYS-013 through REQ-SYS-022) |
 | 1.2     | 2025-12-22 | System | Added code linting and static analysis requirements (REQ-LINT-001 through REQ-LINT-010) |
 | 1.3     | 2025-12-25 | System | Merged reactive data loading pattern requirements from data-loading-specs.md (REQ-FE-027 through REQ-FE-036) |
+| 1.4     | 2025-12-30 | System | Added JSON enum serialization requirements (REQ-API-007 through REQ-API-008) |
 
 ---
 

--- a/PersonalProjectPipeline/src/PersonalProjectPipeline.Api/Program.cs
+++ b/PersonalProjectPipeline/src/PersonalProjectPipeline.Api/Program.cs
@@ -1,6 +1,7 @@
 using PersonalProjectPipeline.Infrastructure;
 using Serilog;
 using Serilog.Events;
+using System.Text.Json.Serialization;
 
 Log.Logger = new LoggerConfiguration()
     .MinimumLevel.Override("Microsoft", LogEventLevel.Information)
@@ -20,7 +21,11 @@ try
     builder.Host.UseSerilog();
 
     // Add services to the container.
-    builder.Services.AddControllers();
+    builder.Services.AddControllers()
+        .AddJsonOptions(options =>
+        {
+            options.JsonSerializerOptions.Converters.Add(new JsonStringEnumConverter());
+        });
     builder.Services.AddEndpointsApiExplorer();
     builder.Services.AddSwaggerGen();
 

--- a/PersonalWiki/docs/specs/implementation-specs.md
+++ b/PersonalWiki/docs/specs/implementation-specs.md
@@ -192,6 +192,21 @@ Id
 ### 5.5 CORS Configuration
 **REQ-API-006**: The API SHALL have a CORS policy defined. The origins allowed in the CORS policy SHALL be retrieved from configuration and SHALL include the URLs where the frontend(s) are hosted.
 
+### 5.6 JSON Serialization
+**REQ-API-007**: The API project Program.cs SHALL include the following using statement:
+```csharp
+using System.Text.Json.Serialization;
+```
+
+**REQ-API-008**: The API SHALL configure JSON serialization to handle enums as text strings. The `AddControllers()` call SHALL be configured with `JsonStringEnumConverter`:
+```csharp
+builder.Services.AddControllers()
+    .AddJsonOptions(options =>
+    {
+        options.JsonSerializerOptions.Converters.Add(new JsonStringEnumConverter());
+    });
+```
+
 ---
 
 ## 6. Frontend Requirements
@@ -470,6 +485,7 @@ All changes to this specification SHALL be tracked and versioned appropriately.
 | 1.1     | 2025-12-22 | System | Added structured logging requirements (REQ-SYS-013 through REQ-SYS-022) |
 | 1.2     | 2025-12-22 | System | Added code linting and static analysis requirements (REQ-LINT-001 through REQ-LINT-010) |
 | 1.3     | 2025-12-25 | System | Merged reactive data loading pattern requirements from data-loading-specs.md (REQ-FE-027 through REQ-FE-036) |
+| 1.4     | 2025-12-30 | System | Added JSON enum serialization requirements (REQ-API-007 through REQ-API-008) |
 
 ---
 

--- a/PersonalWiki/src/PersonalWiki.Api/Program.cs
+++ b/PersonalWiki/src/PersonalWiki.Api/Program.cs
@@ -1,5 +1,6 @@
 using PersonalWiki.Infrastructure;
 using Serilog;
+using System.Text.Json.Serialization;
 
 var builder = WebApplication.CreateBuilder(args);
 
@@ -16,7 +17,11 @@ builder.Host.UseSerilog((context, loggerConfig) =>
 });
 
 // Add services to the container.
-builder.Services.AddControllers();
+builder.Services.AddControllers()
+    .AddJsonOptions(options =>
+    {
+        options.JsonSerializerOptions.Converters.Add(new JsonStringEnumConverter());
+    });
 builder.Services.AddEndpointsApiExplorer();
 builder.Services.AddSwaggerGen(options =>
 {

--- a/PetCareManager/docs/specs/implementation-specs.md
+++ b/PetCareManager/docs/specs/implementation-specs.md
@@ -192,6 +192,21 @@ Id
 ### 5.5 CORS Configuration
 **REQ-API-006**: The API SHALL have a CORS policy defined. The origins allowed in the CORS policy SHALL be retrieved from configuration and SHALL include the URLs where the frontend(s) are hosted.
 
+### 5.6 JSON Serialization
+**REQ-API-007**: The API project Program.cs SHALL include the following using statement:
+```csharp
+using System.Text.Json.Serialization;
+```
+
+**REQ-API-008**: The API SHALL configure JSON serialization to handle enums as text strings. The `AddControllers()` call SHALL be configured with `JsonStringEnumConverter`:
+```csharp
+builder.Services.AddControllers()
+    .AddJsonOptions(options =>
+    {
+        options.JsonSerializerOptions.Converters.Add(new JsonStringEnumConverter());
+    });
+```
+
 ---
 
 ## 6. Frontend Requirements
@@ -470,6 +485,7 @@ All changes to this specification SHALL be tracked and versioned appropriately.
 | 1.1     | 2025-12-22 | System | Added structured logging requirements (REQ-SYS-013 through REQ-SYS-022) |
 | 1.2     | 2025-12-22 | System | Added code linting and static analysis requirements (REQ-LINT-001 through REQ-LINT-010) |
 | 1.3     | 2025-12-25 | System | Merged reactive data loading pattern requirements from data-loading-specs.md (REQ-FE-027 through REQ-FE-036) |
+| 1.4     | 2025-12-30 | System | Added JSON enum serialization requirements (REQ-API-007 through REQ-API-008) |
 
 ---
 

--- a/PetCareManager/src/PetCareManager.Api/Program.cs
+++ b/PetCareManager/src/PetCareManager.Api/Program.cs
@@ -1,5 +1,6 @@
 using PetCareManager.Infrastructure;
 using Serilog;
+using System.Text.Json.Serialization;
 
 var builder = WebApplication.CreateBuilder(args);
 
@@ -16,7 +17,11 @@ builder.Host.UseSerilog((context, loggerConfig) =>
 });
 
 // Add services to the container.
-builder.Services.AddControllers();
+builder.Services.AddControllers()
+    .AddJsonOptions(options =>
+    {
+        options.JsonSerializerOptions.Converters.Add(new JsonStringEnumConverter());
+    });
 builder.Services.AddEndpointsApiExplorer();
 builder.Services.AddSwaggerGen(options =>
 {

--- a/PhotographySessionLogger/docs/specs/implementation-specs.md
+++ b/PhotographySessionLogger/docs/specs/implementation-specs.md
@@ -192,6 +192,21 @@ Id
 ### 5.5 CORS Configuration
 **REQ-API-006**: The API SHALL have a CORS policy defined. The origins allowed in the CORS policy SHALL be retrieved from configuration and SHALL include the URLs where the frontend(s) are hosted.
 
+### 5.6 JSON Serialization
+**REQ-API-007**: The API project Program.cs SHALL include the following using statement:
+```csharp
+using System.Text.Json.Serialization;
+```
+
+**REQ-API-008**: The API SHALL configure JSON serialization to handle enums as text strings. The `AddControllers()` call SHALL be configured with `JsonStringEnumConverter`:
+```csharp
+builder.Services.AddControllers()
+    .AddJsonOptions(options =>
+    {
+        options.JsonSerializerOptions.Converters.Add(new JsonStringEnumConverter());
+    });
+```
+
 ---
 
 ## 6. Frontend Requirements
@@ -470,6 +485,7 @@ All changes to this specification SHALL be tracked and versioned appropriately.
 | 1.1     | 2025-12-22 | System | Added structured logging requirements (REQ-SYS-013 through REQ-SYS-022) |
 | 1.2     | 2025-12-22 | System | Added code linting and static analysis requirements (REQ-LINT-001 through REQ-LINT-010) |
 | 1.3     | 2025-12-25 | System | Merged reactive data loading pattern requirements from data-loading-specs.md (REQ-FE-027 through REQ-FE-036) |
+| 1.4     | 2025-12-30 | System | Added JSON enum serialization requirements (REQ-API-007 through REQ-API-008) |
 
 ---
 

--- a/PhotographySessionLogger/src/PhotographySessionLogger.Api/Program.cs
+++ b/PhotographySessionLogger/src/PhotographySessionLogger.Api/Program.cs
@@ -1,5 +1,6 @@
 using PhotographySessionLogger.Infrastructure;
 using Serilog;
+using System.Text.Json.Serialization;
 
 var builder = WebApplication.CreateBuilder(args);
 
@@ -16,7 +17,11 @@ builder.Host.UseSerilog((context, loggerConfig) =>
 });
 
 // Add services to the container.
-builder.Services.AddControllers();
+builder.Services.AddControllers()
+    .AddJsonOptions(options =>
+    {
+        options.JsonSerializerOptions.Converters.Add(new JsonStringEnumConverter());
+    });
 builder.Services.AddEndpointsApiExplorer();
 builder.Services.AddSwaggerGen(options =>
 {

--- a/PokerGameTracker/docs/specs/implementation-specs.md
+++ b/PokerGameTracker/docs/specs/implementation-specs.md
@@ -192,6 +192,21 @@ Id
 ### 5.5 CORS Configuration
 **REQ-API-006**: The API SHALL have a CORS policy defined. The origins allowed in the CORS policy SHALL be retrieved from configuration and SHALL include the URLs where the frontend(s) are hosted.
 
+### 5.6 JSON Serialization
+**REQ-API-007**: The API project Program.cs SHALL include the following using statement:
+```csharp
+using System.Text.Json.Serialization;
+```
+
+**REQ-API-008**: The API SHALL configure JSON serialization to handle enums as text strings. The `AddControllers()` call SHALL be configured with `JsonStringEnumConverter`:
+```csharp
+builder.Services.AddControllers()
+    .AddJsonOptions(options =>
+    {
+        options.JsonSerializerOptions.Converters.Add(new JsonStringEnumConverter());
+    });
+```
+
 ---
 
 ## 6. Frontend Requirements
@@ -470,6 +485,7 @@ All changes to this specification SHALL be tracked and versioned appropriately.
 | 1.1     | 2025-12-22 | System | Added structured logging requirements (REQ-SYS-013 through REQ-SYS-022) |
 | 1.2     | 2025-12-22 | System | Added code linting and static analysis requirements (REQ-LINT-001 through REQ-LINT-010) |
 | 1.3     | 2025-12-25 | System | Merged reactive data loading pattern requirements from data-loading-specs.md (REQ-FE-027 through REQ-FE-036) |
+| 1.4     | 2025-12-30 | System | Added JSON enum serialization requirements (REQ-API-007 through REQ-API-008) |
 
 ---
 

--- a/PokerGameTracker/src/PokerGameTracker.Api/Program.cs
+++ b/PokerGameTracker/src/PokerGameTracker.Api/Program.cs
@@ -2,6 +2,7 @@ using FluentValidation;
 using PokerGameTracker.Infrastructure;
 using Serilog;
 using System.Reflection;
+using System.Text.Json.Serialization;
 
 // Configure Serilog
 Log.Logger = new LoggerConfiguration()
@@ -20,7 +21,11 @@ try
     builder.Host.UseSerilog();
 
     // Add services to the container.
-    builder.Services.AddControllers();
+    builder.Services.AddControllers()
+        .AddJsonOptions(options =>
+        {
+            options.JsonSerializerOptions.Converters.Add(new JsonStringEnumConverter());
+        });
     builder.Services.AddEndpointsApiExplorer();
     builder.Services.AddSwaggerGen(c =>
     {

--- a/ProfessionalNetworkCRM/docs/specs/implementation-specs.md
+++ b/ProfessionalNetworkCRM/docs/specs/implementation-specs.md
@@ -192,6 +192,21 @@ Id
 ### 5.5 CORS Configuration
 **REQ-API-006**: The API SHALL have a CORS policy defined. The origins allowed in the CORS policy SHALL be retrieved from configuration and SHALL include the URLs where the frontend(s) are hosted.
 
+### 5.6 JSON Serialization
+**REQ-API-007**: The API project Program.cs SHALL include the following using statement:
+```csharp
+using System.Text.Json.Serialization;
+```
+
+**REQ-API-008**: The API SHALL configure JSON serialization to handle enums as text strings. The `AddControllers()` call SHALL be configured with `JsonStringEnumConverter`:
+```csharp
+builder.Services.AddControllers()
+    .AddJsonOptions(options =>
+    {
+        options.JsonSerializerOptions.Converters.Add(new JsonStringEnumConverter());
+    });
+```
+
 ---
 
 ## 6. Frontend Requirements
@@ -470,6 +485,7 @@ All changes to this specification SHALL be tracked and versioned appropriately.
 | 1.1     | 2025-12-22 | System | Added structured logging requirements (REQ-SYS-013 through REQ-SYS-022) |
 | 1.2     | 2025-12-22 | System | Added code linting and static analysis requirements (REQ-LINT-001 through REQ-LINT-010) |
 | 1.3     | 2025-12-25 | System | Merged reactive data loading pattern requirements from data-loading-specs.md (REQ-FE-027 through REQ-FE-036) |
+| 1.4     | 2025-12-30 | System | Added JSON enum serialization requirements (REQ-API-007 through REQ-API-008) |
 
 ---
 

--- a/ProfessionalNetworkCRM/src/ProfessionalNetworkCRM.Api/Program.cs
+++ b/ProfessionalNetworkCRM/src/ProfessionalNetworkCRM.Api/Program.cs
@@ -1,5 +1,6 @@
 using ProfessionalNetworkCRM.Infrastructure;
 using Serilog;
+using System.Text.Json.Serialization;
 
 var builder = WebApplication.CreateBuilder(args);
 
@@ -16,7 +17,11 @@ builder.Host.UseSerilog((context, loggerConfig) =>
 });
 
 // Add services to the container.
-builder.Services.AddControllers();
+builder.Services.AddControllers()
+    .AddJsonOptions(options =>
+    {
+        options.JsonSerializerOptions.Converters.Add(new JsonStringEnumConverter());
+    });
 builder.Services.AddEndpointsApiExplorer();
 builder.Services.AddSwaggerGen(options =>
 {

--- a/ProfessionalReadingList/docs/specs/implementation-specs.md
+++ b/ProfessionalReadingList/docs/specs/implementation-specs.md
@@ -192,6 +192,21 @@ Id
 ### 5.5 CORS Configuration
 **REQ-API-006**: The API SHALL have a CORS policy defined. The origins allowed in the CORS policy SHALL be retrieved from configuration and SHALL include the URLs where the frontend(s) are hosted.
 
+### 5.6 JSON Serialization
+**REQ-API-007**: The API project Program.cs SHALL include the following using statement:
+```csharp
+using System.Text.Json.Serialization;
+```
+
+**REQ-API-008**: The API SHALL configure JSON serialization to handle enums as text strings. The `AddControllers()` call SHALL be configured with `JsonStringEnumConverter`:
+```csharp
+builder.Services.AddControllers()
+    .AddJsonOptions(options =>
+    {
+        options.JsonSerializerOptions.Converters.Add(new JsonStringEnumConverter());
+    });
+```
+
 ---
 
 ## 6. Frontend Requirements
@@ -470,6 +485,7 @@ All changes to this specification SHALL be tracked and versioned appropriately.
 | 1.1     | 2025-12-22 | System | Added structured logging requirements (REQ-SYS-013 through REQ-SYS-022) |
 | 1.2     | 2025-12-22 | System | Added code linting and static analysis requirements (REQ-LINT-001 through REQ-LINT-010) |
 | 1.3     | 2025-12-25 | System | Merged reactive data loading pattern requirements from data-loading-specs.md (REQ-FE-027 through REQ-FE-036) |
+| 1.4     | 2025-12-30 | System | Added JSON enum serialization requirements (REQ-API-007 through REQ-API-008) |
 
 ---
 

--- a/ProfessionalReadingList/src/ProfessionalReadingList.Api/Program.cs
+++ b/ProfessionalReadingList/src/ProfessionalReadingList.Api/Program.cs
@@ -1,5 +1,6 @@
 using ProfessionalReadingList.Infrastructure;
 using Serilog;
+using System.Text.Json.Serialization;
 
 var builder = WebApplication.CreateBuilder(args);
 
@@ -16,7 +17,11 @@ builder.Host.UseSerilog((context, loggerConfig) =>
 });
 
 // Add services to the container.
-builder.Services.AddControllers();
+builder.Services.AddControllers()
+    .AddJsonOptions(options =>
+    {
+        options.JsonSerializerOptions.Converters.Add(new JsonStringEnumConverter());
+    });
 builder.Services.AddEndpointsApiExplorer();
 builder.Services.AddSwaggerGen(options =>
 {

--- a/RealEstateInvestmentAnalyzer/docs/specs/implementation-specs.md
+++ b/RealEstateInvestmentAnalyzer/docs/specs/implementation-specs.md
@@ -192,6 +192,21 @@ Id
 ### 5.5 CORS Configuration
 **REQ-API-006**: The API SHALL have a CORS policy defined. The origins allowed in the CORS policy SHALL be retrieved from configuration and SHALL include the URLs where the frontend(s) are hosted.
 
+### 5.6 JSON Serialization
+**REQ-API-007**: The API project Program.cs SHALL include the following using statement:
+```csharp
+using System.Text.Json.Serialization;
+```
+
+**REQ-API-008**: The API SHALL configure JSON serialization to handle enums as text strings. The `AddControllers()` call SHALL be configured with `JsonStringEnumConverter`:
+```csharp
+builder.Services.AddControllers()
+    .AddJsonOptions(options =>
+    {
+        options.JsonSerializerOptions.Converters.Add(new JsonStringEnumConverter());
+    });
+```
+
 ---
 
 ## 6. Frontend Requirements
@@ -470,6 +485,7 @@ All changes to this specification SHALL be tracked and versioned appropriately.
 | 1.1     | 2025-12-22 | System | Added structured logging requirements (REQ-SYS-013 through REQ-SYS-022) |
 | 1.2     | 2025-12-22 | System | Added code linting and static analysis requirements (REQ-LINT-001 through REQ-LINT-010) |
 | 1.3     | 2025-12-25 | System | Merged reactive data loading pattern requirements from data-loading-specs.md (REQ-FE-027 through REQ-FE-036) |
+| 1.4     | 2025-12-30 | System | Added JSON enum serialization requirements (REQ-API-007 through REQ-API-008) |
 
 ---
 

--- a/RealEstateInvestmentAnalyzer/src/RealEstateInvestmentAnalyzer.Api/Program.cs
+++ b/RealEstateInvestmentAnalyzer/src/RealEstateInvestmentAnalyzer.Api/Program.cs
@@ -1,5 +1,6 @@
 using RealEstateInvestmentAnalyzer.Infrastructure;
 using Serilog;
+using System.Text.Json.Serialization;
 
 var builder = WebApplication.CreateBuilder(args);
 
@@ -16,7 +17,11 @@ builder.Host.UseSerilog((context, loggerConfig) =>
 });
 
 // Add services to the container.
-builder.Services.AddControllers();
+builder.Services.AddControllers()
+    .AddJsonOptions(options =>
+    {
+        options.JsonSerializerOptions.Converters.Add(new JsonStringEnumConverter());
+    });
 builder.Services.AddEndpointsApiExplorer();
 builder.Services.AddSwaggerGen(options =>
 {

--- a/RecipeManagerMealPlanner/docs/specs/implementation-specs.md
+++ b/RecipeManagerMealPlanner/docs/specs/implementation-specs.md
@@ -192,6 +192,21 @@ Id
 ### 5.5 CORS Configuration
 **REQ-API-006**: The API SHALL have a CORS policy defined. The origins allowed in the CORS policy SHALL be retrieved from configuration and SHALL include the URLs where the frontend(s) are hosted.
 
+### 5.6 JSON Serialization
+**REQ-API-007**: The API project Program.cs SHALL include the following using statement:
+```csharp
+using System.Text.Json.Serialization;
+```
+
+**REQ-API-008**: The API SHALL configure JSON serialization to handle enums as text strings. The `AddControllers()` call SHALL be configured with `JsonStringEnumConverter`:
+```csharp
+builder.Services.AddControllers()
+    .AddJsonOptions(options =>
+    {
+        options.JsonSerializerOptions.Converters.Add(new JsonStringEnumConverter());
+    });
+```
+
 ---
 
 ## 6. Frontend Requirements
@@ -470,6 +485,7 @@ All changes to this specification SHALL be tracked and versioned appropriately.
 | 1.1     | 2025-12-22 | System | Added structured logging requirements (REQ-SYS-013 through REQ-SYS-022) |
 | 1.2     | 2025-12-22 | System | Added code linting and static analysis requirements (REQ-LINT-001 through REQ-LINT-010) |
 | 1.3     | 2025-12-25 | System | Merged reactive data loading pattern requirements from data-loading-specs.md (REQ-FE-027 through REQ-FE-036) |
+| 1.4     | 2025-12-30 | System | Added JSON enum serialization requirements (REQ-API-007 through REQ-API-008) |
 
 ---
 

--- a/RecipeManagerMealPlanner/src/RecipeManagerMealPlanner.Api/Program.cs
+++ b/RecipeManagerMealPlanner/src/RecipeManagerMealPlanner.Api/Program.cs
@@ -1,5 +1,6 @@
 using RecipeManagerMealPlanner.Infrastructure;
 using Serilog;
+using System.Text.Json.Serialization;
 
 var builder = WebApplication.CreateBuilder(args);
 
@@ -16,7 +17,11 @@ builder.Host.UseSerilog((context, loggerConfig) =>
 });
 
 // Add services to the container.
-builder.Services.AddControllers();
+builder.Services.AddControllers()
+    .AddJsonOptions(options =>
+    {
+        options.JsonSerializerOptions.Converters.Add(new JsonStringEnumConverter());
+    });
 builder.Services.AddEndpointsApiExplorer();
 builder.Services.AddSwaggerGen(options =>
 {

--- a/ResumeCareerAchievementTracker/docs/specs/implementation-specs.md
+++ b/ResumeCareerAchievementTracker/docs/specs/implementation-specs.md
@@ -192,6 +192,21 @@ Id
 ### 5.5 CORS Configuration
 **REQ-API-006**: The API SHALL have a CORS policy defined. The origins allowed in the CORS policy SHALL be retrieved from configuration and SHALL include the URLs where the frontend(s) are hosted.
 
+### 5.6 JSON Serialization
+**REQ-API-007**: The API project Program.cs SHALL include the following using statement:
+```csharp
+using System.Text.Json.Serialization;
+```
+
+**REQ-API-008**: The API SHALL configure JSON serialization to handle enums as text strings. The `AddControllers()` call SHALL be configured with `JsonStringEnumConverter`:
+```csharp
+builder.Services.AddControllers()
+    .AddJsonOptions(options =>
+    {
+        options.JsonSerializerOptions.Converters.Add(new JsonStringEnumConverter());
+    });
+```
+
 ---
 
 ## 6. Frontend Requirements
@@ -470,6 +485,7 @@ All changes to this specification SHALL be tracked and versioned appropriately.
 | 1.1     | 2025-12-22 | System | Added structured logging requirements (REQ-SYS-013 through REQ-SYS-022) |
 | 1.2     | 2025-12-22 | System | Added code linting and static analysis requirements (REQ-LINT-001 through REQ-LINT-010) |
 | 1.3     | 2025-12-25 | System | Merged reactive data loading pattern requirements from data-loading-specs.md (REQ-FE-027 through REQ-FE-036) |
+| 1.4     | 2025-12-30 | System | Added JSON enum serialization requirements (REQ-API-007 through REQ-API-008) |
 
 ---
 

--- a/ResumeCareerAchievementTracker/src/ResumeCareerAchievementTracker.Api/Program.cs
+++ b/ResumeCareerAchievementTracker/src/ResumeCareerAchievementTracker.Api/Program.cs
@@ -1,5 +1,6 @@
 using ResumeCareerAchievementTracker.Infrastructure;
 using Serilog;
+using System.Text.Json.Serialization;
 
 var builder = WebApplication.CreateBuilder(args);
 
@@ -16,7 +17,11 @@ builder.Host.UseSerilog((context, loggerConfig) =>
 });
 
 // Add services to the container.
-builder.Services.AddControllers();
+builder.Services.AddControllers()
+    .AddJsonOptions(options =>
+    {
+        options.JsonSerializerOptions.Converters.Add(new JsonStringEnumConverter());
+    });
 builder.Services.AddEndpointsApiExplorer();
 builder.Services.AddSwaggerGen(options =>
 {

--- a/RetirementSavingsCalculator/docs/specs/implementation-specs.md
+++ b/RetirementSavingsCalculator/docs/specs/implementation-specs.md
@@ -192,6 +192,21 @@ Id
 ### 5.5 CORS Configuration
 **REQ-API-006**: The API SHALL have a CORS policy defined. The origins allowed in the CORS policy SHALL be retrieved from configuration and SHALL include the URLs where the frontend(s) are hosted.
 
+### 5.6 JSON Serialization
+**REQ-API-007**: The API project Program.cs SHALL include the following using statement:
+```csharp
+using System.Text.Json.Serialization;
+```
+
+**REQ-API-008**: The API SHALL configure JSON serialization to handle enums as text strings. The `AddControllers()` call SHALL be configured with `JsonStringEnumConverter`:
+```csharp
+builder.Services.AddControllers()
+    .AddJsonOptions(options =>
+    {
+        options.JsonSerializerOptions.Converters.Add(new JsonStringEnumConverter());
+    });
+```
+
 ---
 
 ## 6. Frontend Requirements
@@ -470,6 +485,7 @@ All changes to this specification SHALL be tracked and versioned appropriately.
 | 1.1     | 2025-12-22 | System | Added structured logging requirements (REQ-SYS-013 through REQ-SYS-022) |
 | 1.2     | 2025-12-22 | System | Added code linting and static analysis requirements (REQ-LINT-001 through REQ-LINT-010) |
 | 1.3     | 2025-12-25 | System | Merged reactive data loading pattern requirements from data-loading-specs.md (REQ-FE-027 through REQ-FE-036) |
+| 1.4     | 2025-12-30 | System | Added JSON enum serialization requirements (REQ-API-007 through REQ-API-008) |
 
 ---
 

--- a/RetirementSavingsCalculator/src/RetirementSavingsCalculator.Api/Program.cs
+++ b/RetirementSavingsCalculator/src/RetirementSavingsCalculator.Api/Program.cs
@@ -1,5 +1,6 @@
 using RetirementSavingsCalculator.Infrastructure;
 using Serilog;
+using System.Text.Json.Serialization;
 
 var builder = WebApplication.CreateBuilder(args);
 
@@ -16,7 +17,11 @@ builder.Host.UseSerilog((context, loggerConfig) =>
 });
 
 // Add services to the container.
-builder.Services.AddControllers();
+builder.Services.AddControllers()
+    .AddJsonOptions(options =>
+    {
+        options.JsonSerializerOptions.Converters.Add(new JsonStringEnumConverter());
+    });
 builder.Services.AddEndpointsApiExplorer();
 builder.Services.AddSwaggerGen(options =>
 {

--- a/RoadsideAssistanceInfoHub/docs/specs/implementation-specs.md
+++ b/RoadsideAssistanceInfoHub/docs/specs/implementation-specs.md
@@ -192,6 +192,21 @@ Id
 ### 5.5 CORS Configuration
 **REQ-API-006**: The API SHALL have a CORS policy defined. The origins allowed in the CORS policy SHALL be retrieved from configuration and SHALL include the URLs where the frontend(s) are hosted.
 
+### 5.6 JSON Serialization
+**REQ-API-007**: The API project Program.cs SHALL include the following using statement:
+```csharp
+using System.Text.Json.Serialization;
+```
+
+**REQ-API-008**: The API SHALL configure JSON serialization to handle enums as text strings. The `AddControllers()` call SHALL be configured with `JsonStringEnumConverter`:
+```csharp
+builder.Services.AddControllers()
+    .AddJsonOptions(options =>
+    {
+        options.JsonSerializerOptions.Converters.Add(new JsonStringEnumConverter());
+    });
+```
+
 ---
 
 ## 6. Frontend Requirements
@@ -470,6 +485,7 @@ All changes to this specification SHALL be tracked and versioned appropriately.
 | 1.1     | 2025-12-22 | System | Added structured logging requirements (REQ-SYS-013 through REQ-SYS-022) |
 | 1.2     | 2025-12-22 | System | Added code linting and static analysis requirements (REQ-LINT-001 through REQ-LINT-010) |
 | 1.3     | 2025-12-25 | System | Merged reactive data loading pattern requirements from data-loading-specs.md (REQ-FE-027 through REQ-FE-036) |
+| 1.4     | 2025-12-30 | System | Added JSON enum serialization requirements (REQ-API-007 through REQ-API-008) |
 
 ---
 

--- a/RoadsideAssistanceInfoHub/src/RoadsideAssistanceInfoHub.Api/Program.cs
+++ b/RoadsideAssistanceInfoHub/src/RoadsideAssistanceInfoHub.Api/Program.cs
@@ -1,5 +1,6 @@
 using RoadsideAssistanceInfoHub.Infrastructure;
 using Serilog;
+using System.Text.Json.Serialization;
 
 var builder = WebApplication.CreateBuilder(args);
 
@@ -16,7 +17,11 @@ builder.Host.UseSerilog((context, loggerConfig) =>
 });
 
 // Add services to the container.
-builder.Services.AddControllers();
+builder.Services.AddControllers()
+    .AddJsonOptions(options =>
+    {
+        options.JsonSerializerOptions.Converters.Add(new JsonStringEnumConverter());
+    });
 builder.Services.AddEndpointsApiExplorer();
 builder.Services.AddSwaggerGen(options =>
 {

--- a/RunningLogRaceTracker/docs/specs/implementation-specs.md
+++ b/RunningLogRaceTracker/docs/specs/implementation-specs.md
@@ -192,6 +192,21 @@ Id
 ### 5.5 CORS Configuration
 **REQ-API-006**: The API SHALL have a CORS policy defined. The origins allowed in the CORS policy SHALL be retrieved from configuration and SHALL include the URLs where the frontend(s) are hosted.
 
+### 5.6 JSON Serialization
+**REQ-API-007**: The API project Program.cs SHALL include the following using statement:
+```csharp
+using System.Text.Json.Serialization;
+```
+
+**REQ-API-008**: The API SHALL configure JSON serialization to handle enums as text strings. The `AddControllers()` call SHALL be configured with `JsonStringEnumConverter`:
+```csharp
+builder.Services.AddControllers()
+    .AddJsonOptions(options =>
+    {
+        options.JsonSerializerOptions.Converters.Add(new JsonStringEnumConverter());
+    });
+```
+
 ---
 
 ## 6. Frontend Requirements
@@ -470,6 +485,7 @@ All changes to this specification SHALL be tracked and versioned appropriately.
 | 1.1     | 2025-12-22 | System | Added structured logging requirements (REQ-SYS-013 through REQ-SYS-022) |
 | 1.2     | 2025-12-22 | System | Added code linting and static analysis requirements (REQ-LINT-001 through REQ-LINT-010) |
 | 1.3     | 2025-12-25 | System | Merged reactive data loading pattern requirements from data-loading-specs.md (REQ-FE-027 through REQ-FE-036) |
+| 1.4     | 2025-12-30 | System | Added JSON enum serialization requirements (REQ-API-007 through REQ-API-008) |
 
 ---
 

--- a/RunningLogRaceTracker/src/RunningLogRaceTracker.Api/Program.cs
+++ b/RunningLogRaceTracker/src/RunningLogRaceTracker.Api/Program.cs
@@ -3,6 +3,7 @@ using RunningLogRaceTracker.Infrastructure;
 using Microsoft.EntityFrameworkCore;
 using Serilog;
 using Serilog.Events;
+using System.Text.Json.Serialization;
 
 // Configure Serilog
 Log.Logger = new LoggerConfiguration()
@@ -25,7 +26,11 @@ try
     builder.Host.UseSerilog();
 
     // Add services to the container
-    builder.Services.AddControllers();
+    builder.Services.AddControllers()
+        .AddJsonOptions(options =>
+        {
+            options.JsonSerializerOptions.Converters.Add(new JsonStringEnumConverter());
+        });
     builder.Services.AddEndpointsApiExplorer();
     builder.Services.AddSwaggerGen();
 

--- a/SalaryCompensationTracker/docs/specs/implementation-specs.md
+++ b/SalaryCompensationTracker/docs/specs/implementation-specs.md
@@ -192,6 +192,21 @@ Id
 ### 5.5 CORS Configuration
 **REQ-API-006**: The API SHALL have a CORS policy defined. The origins allowed in the CORS policy SHALL be retrieved from configuration and SHALL include the URLs where the frontend(s) are hosted.
 
+### 5.6 JSON Serialization
+**REQ-API-007**: The API project Program.cs SHALL include the following using statement:
+```csharp
+using System.Text.Json.Serialization;
+```
+
+**REQ-API-008**: The API SHALL configure JSON serialization to handle enums as text strings. The `AddControllers()` call SHALL be configured with `JsonStringEnumConverter`:
+```csharp
+builder.Services.AddControllers()
+    .AddJsonOptions(options =>
+    {
+        options.JsonSerializerOptions.Converters.Add(new JsonStringEnumConverter());
+    });
+```
+
 ---
 
 ## 6. Frontend Requirements
@@ -470,6 +485,7 @@ All changes to this specification SHALL be tracked and versioned appropriately.
 | 1.1     | 2025-12-22 | System | Added structured logging requirements (REQ-SYS-013 through REQ-SYS-022) |
 | 1.2     | 2025-12-22 | System | Added code linting and static analysis requirements (REQ-LINT-001 through REQ-LINT-010) |
 | 1.3     | 2025-12-25 | System | Merged reactive data loading pattern requirements from data-loading-specs.md (REQ-FE-027 through REQ-FE-036) |
+| 1.4     | 2025-12-30 | System | Added JSON enum serialization requirements (REQ-API-007 through REQ-API-008) |
 
 ---
 

--- a/SalaryCompensationTracker/src/SalaryCompensationTracker.Api/Program.cs
+++ b/SalaryCompensationTracker/src/SalaryCompensationTracker.Api/Program.cs
@@ -1,5 +1,6 @@
 using SalaryCompensationTracker.Infrastructure;
 using Serilog;
+using System.Text.Json.Serialization;
 
 var builder = WebApplication.CreateBuilder(args);
 
@@ -16,7 +17,11 @@ builder.Host.UseSerilog((context, loggerConfig) =>
 });
 
 // Add services to the container.
-builder.Services.AddControllers();
+builder.Services.AddControllers()
+    .AddJsonOptions(options =>
+    {
+        options.JsonSerializerOptions.Converters.Add(new JsonStringEnumConverter());
+    });
 builder.Services.AddEndpointsApiExplorer();
 builder.Services.AddSwaggerGen(options =>
 {

--- a/SideHustleIncomeTracker/docs/specs/implementation-specs.md
+++ b/SideHustleIncomeTracker/docs/specs/implementation-specs.md
@@ -192,6 +192,21 @@ Id
 ### 5.5 CORS Configuration
 **REQ-API-006**: The API SHALL have a CORS policy defined. The origins allowed in the CORS policy SHALL be retrieved from configuration and SHALL include the URLs where the frontend(s) are hosted.
 
+### 5.6 JSON Serialization
+**REQ-API-007**: The API project Program.cs SHALL include the following using statement:
+```csharp
+using System.Text.Json.Serialization;
+```
+
+**REQ-API-008**: The API SHALL configure JSON serialization to handle enums as text strings. The `AddControllers()` call SHALL be configured with `JsonStringEnumConverter`:
+```csharp
+builder.Services.AddControllers()
+    .AddJsonOptions(options =>
+    {
+        options.JsonSerializerOptions.Converters.Add(new JsonStringEnumConverter());
+    });
+```
+
 ---
 
 ## 6. Frontend Requirements
@@ -470,6 +485,7 @@ All changes to this specification SHALL be tracked and versioned appropriately.
 | 1.1     | 2025-12-22 | System | Added structured logging requirements (REQ-SYS-013 through REQ-SYS-022) |
 | 1.2     | 2025-12-22 | System | Added code linting and static analysis requirements (REQ-LINT-001 through REQ-LINT-010) |
 | 1.3     | 2025-12-25 | System | Merged reactive data loading pattern requirements from data-loading-specs.md (REQ-FE-027 through REQ-FE-036) |
+| 1.4     | 2025-12-30 | System | Added JSON enum serialization requirements (REQ-API-007 through REQ-API-008) |
 
 ---
 

--- a/SideHustleIncomeTracker/src/SideHustleIncomeTracker.Api/Program.cs
+++ b/SideHustleIncomeTracker/src/SideHustleIncomeTracker.Api/Program.cs
@@ -1,5 +1,6 @@
 using SideHustleIncomeTracker.Infrastructure;
 using Serilog;
+using System.Text.Json.Serialization;
 
 var builder = WebApplication.CreateBuilder(args);
 
@@ -16,7 +17,11 @@ builder.Host.UseSerilog((context, loggerConfig) =>
 });
 
 // Add services to the container.
-builder.Services.AddControllers();
+builder.Services.AddControllers()
+    .AddJsonOptions(options =>
+    {
+        options.JsonSerializerOptions.Converters.Add(new JsonStringEnumConverter());
+    });
 builder.Services.AddEndpointsApiExplorer();
 builder.Services.AddSwaggerGen(options =>
 {

--- a/SkillDevelopmentTracker/docs/specs/implementation-specs.md
+++ b/SkillDevelopmentTracker/docs/specs/implementation-specs.md
@@ -192,6 +192,21 @@ Id
 ### 5.5 CORS Configuration
 **REQ-API-006**: The API SHALL have a CORS policy defined. The origins allowed in the CORS policy SHALL be retrieved from configuration and SHALL include the URLs where the frontend(s) are hosted.
 
+### 5.6 JSON Serialization
+**REQ-API-007**: The API project Program.cs SHALL include the following using statement:
+```csharp
+using System.Text.Json.Serialization;
+```
+
+**REQ-API-008**: The API SHALL configure JSON serialization to handle enums as text strings. The `AddControllers()` call SHALL be configured with `JsonStringEnumConverter`:
+```csharp
+builder.Services.AddControllers()
+    .AddJsonOptions(options =>
+    {
+        options.JsonSerializerOptions.Converters.Add(new JsonStringEnumConverter());
+    });
+```
+
 ---
 
 ## 6. Frontend Requirements
@@ -470,6 +485,7 @@ All changes to this specification SHALL be tracked and versioned appropriately.
 | 1.1     | 2025-12-22 | System | Added structured logging requirements (REQ-SYS-013 through REQ-SYS-022) |
 | 1.2     | 2025-12-22 | System | Added code linting and static analysis requirements (REQ-LINT-001 through REQ-LINT-010) |
 | 1.3     | 2025-12-25 | System | Merged reactive data loading pattern requirements from data-loading-specs.md (REQ-FE-027 through REQ-FE-036) |
+| 1.4     | 2025-12-30 | System | Added JSON enum serialization requirements (REQ-API-007 through REQ-API-008) |
 
 ---
 

--- a/SkillDevelopmentTracker/src/SkillDevelopmentTracker.Api/Program.cs
+++ b/SkillDevelopmentTracker/src/SkillDevelopmentTracker.Api/Program.cs
@@ -1,5 +1,6 @@
 using SkillDevelopmentTracker.Infrastructure;
 using Serilog;
+using System.Text.Json.Serialization;
 
 var builder = WebApplication.CreateBuilder(args);
 
@@ -16,7 +17,11 @@ builder.Host.UseSerilog((context, loggerConfig) =>
 });
 
 // Add services to the container.
-builder.Services.AddControllers();
+builder.Services.AddControllers()
+    .AddJsonOptions(options =>
+    {
+        options.JsonSerializerOptions.Converters.Add(new JsonStringEnumConverter());
+    });
 builder.Services.AddEndpointsApiExplorer();
 builder.Services.AddSwaggerGen(options =>
 {

--- a/SleepQualityTracker/docs/specs/implementation-specs.md
+++ b/SleepQualityTracker/docs/specs/implementation-specs.md
@@ -192,6 +192,21 @@ Id
 ### 5.5 CORS Configuration
 **REQ-API-006**: The API SHALL have a CORS policy defined. The origins allowed in the CORS policy SHALL be retrieved from configuration and SHALL include the URLs where the frontend(s) are hosted.
 
+### 5.6 JSON Serialization
+**REQ-API-007**: The API project Program.cs SHALL include the following using statement:
+```csharp
+using System.Text.Json.Serialization;
+```
+
+**REQ-API-008**: The API SHALL configure JSON serialization to handle enums as text strings. The `AddControllers()` call SHALL be configured with `JsonStringEnumConverter`:
+```csharp
+builder.Services.AddControllers()
+    .AddJsonOptions(options =>
+    {
+        options.JsonSerializerOptions.Converters.Add(new JsonStringEnumConverter());
+    });
+```
+
 ---
 
 ## 6. Frontend Requirements
@@ -470,6 +485,7 @@ All changes to this specification SHALL be tracked and versioned appropriately.
 | 1.1     | 2025-12-22 | System | Added structured logging requirements (REQ-SYS-013 through REQ-SYS-022) |
 | 1.2     | 2025-12-22 | System | Added code linting and static analysis requirements (REQ-LINT-001 through REQ-LINT-010) |
 | 1.3     | 2025-12-25 | System | Merged reactive data loading pattern requirements from data-loading-specs.md (REQ-FE-027 through REQ-FE-036) |
+| 1.4     | 2025-12-30 | System | Added JSON enum serialization requirements (REQ-API-007 through REQ-API-008) |
 
 ---
 

--- a/SleepQualityTracker/src/SleepQualityTracker.Api/Program.cs
+++ b/SleepQualityTracker/src/SleepQualityTracker.Api/Program.cs
@@ -1,5 +1,6 @@
 using SleepQualityTracker.Infrastructure;
 using Serilog;
+using System.Text.Json.Serialization;
 
 var builder = WebApplication.CreateBuilder(args);
 
@@ -16,7 +17,11 @@ builder.Host.UseSerilog((context, loggerConfig) =>
 });
 
 // Add services to the container.
-builder.Services.AddControllers();
+builder.Services.AddControllers()
+    .AddJsonOptions(options =>
+    {
+        options.JsonSerializerOptions.Converters.Add(new JsonStringEnumConverter());
+    });
 builder.Services.AddEndpointsApiExplorer();
 builder.Services.AddSwaggerGen(options =>
 {

--- a/SportsTeamFollowingTracker/docs/specs/implementation-specs.md
+++ b/SportsTeamFollowingTracker/docs/specs/implementation-specs.md
@@ -192,6 +192,21 @@ Id
 ### 5.5 CORS Configuration
 **REQ-API-006**: The API SHALL have a CORS policy defined. The origins allowed in the CORS policy SHALL be retrieved from configuration and SHALL include the URLs where the frontend(s) are hosted.
 
+### 5.6 JSON Serialization
+**REQ-API-007**: The API project Program.cs SHALL include the following using statement:
+```csharp
+using System.Text.Json.Serialization;
+```
+
+**REQ-API-008**: The API SHALL configure JSON serialization to handle enums as text strings. The `AddControllers()` call SHALL be configured with `JsonStringEnumConverter`:
+```csharp
+builder.Services.AddControllers()
+    .AddJsonOptions(options =>
+    {
+        options.JsonSerializerOptions.Converters.Add(new JsonStringEnumConverter());
+    });
+```
+
 ---
 
 ## 6. Frontend Requirements
@@ -470,6 +485,7 @@ All changes to this specification SHALL be tracked and versioned appropriately.
 | 1.1     | 2025-12-22 | System | Added structured logging requirements (REQ-SYS-013 through REQ-SYS-022) |
 | 1.2     | 2025-12-22 | System | Added code linting and static analysis requirements (REQ-LINT-001 through REQ-LINT-010) |
 | 1.3     | 2025-12-25 | System | Merged reactive data loading pattern requirements from data-loading-specs.md (REQ-FE-027 through REQ-FE-036) |
+| 1.4     | 2025-12-30 | System | Added JSON enum serialization requirements (REQ-API-007 through REQ-API-008) |
 
 ---
 

--- a/SportsTeamFollowingTracker/src/SportsTeamFollowingTracker.Api/Program.cs
+++ b/SportsTeamFollowingTracker/src/SportsTeamFollowingTracker.Api/Program.cs
@@ -1,5 +1,6 @@
 using SportsTeamFollowingTracker.Infrastructure;
 using Serilog;
+using System.Text.Json.Serialization;
 
 var builder = WebApplication.CreateBuilder(args);
 
@@ -16,7 +17,11 @@ builder.Host.UseSerilog((context, loggerConfig) =>
 });
 
 // Add services to the container.
-builder.Services.AddControllers();
+builder.Services.AddControllers()
+    .AddJsonOptions(options =>
+    {
+        options.JsonSerializerOptions.Converters.Add(new JsonStringEnumConverter());
+    });
 builder.Services.AddEndpointsApiExplorer();
 builder.Services.AddSwaggerGen(options =>
 {

--- a/StressMoodTracker/docs/specs/implementation-specs.md
+++ b/StressMoodTracker/docs/specs/implementation-specs.md
@@ -192,6 +192,21 @@ Id
 ### 5.5 CORS Configuration
 **REQ-API-006**: The API SHALL have a CORS policy defined. The origins allowed in the CORS policy SHALL be retrieved from configuration and SHALL include the URLs where the frontend(s) are hosted.
 
+### 5.6 JSON Serialization
+**REQ-API-007**: The API project Program.cs SHALL include the following using statement:
+```csharp
+using System.Text.Json.Serialization;
+```
+
+**REQ-API-008**: The API SHALL configure JSON serialization to handle enums as text strings. The `AddControllers()` call SHALL be configured with `JsonStringEnumConverter`:
+```csharp
+builder.Services.AddControllers()
+    .AddJsonOptions(options =>
+    {
+        options.JsonSerializerOptions.Converters.Add(new JsonStringEnumConverter());
+    });
+```
+
 ---
 
 ## 6. Frontend Requirements
@@ -470,6 +485,7 @@ All changes to this specification SHALL be tracked and versioned appropriately.
 | 1.1     | 2025-12-22 | System | Added structured logging requirements (REQ-SYS-013 through REQ-SYS-022) |
 | 1.2     | 2025-12-22 | System | Added code linting and static analysis requirements (REQ-LINT-001 through REQ-LINT-010) |
 | 1.3     | 2025-12-25 | System | Merged reactive data loading pattern requirements from data-loading-specs.md (REQ-FE-027 through REQ-FE-036) |
+| 1.4     | 2025-12-30 | System | Added JSON enum serialization requirements (REQ-API-007 through REQ-API-008) |
 
 ---
 

--- a/StressMoodTracker/src/StressMoodTracker.Api/Program.cs
+++ b/StressMoodTracker/src/StressMoodTracker.Api/Program.cs
@@ -1,5 +1,6 @@
 using StressMoodTracker.Infrastructure;
 using Serilog;
+using System.Text.Json.Serialization;
 
 var builder = WebApplication.CreateBuilder(args);
 
@@ -16,7 +17,11 @@ builder.Host.UseSerilog((context, loggerConfig) =>
 });
 
 // Add services to the container.
-builder.Services.AddControllers();
+builder.Services.AddControllers()
+    .AddJsonOptions(options =>
+    {
+        options.JsonSerializerOptions.Converters.Add(new JsonStringEnumConverter());
+    });
 builder.Services.AddEndpointsApiExplorer();
 builder.Services.AddSwaggerGen(options =>
 {

--- a/SubscriptionAuditTool/docs/specs/implementation-specs.md
+++ b/SubscriptionAuditTool/docs/specs/implementation-specs.md
@@ -192,6 +192,21 @@ Id
 ### 5.5 CORS Configuration
 **REQ-API-006**: The API SHALL have a CORS policy defined. The origins allowed in the CORS policy SHALL be retrieved from configuration and SHALL include the URLs where the frontend(s) are hosted.
 
+### 5.6 JSON Serialization
+**REQ-API-007**: The API project Program.cs SHALL include the following using statement:
+```csharp
+using System.Text.Json.Serialization;
+```
+
+**REQ-API-008**: The API SHALL configure JSON serialization to handle enums as text strings. The `AddControllers()` call SHALL be configured with `JsonStringEnumConverter`:
+```csharp
+builder.Services.AddControllers()
+    .AddJsonOptions(options =>
+    {
+        options.JsonSerializerOptions.Converters.Add(new JsonStringEnumConverter());
+    });
+```
+
 ---
 
 ## 6. Frontend Requirements
@@ -470,6 +485,7 @@ All changes to this specification SHALL be tracked and versioned appropriately.
 | 1.1     | 2025-12-22 | System | Added structured logging requirements (REQ-SYS-013 through REQ-SYS-022) |
 | 1.2     | 2025-12-22 | System | Added code linting and static analysis requirements (REQ-LINT-001 through REQ-LINT-010) |
 | 1.3     | 2025-12-25 | System | Merged reactive data loading pattern requirements from data-loading-specs.md (REQ-FE-027 through REQ-FE-036) |
+| 1.4     | 2025-12-30 | System | Added JSON enum serialization requirements (REQ-API-007 through REQ-API-008) |
 
 ---
 

--- a/SubscriptionAuditTool/src/SubscriptionAuditTool.Api/Program.cs
+++ b/SubscriptionAuditTool/src/SubscriptionAuditTool.Api/Program.cs
@@ -1,6 +1,7 @@
 using SubscriptionAuditTool.Infrastructure;
 using SubscriptionAuditTool.Infrastructure.Data;
 using Serilog;
+using System.Text.Json.Serialization;
 
 var builder = WebApplication.CreateBuilder(args);
 
@@ -17,7 +18,11 @@ builder.Host.UseSerilog((context, loggerConfig) =>
 });
 
 // Add services to the container.
-builder.Services.AddControllers();
+builder.Services.AddControllers()
+    .AddJsonOptions(options =>
+    {
+        options.JsonSerializerOptions.Converters.Add(new JsonStringEnumConverter());
+    });
 builder.Services.AddEndpointsApiExplorer();
 builder.Services.AddSwaggerGen(options =>
 {

--- a/TaxDeductionOrganizer/docs/specs/implementation-specs.md
+++ b/TaxDeductionOrganizer/docs/specs/implementation-specs.md
@@ -192,6 +192,21 @@ Id
 ### 5.5 CORS Configuration
 **REQ-API-006**: The API SHALL have a CORS policy defined. The origins allowed in the CORS policy SHALL be retrieved from configuration and SHALL include the URLs where the frontend(s) are hosted.
 
+### 5.6 JSON Serialization
+**REQ-API-007**: The API project Program.cs SHALL include the following using statement:
+```csharp
+using System.Text.Json.Serialization;
+```
+
+**REQ-API-008**: The API SHALL configure JSON serialization to handle enums as text strings. The `AddControllers()` call SHALL be configured with `JsonStringEnumConverter`:
+```csharp
+builder.Services.AddControllers()
+    .AddJsonOptions(options =>
+    {
+        options.JsonSerializerOptions.Converters.Add(new JsonStringEnumConverter());
+    });
+```
+
 ---
 
 ## 6. Frontend Requirements
@@ -470,6 +485,7 @@ All changes to this specification SHALL be tracked and versioned appropriately.
 | 1.1     | 2025-12-22 | System | Added structured logging requirements (REQ-SYS-013 through REQ-SYS-022) |
 | 1.2     | 2025-12-22 | System | Added code linting and static analysis requirements (REQ-LINT-001 through REQ-LINT-010) |
 | 1.3     | 2025-12-25 | System | Merged reactive data loading pattern requirements from data-loading-specs.md (REQ-FE-027 through REQ-FE-036) |
+| 1.4     | 2025-12-30 | System | Added JSON enum serialization requirements (REQ-API-007 through REQ-API-008) |
 
 ---
 

--- a/TaxDeductionOrganizer/src/TaxDeductionOrganizer.Api/Program.cs
+++ b/TaxDeductionOrganizer/src/TaxDeductionOrganizer.Api/Program.cs
@@ -1,4 +1,5 @@
 using Serilog;
+using System.Text.Json.Serialization;
 using TaxDeductionOrganizer.Infrastructure;
 
 var builder = WebApplication.CreateBuilder(args);
@@ -12,7 +13,11 @@ builder.Host.UseSerilog((context, services, configuration) => configuration
     .Enrich.WithThreadId());
 
 // Add services to the container.
-builder.Services.AddControllers();
+builder.Services.AddControllers()
+    .AddJsonOptions(options =>
+    {
+        options.JsonSerializerOptions.Converters.Add(new JsonStringEnumConverter());
+    });
 builder.Services.AddEndpointsApiExplorer();
 builder.Services.AddSwaggerGen(c =>
 {

--- a/TimeAuditTracker/docs/specs/implementation-specs.md
+++ b/TimeAuditTracker/docs/specs/implementation-specs.md
@@ -192,6 +192,21 @@ Id
 ### 5.5 CORS Configuration
 **REQ-API-006**: The API SHALL have a CORS policy defined. The origins allowed in the CORS policy SHALL be retrieved from configuration and SHALL include the URLs where the frontend(s) are hosted.
 
+### 5.6 JSON Serialization
+**REQ-API-007**: The API project Program.cs SHALL include the following using statement:
+```csharp
+using System.Text.Json.Serialization;
+```
+
+**REQ-API-008**: The API SHALL configure JSON serialization to handle enums as text strings. The `AddControllers()` call SHALL be configured with `JsonStringEnumConverter`:
+```csharp
+builder.Services.AddControllers()
+    .AddJsonOptions(options =>
+    {
+        options.JsonSerializerOptions.Converters.Add(new JsonStringEnumConverter());
+    });
+```
+
 ---
 
 ## 6. Frontend Requirements
@@ -470,6 +485,7 @@ All changes to this specification SHALL be tracked and versioned appropriately.
 | 1.1     | 2025-12-22 | System | Added structured logging requirements (REQ-SYS-013 through REQ-SYS-022) |
 | 1.2     | 2025-12-22 | System | Added code linting and static analysis requirements (REQ-LINT-001 through REQ-LINT-010) |
 | 1.3     | 2025-12-25 | System | Merged reactive data loading pattern requirements from data-loading-specs.md (REQ-FE-027 through REQ-FE-036) |
+| 1.4     | 2025-12-30 | System | Added JSON enum serialization requirements (REQ-API-007 through REQ-API-008) |
 
 ---
 

--- a/TimeAuditTracker/src/TimeAuditTracker.Api/Program.cs
+++ b/TimeAuditTracker/src/TimeAuditTracker.Api/Program.cs
@@ -1,5 +1,6 @@
 using TimeAuditTracker.Infrastructure;
 using Serilog;
+using System.Text.Json.Serialization;
 
 var builder = WebApplication.CreateBuilder(args);
 
@@ -16,7 +17,11 @@ builder.Host.UseSerilog((context, loggerConfig) =>
 });
 
 // Add services to the container.
-builder.Services.AddControllers();
+builder.Services.AddControllers()
+    .AddJsonOptions(options =>
+    {
+        options.JsonSerializerOptions.Converters.Add(new JsonStringEnumConverter());
+    });
 builder.Services.AddEndpointsApiExplorer();
 builder.Services.AddSwaggerGen(options =>
 {

--- a/TravelDestinationWishlist/docs/specs/implementation-specs.md
+++ b/TravelDestinationWishlist/docs/specs/implementation-specs.md
@@ -192,6 +192,21 @@ Id
 ### 5.5 CORS Configuration
 **REQ-API-006**: The API SHALL have a CORS policy defined. The origins allowed in the CORS policy SHALL be retrieved from configuration and SHALL include the URLs where the frontend(s) are hosted.
 
+### 5.6 JSON Serialization
+**REQ-API-007**: The API project Program.cs SHALL include the following using statement:
+```csharp
+using System.Text.Json.Serialization;
+```
+
+**REQ-API-008**: The API SHALL configure JSON serialization to handle enums as text strings. The `AddControllers()` call SHALL be configured with `JsonStringEnumConverter`:
+```csharp
+builder.Services.AddControllers()
+    .AddJsonOptions(options =>
+    {
+        options.JsonSerializerOptions.Converters.Add(new JsonStringEnumConverter());
+    });
+```
+
 ---
 
 ## 6. Frontend Requirements
@@ -470,6 +485,7 @@ All changes to this specification SHALL be tracked and versioned appropriately.
 | 1.1     | 2025-12-22 | System | Added structured logging requirements (REQ-SYS-013 through REQ-SYS-022) |
 | 1.2     | 2025-12-22 | System | Added code linting and static analysis requirements (REQ-LINT-001 through REQ-LINT-010) |
 | 1.3     | 2025-12-25 | System | Merged reactive data loading pattern requirements from data-loading-specs.md (REQ-FE-027 through REQ-FE-036) |
+| 1.4     | 2025-12-30 | System | Added JSON enum serialization requirements (REQ-API-007 through REQ-API-008) |
 
 ---
 

--- a/TravelDestinationWishlist/src/TravelDestinationWishlist.Api/Program.cs
+++ b/TravelDestinationWishlist/src/TravelDestinationWishlist.Api/Program.cs
@@ -1,5 +1,6 @@
 using TravelDestinationWishlist.Infrastructure;
 using Serilog;
+using System.Text.Json.Serialization;
 
 var builder = WebApplication.CreateBuilder(args);
 
@@ -16,7 +17,11 @@ builder.Host.UseSerilog((context, loggerConfig) =>
 });
 
 // Add services to the container.
-builder.Services.AddControllers();
+builder.Services.AddControllers()
+    .AddJsonOptions(options =>
+    {
+        options.JsonSerializerOptions.Converters.Add(new JsonStringEnumConverter());
+    });
 builder.Services.AddEndpointsApiExplorer();
 builder.Services.AddSwaggerGen(options =>
 {

--- a/VehicleMaintenanceLogger/docs/specs/implementation-specs.md
+++ b/VehicleMaintenanceLogger/docs/specs/implementation-specs.md
@@ -192,6 +192,21 @@ Id
 ### 5.5 CORS Configuration
 **REQ-API-006**: The API SHALL have a CORS policy defined. The origins allowed in the CORS policy SHALL be retrieved from configuration and SHALL include the URLs where the frontend(s) are hosted.
 
+### 5.6 JSON Serialization
+**REQ-API-007**: The API project Program.cs SHALL include the following using statement:
+```csharp
+using System.Text.Json.Serialization;
+```
+
+**REQ-API-008**: The API SHALL configure JSON serialization to handle enums as text strings. The `AddControllers()` call SHALL be configured with `JsonStringEnumConverter`:
+```csharp
+builder.Services.AddControllers()
+    .AddJsonOptions(options =>
+    {
+        options.JsonSerializerOptions.Converters.Add(new JsonStringEnumConverter());
+    });
+```
+
 ---
 
 ## 6. Frontend Requirements
@@ -470,6 +485,7 @@ All changes to this specification SHALL be tracked and versioned appropriately.
 | 1.1     | 2025-12-22 | System | Added structured logging requirements (REQ-SYS-013 through REQ-SYS-022) |
 | 1.2     | 2025-12-22 | System | Added code linting and static analysis requirements (REQ-LINT-001 through REQ-LINT-010) |
 | 1.3     | 2025-12-25 | System | Merged reactive data loading pattern requirements from data-loading-specs.md (REQ-FE-027 through REQ-FE-036) |
+| 1.4     | 2025-12-30 | System | Added JSON enum serialization requirements (REQ-API-007 through REQ-API-008) |
 
 ---
 

--- a/VehicleMaintenanceLogger/src/VehicleMaintenanceLogger.Api/Program.cs
+++ b/VehicleMaintenanceLogger/src/VehicleMaintenanceLogger.Api/Program.cs
@@ -1,5 +1,6 @@
 using VehicleMaintenanceLogger.Infrastructure;
 using Serilog;
+using System.Text.Json.Serialization;
 
 var builder = WebApplication.CreateBuilder(args);
 
@@ -16,7 +17,11 @@ builder.Host.UseSerilog((context, loggerConfig) =>
 });
 
 // Add services to the container.
-builder.Services.AddControllers();
+builder.Services.AddControllers()
+    .AddJsonOptions(options =>
+    {
+        options.JsonSerializerOptions.Converters.Add(new JsonStringEnumConverter());
+    });
 builder.Services.AddEndpointsApiExplorer();
 builder.Services.AddSwaggerGen(options =>
 {

--- a/VehicleValueTracker/docs/specs/implementation-specs.md
+++ b/VehicleValueTracker/docs/specs/implementation-specs.md
@@ -192,6 +192,21 @@ Id
 ### 5.5 CORS Configuration
 **REQ-API-006**: The API SHALL have a CORS policy defined. The origins allowed in the CORS policy SHALL be retrieved from configuration and SHALL include the URLs where the frontend(s) are hosted.
 
+### 5.6 JSON Serialization
+**REQ-API-007**: The API project Program.cs SHALL include the following using statement:
+```csharp
+using System.Text.Json.Serialization;
+```
+
+**REQ-API-008**: The API SHALL configure JSON serialization to handle enums as text strings. The `AddControllers()` call SHALL be configured with `JsonStringEnumConverter`:
+```csharp
+builder.Services.AddControllers()
+    .AddJsonOptions(options =>
+    {
+        options.JsonSerializerOptions.Converters.Add(new JsonStringEnumConverter());
+    });
+```
+
 ---
 
 ## 6. Frontend Requirements
@@ -470,6 +485,7 @@ All changes to this specification SHALL be tracked and versioned appropriately.
 | 1.1     | 2025-12-22 | System | Added structured logging requirements (REQ-SYS-013 through REQ-SYS-022) |
 | 1.2     | 2025-12-22 | System | Added code linting and static analysis requirements (REQ-LINT-001 through REQ-LINT-010) |
 | 1.3     | 2025-12-25 | System | Merged reactive data loading pattern requirements from data-loading-specs.md (REQ-FE-027 through REQ-FE-036) |
+| 1.4     | 2025-12-30 | System | Added JSON enum serialization requirements (REQ-API-007 through REQ-API-008) |
 
 ---
 

--- a/VehicleValueTracker/src/VehicleValueTracker.Api/Program.cs
+++ b/VehicleValueTracker/src/VehicleValueTracker.Api/Program.cs
@@ -1,5 +1,6 @@
 using VehicleValueTracker.Infrastructure;
 using Serilog;
+using System.Text.Json.Serialization;
 
 var builder = WebApplication.CreateBuilder(args);
 
@@ -16,7 +17,11 @@ builder.Host.UseSerilog((context, loggerConfig) =>
 });
 
 // Add services to the container.
-builder.Services.AddControllers();
+builder.Services.AddControllers()
+    .AddJsonOptions(options =>
+    {
+        options.JsonSerializerOptions.Converters.Add(new JsonStringEnumConverter());
+    });
 builder.Services.AddEndpointsApiExplorer();
 builder.Services.AddSwaggerGen(options =>
 {

--- a/VideoGameCollectionManager/docs/specs/implementation-specs.md
+++ b/VideoGameCollectionManager/docs/specs/implementation-specs.md
@@ -192,6 +192,21 @@ Id
 ### 5.5 CORS Configuration
 **REQ-API-006**: The API SHALL have a CORS policy defined. The origins allowed in the CORS policy SHALL be retrieved from configuration and SHALL include the URLs where the frontend(s) are hosted.
 
+### 5.6 JSON Serialization
+**REQ-API-007**: The API project Program.cs SHALL include the following using statement:
+```csharp
+using System.Text.Json.Serialization;
+```
+
+**REQ-API-008**: The API SHALL configure JSON serialization to handle enums as text strings. The `AddControllers()` call SHALL be configured with `JsonStringEnumConverter`:
+```csharp
+builder.Services.AddControllers()
+    .AddJsonOptions(options =>
+    {
+        options.JsonSerializerOptions.Converters.Add(new JsonStringEnumConverter());
+    });
+```
+
 ---
 
 ## 6. Frontend Requirements
@@ -470,6 +485,7 @@ All changes to this specification SHALL be tracked and versioned appropriately.
 | 1.1     | 2025-12-22 | System | Added structured logging requirements (REQ-SYS-013 through REQ-SYS-022) |
 | 1.2     | 2025-12-22 | System | Added code linting and static analysis requirements (REQ-LINT-001 through REQ-LINT-010) |
 | 1.3     | 2025-12-25 | System | Merged reactive data loading pattern requirements from data-loading-specs.md (REQ-FE-027 through REQ-FE-036) |
+| 1.4     | 2025-12-30 | System | Added JSON enum serialization requirements (REQ-API-007 through REQ-API-008) |
 
 ---
 

--- a/VideoGameCollectionManager/src/VideoGameCollectionManager.Api/Program.cs
+++ b/VideoGameCollectionManager/src/VideoGameCollectionManager.Api/Program.cs
@@ -1,5 +1,6 @@
 using Serilog;
 using Serilog.Events;
+using System.Text.Json.Serialization;
 using VideoGameCollectionManager.Infrastructure;
 
 Log.Logger = new LoggerConfiguration()
@@ -25,7 +26,11 @@ try
         .WriteTo.Console());
 
     // Add services to the container.
-    builder.Services.AddControllers();
+    builder.Services.AddControllers()
+        .AddJsonOptions(options =>
+        {
+            options.JsonSerializerOptions.Converters.Add(new JsonStringEnumConverter());
+        });
     builder.Services.AddEndpointsApiExplorer();
     builder.Services.AddSwaggerGen();
 

--- a/WarrantyReturnPeriodTracker/docs/specs/implementation-specs.md
+++ b/WarrantyReturnPeriodTracker/docs/specs/implementation-specs.md
@@ -192,6 +192,21 @@ Id
 ### 5.5 CORS Configuration
 **REQ-API-006**: The API SHALL have a CORS policy defined. The origins allowed in the CORS policy SHALL be retrieved from configuration and SHALL include the URLs where the frontend(s) are hosted.
 
+### 5.6 JSON Serialization
+**REQ-API-007**: The API project Program.cs SHALL include the following using statement:
+```csharp
+using System.Text.Json.Serialization;
+```
+
+**REQ-API-008**: The API SHALL configure JSON serialization to handle enums as text strings. The `AddControllers()` call SHALL be configured with `JsonStringEnumConverter`:
+```csharp
+builder.Services.AddControllers()
+    .AddJsonOptions(options =>
+    {
+        options.JsonSerializerOptions.Converters.Add(new JsonStringEnumConverter());
+    });
+```
+
 ---
 
 ## 6. Frontend Requirements
@@ -470,6 +485,7 @@ All changes to this specification SHALL be tracked and versioned appropriately.
 | 1.1     | 2025-12-22 | System | Added structured logging requirements (REQ-SYS-013 through REQ-SYS-022) |
 | 1.2     | 2025-12-22 | System | Added code linting and static analysis requirements (REQ-LINT-001 through REQ-LINT-010) |
 | 1.3     | 2025-12-25 | System | Merged reactive data loading pattern requirements from data-loading-specs.md (REQ-FE-027 through REQ-FE-036) |
+| 1.4     | 2025-12-30 | System | Added JSON enum serialization requirements (REQ-API-007 through REQ-API-008) |
 
 ---
 

--- a/WarrantyReturnPeriodTracker/src/WarrantyReturnPeriodTracker.Api/Program.cs
+++ b/WarrantyReturnPeriodTracker/src/WarrantyReturnPeriodTracker.Api/Program.cs
@@ -2,6 +2,7 @@ using MediatR;
 using Microsoft.EntityFrameworkCore;
 using Serilog;
 using Serilog.Events;
+using System.Text.Json.Serialization;
 using WarrantyReturnPeriodTracker.Core;
 using WarrantyReturnPeriodTracker.Infrastructure;
 
@@ -27,7 +28,11 @@ try
     builder.Host.UseSerilog();
 
     // Add services to the container
-    builder.Services.AddControllers();
+    builder.Services.AddControllers()
+        .AddJsonOptions(options =>
+        {
+            options.JsonSerializerOptions.Converters.Add(new JsonStringEnumConverter());
+        });
     builder.Services.AddEndpointsApiExplorer();
     builder.Services.AddSwaggerGen();
 

--- a/WeeklyReviewSystem/docs/specs/implementation-specs.md
+++ b/WeeklyReviewSystem/docs/specs/implementation-specs.md
@@ -192,6 +192,21 @@ Id
 ### 5.5 CORS Configuration
 **REQ-API-006**: The API SHALL have a CORS policy defined. The origins allowed in the CORS policy SHALL be retrieved from configuration and SHALL include the URLs where the frontend(s) are hosted.
 
+### 5.6 JSON Serialization
+**REQ-API-007**: The API project Program.cs SHALL include the following using statement:
+```csharp
+using System.Text.Json.Serialization;
+```
+
+**REQ-API-008**: The API SHALL configure JSON serialization to handle enums as text strings. The `AddControllers()` call SHALL be configured with `JsonStringEnumConverter`:
+```csharp
+builder.Services.AddControllers()
+    .AddJsonOptions(options =>
+    {
+        options.JsonSerializerOptions.Converters.Add(new JsonStringEnumConverter());
+    });
+```
+
 ---
 
 ## 6. Frontend Requirements
@@ -470,6 +485,7 @@ All changes to this specification SHALL be tracked and versioned appropriately.
 | 1.1     | 2025-12-22 | System | Added structured logging requirements (REQ-SYS-013 through REQ-SYS-022) |
 | 1.2     | 2025-12-22 | System | Added code linting and static analysis requirements (REQ-LINT-001 through REQ-LINT-010) |
 | 1.3     | 2025-12-25 | System | Merged reactive data loading pattern requirements from data-loading-specs.md (REQ-FE-027 through REQ-FE-036) |
+| 1.4     | 2025-12-30 | System | Added JSON enum serialization requirements (REQ-API-007 through REQ-API-008) |
 
 ---
 

--- a/WeeklyReviewSystem/src/WeeklyReviewSystem.Api/Program.cs
+++ b/WeeklyReviewSystem/src/WeeklyReviewSystem.Api/Program.cs
@@ -1,4 +1,5 @@
 using Serilog;
+using System.Text.Json.Serialization;
 using WeeklyReviewSystem.Infrastructure;
 
 var builder = WebApplication.CreateBuilder(args);
@@ -15,7 +16,11 @@ Log.Logger = new LoggerConfiguration()
 builder.Host.UseSerilog();
 
 // Add services to the container.
-builder.Services.AddControllers();
+builder.Services.AddControllers()
+    .AddJsonOptions(options =>
+    {
+        options.JsonSerializerOptions.Converters.Add(new JsonStringEnumConverter());
+    });
 builder.Services.AddEndpointsApiExplorer();
 builder.Services.AddSwaggerGen(c =>
 {

--- a/WineCellarInventory/docs/specs/implementation-specs.md
+++ b/WineCellarInventory/docs/specs/implementation-specs.md
@@ -192,6 +192,21 @@ Id
 ### 5.5 CORS Configuration
 **REQ-API-006**: The API SHALL have a CORS policy defined. The origins allowed in the CORS policy SHALL be retrieved from configuration and SHALL include the URLs where the frontend(s) are hosted.
 
+### 5.6 JSON Serialization
+**REQ-API-007**: The API project Program.cs SHALL include the following using statement:
+```csharp
+using System.Text.Json.Serialization;
+```
+
+**REQ-API-008**: The API SHALL configure JSON serialization to handle enums as text strings. The `AddControllers()` call SHALL be configured with `JsonStringEnumConverter`:
+```csharp
+builder.Services.AddControllers()
+    .AddJsonOptions(options =>
+    {
+        options.JsonSerializerOptions.Converters.Add(new JsonStringEnumConverter());
+    });
+```
+
 ---
 
 ## 6. Frontend Requirements
@@ -470,6 +485,7 @@ All changes to this specification SHALL be tracked and versioned appropriately.
 | 1.1     | 2025-12-22 | System | Added structured logging requirements (REQ-SYS-013 through REQ-SYS-022) |
 | 1.2     | 2025-12-22 | System | Added code linting and static analysis requirements (REQ-LINT-001 through REQ-LINT-010) |
 | 1.3     | 2025-12-25 | System | Merged reactive data loading pattern requirements from data-loading-specs.md (REQ-FE-027 through REQ-FE-036) |
+| 1.4     | 2025-12-30 | System | Added JSON enum serialization requirements (REQ-API-007 through REQ-API-008) |
 
 ---
 

--- a/WineCellarInventory/src/WineCellarInventory.Api/Program.cs
+++ b/WineCellarInventory/src/WineCellarInventory.Api/Program.cs
@@ -1,5 +1,6 @@
 using WineCellarInventory.Infrastructure;
 using Serilog;
+using System.Text.Json.Serialization;
 
 var builder = WebApplication.CreateBuilder(args);
 
@@ -16,7 +17,11 @@ builder.Host.UseSerilog((context, loggerConfig) =>
 });
 
 // Add services to the container.
-builder.Services.AddControllers();
+builder.Services.AddControllers()
+    .AddJsonOptions(options =>
+    {
+        options.JsonSerializerOptions.Converters.Add(new JsonStringEnumConverter());
+    });
 builder.Services.AddEndpointsApiExplorer();
 builder.Services.AddSwaggerGen(options =>
 {

--- a/WoodworkingProjectManager/docs/specs/implementation-specs.md
+++ b/WoodworkingProjectManager/docs/specs/implementation-specs.md
@@ -192,6 +192,21 @@ Id
 ### 5.5 CORS Configuration
 **REQ-API-006**: The API SHALL have a CORS policy defined. The origins allowed in the CORS policy SHALL be retrieved from configuration and SHALL include the URLs where the frontend(s) are hosted.
 
+### 5.6 JSON Serialization
+**REQ-API-007**: The API project Program.cs SHALL include the following using statement:
+```csharp
+using System.Text.Json.Serialization;
+```
+
+**REQ-API-008**: The API SHALL configure JSON serialization to handle enums as text strings. The `AddControllers()` call SHALL be configured with `JsonStringEnumConverter`:
+```csharp
+builder.Services.AddControllers()
+    .AddJsonOptions(options =>
+    {
+        options.JsonSerializerOptions.Converters.Add(new JsonStringEnumConverter());
+    });
+```
+
 ---
 
 ## 6. Frontend Requirements
@@ -470,6 +485,7 @@ All changes to this specification SHALL be tracked and versioned appropriately.
 | 1.1     | 2025-12-22 | System | Added structured logging requirements (REQ-SYS-013 through REQ-SYS-022) |
 | 1.2     | 2025-12-22 | System | Added code linting and static analysis requirements (REQ-LINT-001 through REQ-LINT-010) |
 | 1.3     | 2025-12-25 | System | Merged reactive data loading pattern requirements from data-loading-specs.md (REQ-FE-027 through REQ-FE-036) |
+| 1.4     | 2025-12-30 | System | Added JSON enum serialization requirements (REQ-API-007 through REQ-API-008) |
 
 ---
 

--- a/WoodworkingProjectManager/src/WoodworkingProjectManager.Api/Program.cs
+++ b/WoodworkingProjectManager/src/WoodworkingProjectManager.Api/Program.cs
@@ -1,5 +1,6 @@
 using WoodworkingProjectManager.Infrastructure;
 using Serilog;
+using System.Text.Json.Serialization;
 
 var builder = WebApplication.CreateBuilder(args);
 
@@ -16,7 +17,11 @@ builder.Host.UseSerilog((context, loggerConfig) =>
 });
 
 // Add services to the container.
-builder.Services.AddControllers();
+builder.Services.AddControllers()
+    .AddJsonOptions(options =>
+    {
+        options.JsonSerializerOptions.Converters.Add(new JsonStringEnumConverter());
+    });
 builder.Services.AddEndpointsApiExplorer();
 builder.Services.AddSwaggerGen(options =>
 {

--- a/WorkoutPlanBuilder/docs/specs/implementation-specs.md
+++ b/WorkoutPlanBuilder/docs/specs/implementation-specs.md
@@ -192,6 +192,21 @@ Id
 ### 5.5 CORS Configuration
 **REQ-API-006**: The API SHALL have a CORS policy defined. The origins allowed in the CORS policy SHALL be retrieved from configuration and SHALL include the URLs where the frontend(s) are hosted.
 
+### 5.6 JSON Serialization
+**REQ-API-007**: The API project Program.cs SHALL include the following using statement:
+```csharp
+using System.Text.Json.Serialization;
+```
+
+**REQ-API-008**: The API SHALL configure JSON serialization to handle enums as text strings. The `AddControllers()` call SHALL be configured with `JsonStringEnumConverter`:
+```csharp
+builder.Services.AddControllers()
+    .AddJsonOptions(options =>
+    {
+        options.JsonSerializerOptions.Converters.Add(new JsonStringEnumConverter());
+    });
+```
+
 ---
 
 ## 6. Frontend Requirements
@@ -470,6 +485,7 @@ All changes to this specification SHALL be tracked and versioned appropriately.
 | 1.1     | 2025-12-22 | System | Added structured logging requirements (REQ-SYS-013 through REQ-SYS-022) |
 | 1.2     | 2025-12-22 | System | Added code linting and static analysis requirements (REQ-LINT-001 through REQ-LINT-010) |
 | 1.3     | 2025-12-25 | System | Merged reactive data loading pattern requirements from data-loading-specs.md (REQ-FE-027 through REQ-FE-036) |
+| 1.4     | 2025-12-30 | System | Added JSON enum serialization requirements (REQ-API-007 through REQ-API-008) |
 
 ---
 

--- a/WorkoutPlanBuilder/src/WorkoutPlanBuilder.Api/Program.cs
+++ b/WorkoutPlanBuilder/src/WorkoutPlanBuilder.Api/Program.cs
@@ -1,5 +1,6 @@
 using Serilog;
 using Serilog.Events;
+using System.Text.Json.Serialization;
 using WorkoutPlanBuilder.Infrastructure;
 
 Log.Logger = new LoggerConfiguration()
@@ -22,7 +23,11 @@ try
     builder.Host.UseSerilog();
 
     // Add services to the container.
-    builder.Services.AddControllers();
+    builder.Services.AddControllers()
+        .AddJsonOptions(options =>
+        {
+            options.JsonSerializerOptions.Converters.Add(new JsonStringEnumConverter());
+        });
     builder.Services.AddEndpointsApiExplorer();
     builder.Services.AddSwaggerGen(c =>
     {


### PR DESCRIPTION
- Add using System.Text.Json.Serialization to all Program.cs files
- Configure AddControllers() with JsonStringEnumConverter for all APIs
- Update implementation specs with new requirements REQ-API-007 and REQ-API-008
- This ensures all enum values in API payloads are serialized as text strings