### PR TITLE
Add Material dialogs and toasts for confirmations

### DIFF
--- a/FamilyCalendarEventPlanner/src/FamilyCalendarEventPlanner.WebApp/projects/family-calendar-event-planner-admin/src/app/components/confirm-dialog/confirm-dialog.html
+++ b/FamilyCalendarEventPlanner/src/FamilyCalendarEventPlanner.WebApp/projects/family-calendar-event-planner-admin/src/app/components/confirm-dialog/confirm-dialog.html
@@ -1,0 +1,15 @@
+<h2 mat-dialog-title class="dialog-title">
+  <mat-icon color="warn">warning</mat-icon>
+  {{ data.title }}
+</h2>
+
+<mat-dialog-content>
+  <p class="dialog-message">{{ data.message }}</p>
+</mat-dialog-content>
+
+<mat-dialog-actions align="end">
+  <button mat-button (click)="onCancel()">{{ cancelButtonText }}</button>
+  <button mat-raised-button color="warn" (click)="onConfirm()">
+    {{ confirmButtonText }}
+  </button>
+</mat-dialog-actions>

--- a/FamilyCalendarEventPlanner/src/FamilyCalendarEventPlanner.WebApp/projects/family-calendar-event-planner-admin/src/app/components/confirm-dialog/confirm-dialog.scss
+++ b/FamilyCalendarEventPlanner/src/FamilyCalendarEventPlanner.WebApp/projects/family-calendar-event-planner-admin/src/app/components/confirm-dialog/confirm-dialog.scss
@@ -1,0 +1,18 @@
+.dialog-title {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+
+  mat-icon {
+    font-size: 28px;
+    height: 28px;
+    width: 28px;
+  }
+}
+
+.dialog-message {
+  font-size: 14px;
+  color: rgba(0, 0, 0, 0.7);
+  margin: 8px 0;
+  min-width: 350px;
+}

--- a/FamilyCalendarEventPlanner/src/FamilyCalendarEventPlanner.WebApp/projects/family-calendar-event-planner-admin/src/app/components/confirm-dialog/confirm-dialog.ts
+++ b/FamilyCalendarEventPlanner/src/FamilyCalendarEventPlanner.WebApp/projects/family-calendar-event-planner-admin/src/app/components/confirm-dialog/confirm-dialog.ts
@@ -1,0 +1,51 @@
+import { Component, Inject } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { MatDialogModule, MatDialogRef, MAT_DIALOG_DATA } from '@angular/material/dialog';
+import { MatButtonModule } from '@angular/material/button';
+import { MatIconModule } from '@angular/material/icon';
+
+export interface ConfirmDialogData {
+  title: string;
+  message: string;
+  confirmText?: string;
+  cancelText?: string;
+}
+
+export interface ConfirmDialogResult {
+  confirmed: boolean;
+}
+
+@Component({
+  selector: 'app-confirm-dialog',
+  standalone: true,
+  imports: [
+    CommonModule,
+    MatDialogModule,
+    MatButtonModule,
+    MatIconModule
+  ],
+  templateUrl: './confirm-dialog.html',
+  styleUrls: ['./confirm-dialog.scss']
+})
+export class ConfirmDialog {
+  constructor(
+    public dialogRef: MatDialogRef<ConfirmDialog>,
+    @Inject(MAT_DIALOG_DATA) public data: ConfirmDialogData
+  ) {}
+
+  get confirmButtonText(): string {
+    return this.data.confirmText || 'Delete';
+  }
+
+  get cancelButtonText(): string {
+    return this.data.cancelText || 'Cancel';
+  }
+
+  onConfirm(): void {
+    this.dialogRef.close({ confirmed: true } as ConfirmDialogResult);
+  }
+
+  onCancel(): void {
+    this.dialogRef.close({ confirmed: false } as ConfirmDialogResult);
+  }
+}

--- a/FamilyCalendarEventPlanner/src/FamilyCalendarEventPlanner.WebApp/projects/family-calendar-event-planner-admin/src/app/components/confirm-dialog/index.ts
+++ b/FamilyCalendarEventPlanner/src/FamilyCalendarEventPlanner.WebApp/projects/family-calendar-event-planner-admin/src/app/components/confirm-dialog/index.ts
@@ -1,0 +1,4 @@
+// Copyright (c) Quinntyne Brown. All Rights Reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+export * from './confirm-dialog';

--- a/FamilyCalendarEventPlanner/src/FamilyCalendarEventPlanner.WebApp/projects/family-calendar-event-planner-admin/src/app/components/index.ts
+++ b/FamilyCalendarEventPlanner/src/FamilyCalendarEventPlanner.WebApp/projects/family-calendar-event-planner-admin/src/app/components/index.ts
@@ -1,6 +1,7 @@
 // Copyright (c) Quinntyne Brown. All Rights Reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
+export * from './confirm-dialog';
 export * from './create-or-edit-family-member-dialog';
 export * from './create-or-edit-household-dialog';
 export * from './create-or-edit-event-dialog';

--- a/FamilyCalendarEventPlanner/src/FamilyCalendarEventPlanner.WebApp/projects/family-calendar-event-planner-admin/src/app/pages/users/users.ts
+++ b/FamilyCalendarEventPlanner/src/FamilyCalendarEventPlanner.WebApp/projects/family-calendar-event-planner-admin/src/app/pages/users/users.ts
@@ -7,11 +7,13 @@ import { MatDialog } from '@angular/material/dialog';
 import { MatTooltipModule } from '@angular/material/tooltip';
 import { MatChipsModule } from '@angular/material/chips';
 import { MatMenuModule } from '@angular/material/menu';
+import { MatSnackBar, MatSnackBarModule } from '@angular/material/snack-bar';
 import { BehaviorSubject, switchMap, forkJoin, of } from 'rxjs';
 import { UsersService } from '../../services/users.service';
 import { RolesService } from '../../services/roles.service';
 import { UserDto, RoleDto } from '../../models/user-dto';
 import { CreateOrEditUserDialog, CreateOrEditUserDialogResult } from '../../components/create-or-edit-user-dialog';
+import { ConfirmDialog, ConfirmDialogResult } from '../../components/confirm-dialog';
 
 @Component({
   selector: 'app-users',
@@ -23,7 +25,8 @@ import { CreateOrEditUserDialog, CreateOrEditUserDialogResult } from '../../comp
     MatIconModule,
     MatTooltipModule,
     MatChipsModule,
-    MatMenuModule
+    MatMenuModule,
+    MatSnackBarModule
   ],
   templateUrl: './users.html',
   styleUrls: ['./users.scss']
@@ -32,6 +35,7 @@ export class Users {
   private usersService = inject(UsersService);
   private rolesService = inject(RolesService);
   private dialog = inject(MatDialog);
+  private snackBar = inject(MatSnackBar);
 
   private refresh$ = new BehaviorSubject<void>(undefined);
 
@@ -54,9 +58,11 @@ export class Users {
         this.usersService.createUser(result.data).subscribe({
           next: () => {
             this.refresh$.next();
+            this.snackBar.open('User created successfully', 'Close', { duration: 3000 });
           },
           error: (error) => {
             console.error('Error creating user:', error);
+            this.snackBar.open('Error creating user', 'Close', { duration: 3000 });
           }
         });
       }
@@ -79,9 +85,11 @@ export class Users {
         }).subscribe({
           next: () => {
             this.refresh$.next();
+            this.snackBar.open('User updated successfully', 'Close', { duration: 3000 });
           },
           error: (error) => {
             console.error('Error updating user:', error);
+            this.snackBar.open('Error updating user', 'Close', { duration: 3000 });
           }
         });
       }
@@ -89,25 +97,39 @@ export class Users {
   }
 
   onDeleteUser(user: UserDto): void {
-    if (confirm(`Are you sure you want to delete ${user.userName}?`)) {
-      this.usersService.deleteUser(user.userId).subscribe({
-        next: () => {
-          this.refresh$.next();
-        },
-        error: (error) => {
-          console.error('Error deleting user:', error);
-        }
-      });
-    }
+    const dialogRef = this.dialog.open(ConfirmDialog, {
+      width: '400px',
+      data: {
+        title: 'Delete User',
+        message: `Are you sure you want to delete ${user.userName}?`
+      }
+    });
+
+    dialogRef.afterClosed().subscribe((result: ConfirmDialogResult) => {
+      if (result?.confirmed) {
+        this.usersService.deleteUser(user.userId).subscribe({
+          next: () => {
+            this.refresh$.next();
+            this.snackBar.open('User deleted successfully', 'Close', { duration: 3000 });
+          },
+          error: (error) => {
+            console.error('Error deleting user:', error);
+            this.snackBar.open('Error deleting user', 'Close', { duration: 3000 });
+          }
+        });
+      }
+    });
   }
 
   onAddRole(user: UserDto, role: { roleId: string; name: string }): void {
     this.usersService.addRoleToUser(user.userId, role.roleId).subscribe({
       next: () => {
         this.refresh$.next();
+        this.snackBar.open('Role added successfully', 'Close', { duration: 3000 });
       },
       error: (error) => {
         console.error('Error adding role:', error);
+        this.snackBar.open('Error adding role', 'Close', { duration: 3000 });
       }
     });
   }
@@ -116,9 +138,11 @@ export class Users {
     this.usersService.removeRoleFromUser(user.userId, roleId).subscribe({
       next: () => {
         this.refresh$.next();
+        this.snackBar.open('Role removed successfully', 'Close', { duration: 3000 });
       },
       error: (error) => {
         console.error('Error removing role:', error);
+        this.snackBar.open('Error removing role', 'Close', { duration: 3000 });
       }
     });
   }


### PR DESCRIPTION
- Create reusable ConfirmDialog component for delete confirmations
- Replace browser confirm() with Material Dialog in all pages
- Add MatSnackBar toast notifications for CRUD operations
- Update users, roles, family-members, households, and events pages