### PR TITLE
Fix Infrastructure projects syntax and package issues

### DIFF
--- a/AnniversaryBirthdayReminder/src/AnniversaryBirthdayReminder.Infrastructure/AnniversaryBirthdayReminder.Infrastructure.csproj
+++ b/AnniversaryBirthdayReminder/src/AnniversaryBirthdayReminder.Infrastructure/AnniversaryBirthdayReminder.Infrastructure.csproj
@@ -7,8 +7,13 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <FrameworkReference Include="Microsoft.AspNetCore.App" />
+  </ItemGroup>
+
+  <ItemGroup>
     <PackageReference Include="Microsoft.EntityFrameworkCore" Version="8.0.0" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="8.0.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="8.0.0" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="8.0.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/AnnualHealthScreeningReminder/src/AnnualHealthScreeningReminder.Infrastructure/AnnualHealthScreeningReminder.Infrastructure.csproj
+++ b/AnnualHealthScreeningReminder/src/AnnualHealthScreeningReminder.Infrastructure/AnnualHealthScreeningReminder.Infrastructure.csproj
@@ -7,6 +7,16 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <FrameworkReference Include="Microsoft.AspNetCore.App" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="8.0.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="8.0.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="8.0.0" />
+  </ItemGroup>
+
+  <ItemGroup>
     <ProjectReference Include="..\AnnualHealthScreeningReminder.Core\AnnualHealthScreeningReminder.Core.csproj" />
   </ItemGroup>
 

--- a/AnnualHealthScreeningReminder/src/AnnualHealthScreeningReminder.Infrastructure/Data/AnnualHealthScreeningReminderContext.cs
+++ b/AnnualHealthScreeningReminder/src/AnnualHealthScreeningReminder.Infrastructure/Data/AnnualHealthScreeningReminderContext.cs
@@ -52,18 +52,13 @@ public class AnnualHealthScreeningReminderContext : DbContext, IAnnualHealthScre
     /// <inheritdoc/>
     protected override void OnModelCreating(ModelBuilder modelBuilder)
     {
-        
-        // Apply tenant filter to User
-        modelBuilder.Entity<User>().HasQueryFilter(u => u.TenantId == _tenantContext.TenantId);
-
-        // Apply tenant filter to Role
-        modelBuilder.Entity<Role>().HasQueryFilter(r => r.TenantId == _tenantContext.TenantId);
-
         base.OnModelCreating(modelBuilder);
 
         // Apply tenant isolation filters
         if (_tenantContext != null)
         {
+            modelBuilder.Entity<User>().HasQueryFilter(u => u.TenantId == _tenantContext.TenantId);
+            modelBuilder.Entity<Role>().HasQueryFilter(r => r.TenantId == _tenantContext.TenantId);
             modelBuilder.Entity<Screening>().HasQueryFilter(e => e.TenantId == _tenantContext.TenantId);
             modelBuilder.Entity<Appointment>().HasQueryFilter(e => e.TenantId == _tenantContext.TenantId);
             modelBuilder.Entity<Reminder>().HasQueryFilter(e => e.TenantId == _tenantContext.TenantId);

--- a/AnnualHealthScreeningReminder/src/AnnualHealthScreeningReminder.Infrastructure/Data/SeedData.cs
+++ b/AnnualHealthScreeningReminder/src/AnnualHealthScreeningReminder.Infrastructure/Data/SeedData.cs
@@ -21,7 +21,7 @@ public static class SeedData
     /// <param name="context">The database context.</param>
     /// <param name="logger">The logger.</param>
     /// <returns>A task representing the asynchronous operation.</returns>
-    public static async Task SeedAsync(AnnualHealthScreeningReminderContext context context, ILogger logger, IPasswordHasher passwordHasher)
+    public static async Task SeedAsync(AnnualHealthScreeningReminderContext context, ILogger logger, IPasswordHasher passwordHasher)
     {
         ArgumentNullException.ThrowIfNull(context);
         ArgumentNullException.ThrowIfNull(logger);

--- a/ApplianceWarrantyManualOrganizer/src/ApplianceWarrantyManualOrganizer.Infrastructure/ApplianceWarrantyManualOrganizer.Infrastructure.csproj
+++ b/ApplianceWarrantyManualOrganizer/src/ApplianceWarrantyManualOrganizer.Infrastructure/ApplianceWarrantyManualOrganizer.Infrastructure.csproj
@@ -7,6 +7,16 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <FrameworkReference Include="Microsoft.AspNetCore.App" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="8.0.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="8.0.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="8.0.0" />
+  </ItemGroup>
+
+  <ItemGroup>
     <ProjectReference Include="..\ApplianceWarrantyManualOrganizer.Core\ApplianceWarrantyManualOrganizer.Core.csproj" />
   </ItemGroup>
 

--- a/ApplianceWarrantyManualOrganizer/src/ApplianceWarrantyManualOrganizer.Infrastructure/Data/ApplianceWarrantyManualOrganizerContext.cs
+++ b/ApplianceWarrantyManualOrganizer/src/ApplianceWarrantyManualOrganizer.Infrastructure/Data/ApplianceWarrantyManualOrganizerContext.cs
@@ -55,18 +55,13 @@ public class ApplianceWarrantyManualOrganizerContext : DbContext, IApplianceWarr
     /// <inheritdoc/>
     protected override void OnModelCreating(ModelBuilder modelBuilder)
     {
-        
-        // Apply tenant filter to User
-        modelBuilder.Entity<User>().HasQueryFilter(u => u.TenantId == _tenantContext.TenantId);
-
-        // Apply tenant filter to Role
-        modelBuilder.Entity<Role>().HasQueryFilter(r => r.TenantId == _tenantContext.TenantId);
-
         base.OnModelCreating(modelBuilder);
 
         // Apply tenant isolation filters
         if (_tenantContext != null)
         {
+            modelBuilder.Entity<User>().HasQueryFilter(u => u.TenantId == _tenantContext.TenantId);
+            modelBuilder.Entity<Role>().HasQueryFilter(r => r.TenantId == _tenantContext.TenantId);
             modelBuilder.Entity<Appliance>().HasQueryFilter(e => e.TenantId == _tenantContext.TenantId);
             modelBuilder.Entity<Warranty>().HasQueryFilter(e => e.TenantId == _tenantContext.TenantId);
             modelBuilder.Entity<Manual>().HasQueryFilter(e => e.TenantId == _tenantContext.TenantId);

--- a/ApplianceWarrantyManualOrganizer/src/ApplianceWarrantyManualOrganizer.Infrastructure/Data/SeedData.cs
+++ b/ApplianceWarrantyManualOrganizer/src/ApplianceWarrantyManualOrganizer.Infrastructure/Data/SeedData.cs
@@ -21,7 +21,7 @@ public static class SeedData
     /// <param name="context">The database context.</param>
     /// <param name="logger">The logger.</param>
     /// <returns>A task representing the asynchronous operation.</returns>
-    public static async Task SeedAsync(ApplianceWarrantyManualOrganizerContext context context, ILogger logger, IPasswordHasher passwordHasher)
+    public static async Task SeedAsync(ApplianceWarrantyManualOrganizerContext context, ILogger logger, IPasswordHasher passwordHasher)
     {
         ArgumentNullException.ThrowIfNull(context);
         ArgumentNullException.ThrowIfNull(logger);

--- a/BBQGrillingRecipeBook/src/BBQGrillingRecipeBook.Infrastructure/BBQGrillingRecipeBook.Infrastructure.csproj
+++ b/BBQGrillingRecipeBook/src/BBQGrillingRecipeBook.Infrastructure/BBQGrillingRecipeBook.Infrastructure.csproj
@@ -7,6 +7,16 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <FrameworkReference Include="Microsoft.AspNetCore.App" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="8.0.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="8.0.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="8.0.0" />
+  </ItemGroup>
+
+  <ItemGroup>
     <ProjectReference Include="..\BBQGrillingRecipeBook.Core\BBQGrillingRecipeBook.Core.csproj" />
   </ItemGroup>
 

--- a/BBQGrillingRecipeBook/src/BBQGrillingRecipeBook.Infrastructure/Data/BBQGrillingRecipeBookContext.cs
+++ b/BBQGrillingRecipeBook/src/BBQGrillingRecipeBook.Infrastructure/Data/BBQGrillingRecipeBookContext.cs
@@ -52,18 +52,13 @@ public class BBQGrillingRecipeBookContext : DbContext, IBBQGrillingRecipeBookCon
     /// <inheritdoc/>
     protected override void OnModelCreating(ModelBuilder modelBuilder)
     {
-        
-        // Apply tenant filter to User
-        modelBuilder.Entity<User>().HasQueryFilter(u => u.TenantId == _tenantContext.TenantId);
-
-        // Apply tenant filter to Role
-        modelBuilder.Entity<Role>().HasQueryFilter(r => r.TenantId == _tenantContext.TenantId);
-
         base.OnModelCreating(modelBuilder);
 
         // Apply tenant isolation filters
         if (_tenantContext != null)
         {
+            modelBuilder.Entity<User>().HasQueryFilter(u => u.TenantId == _tenantContext.TenantId);
+            modelBuilder.Entity<Role>().HasQueryFilter(r => r.TenantId == _tenantContext.TenantId);
             modelBuilder.Entity<Recipe>().HasQueryFilter(e => e.TenantId == _tenantContext.TenantId);
             modelBuilder.Entity<CookSession>().HasQueryFilter(e => e.TenantId == _tenantContext.TenantId);
             modelBuilder.Entity<Technique>().HasQueryFilter(e => e.TenantId == _tenantContext.TenantId);

--- a/BBQGrillingRecipeBook/src/BBQGrillingRecipeBook.Infrastructure/Data/SeedData.cs
+++ b/BBQGrillingRecipeBook/src/BBQGrillingRecipeBook.Infrastructure/Data/SeedData.cs
@@ -21,7 +21,7 @@ public static class SeedData
     /// <param name="context">The database context.</param>
     /// <param name="logger">The logger.</param>
     /// <returns>A task representing the asynchronous operation.</returns>
-    public static async Task SeedAsync(BBQGrillingRecipeBookContext context context, ILogger logger, IPasswordHasher passwordHasher)
+    public static async Task SeedAsync(BBQGrillingRecipeBookContext context, ILogger logger, IPasswordHasher passwordHasher)
     {
         ArgumentNullException.ThrowIfNull(context);
         ArgumentNullException.ThrowIfNull(logger);

--- a/BillPaymentScheduler/src/BillPaymentScheduler.Infrastructure/BillPaymentScheduler.Infrastructure.csproj
+++ b/BillPaymentScheduler/src/BillPaymentScheduler.Infrastructure/BillPaymentScheduler.Infrastructure.csproj
@@ -7,6 +7,16 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <FrameworkReference Include="Microsoft.AspNetCore.App" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="8.0.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="8.0.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="8.0.0" />
+  </ItemGroup>
+
+  <ItemGroup>
     <ProjectReference Include="..\BillPaymentScheduler.Core\BillPaymentScheduler.Core.csproj" />
   </ItemGroup>
 

--- a/BillPaymentScheduler/src/BillPaymentScheduler.Infrastructure/Data/BillPaymentSchedulerContext.cs
+++ b/BillPaymentScheduler/src/BillPaymentScheduler.Infrastructure/Data/BillPaymentSchedulerContext.cs
@@ -52,18 +52,13 @@ public class BillPaymentSchedulerContext : DbContext, IBillPaymentSchedulerConte
     /// <inheritdoc/>
     protected override void OnModelCreating(ModelBuilder modelBuilder)
     {
-        
-        // Apply tenant filter to User
-        modelBuilder.Entity<User>().HasQueryFilter(u => u.TenantId == _tenantContext.TenantId);
-
-        // Apply tenant filter to Role
-        modelBuilder.Entity<Role>().HasQueryFilter(r => r.TenantId == _tenantContext.TenantId);
-
         base.OnModelCreating(modelBuilder);
 
         // Apply tenant isolation filters
         if (_tenantContext != null)
         {
+            modelBuilder.Entity<User>().HasQueryFilter(u => u.TenantId == _tenantContext.TenantId);
+            modelBuilder.Entity<Role>().HasQueryFilter(r => r.TenantId == _tenantContext.TenantId);
             modelBuilder.Entity<Bill>().HasQueryFilter(e => e.TenantId == _tenantContext.TenantId);
             modelBuilder.Entity<Payment>().HasQueryFilter(e => e.TenantId == _tenantContext.TenantId);
             modelBuilder.Entity<Payee>().HasQueryFilter(e => e.TenantId == _tenantContext.TenantId);

--- a/BillPaymentScheduler/src/BillPaymentScheduler.Infrastructure/Data/SeedData.cs
+++ b/BillPaymentScheduler/src/BillPaymentScheduler.Infrastructure/Data/SeedData.cs
@@ -21,7 +21,7 @@ public static class SeedData
     /// <param name="context">The database context.</param>
     /// <param name="logger">The logger.</param>
     /// <returns>A task representing the asynchronous operation.</returns>
-    public static async Task SeedAsync(BillPaymentSchedulerContext context context, ILogger logger, IPasswordHasher passwordHasher)
+    public static async Task SeedAsync(BillPaymentSchedulerContext context, ILogger logger, IPasswordHasher passwordHasher)
     {
         ArgumentNullException.ThrowIfNull(context);
         ArgumentNullException.ThrowIfNull(logger);

--- a/BloodPressureMonitor/src/BloodPressureMonitor.Infrastructure/BloodPressureMonitor.Infrastructure.csproj
+++ b/BloodPressureMonitor/src/BloodPressureMonitor.Infrastructure/BloodPressureMonitor.Infrastructure.csproj
@@ -7,6 +7,16 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <FrameworkReference Include="Microsoft.AspNetCore.App" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="8.0.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="8.0.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="8.0.0" />
+  </ItemGroup>
+
+  <ItemGroup>
     <ProjectReference Include="..\BloodPressureMonitor.Core\BloodPressureMonitor.Core.csproj" />
   </ItemGroup>
 

--- a/BloodPressureMonitor/src/BloodPressureMonitor.Infrastructure/Data/BloodPressureMonitorContext.cs
+++ b/BloodPressureMonitor/src/BloodPressureMonitor.Infrastructure/Data/BloodPressureMonitorContext.cs
@@ -49,18 +49,13 @@ public class BloodPressureMonitorContext : DbContext, IBloodPressureMonitorConte
     /// <inheritdoc/>
     protected override void OnModelCreating(ModelBuilder modelBuilder)
     {
-        
-        // Apply tenant filter to User
-        modelBuilder.Entity<User>().HasQueryFilter(u => u.TenantId == _tenantContext.TenantId);
-
-        // Apply tenant filter to Role
-        modelBuilder.Entity<Role>().HasQueryFilter(r => r.TenantId == _tenantContext.TenantId);
-
         base.OnModelCreating(modelBuilder);
 
         // Apply tenant isolation filters
         if (_tenantContext != null)
         {
+            modelBuilder.Entity<User>().HasQueryFilter(u => u.TenantId == _tenantContext.TenantId);
+            modelBuilder.Entity<Role>().HasQueryFilter(r => r.TenantId == _tenantContext.TenantId);
             modelBuilder.Entity<Reading>().HasQueryFilter(e => e.TenantId == _tenantContext.TenantId);
             modelBuilder.Entity<Trend>().HasQueryFilter(e => e.TenantId == _tenantContext.TenantId);
         }

--- a/BloodPressureMonitor/src/BloodPressureMonitor.Infrastructure/Data/SeedData.cs
+++ b/BloodPressureMonitor/src/BloodPressureMonitor.Infrastructure/Data/SeedData.cs
@@ -21,7 +21,7 @@ public static class SeedData
     /// <param name="context">The database context.</param>
     /// <param name="logger">The logger.</param>
     /// <returns>A task representing the asynchronous operation.</returns>
-    public static async Task SeedAsync(BloodPressureMonitorContext context context, ILogger logger, IPasswordHasher passwordHasher)
+    public static async Task SeedAsync(BloodPressureMonitorContext context, ILogger logger, IPasswordHasher passwordHasher)
     {
         ArgumentNullException.ThrowIfNull(context);
         ArgumentNullException.ThrowIfNull(logger);

--- a/BookReadingTrackerLibrary/src/BookReadingTrackerLibrary.Infrastructure/BookReadingTrackerLibrary.Infrastructure.csproj
+++ b/BookReadingTrackerLibrary/src/BookReadingTrackerLibrary.Infrastructure/BookReadingTrackerLibrary.Infrastructure.csproj
@@ -7,6 +7,16 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <FrameworkReference Include="Microsoft.AspNetCore.App" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="8.0.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="8.0.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="8.0.0" />
+  </ItemGroup>
+
+  <ItemGroup>
     <ProjectReference Include="..\BookReadingTrackerLibrary.Core\BookReadingTrackerLibrary.Core.csproj" />
   </ItemGroup>
 

--- a/BookReadingTrackerLibrary/src/BookReadingTrackerLibrary.Infrastructure/Data/BookReadingTrackerLibraryContext.cs
+++ b/BookReadingTrackerLibrary/src/BookReadingTrackerLibrary.Infrastructure/Data/BookReadingTrackerLibraryContext.cs
@@ -55,18 +55,13 @@ public class BookReadingTrackerLibraryContext : DbContext, IBookReadingTrackerLi
     /// <inheritdoc/>
     protected override void OnModelCreating(ModelBuilder modelBuilder)
     {
-        
-        // Apply tenant filter to User
-        modelBuilder.Entity<User>().HasQueryFilter(u => u.TenantId == _tenantContext.TenantId);
-
-        // Apply tenant filter to Role
-        modelBuilder.Entity<Role>().HasQueryFilter(r => r.TenantId == _tenantContext.TenantId);
-
         base.OnModelCreating(modelBuilder);
 
         // Apply tenant isolation filters
         if (_tenantContext != null)
         {
+            modelBuilder.Entity<User>().HasQueryFilter(u => u.TenantId == _tenantContext.TenantId);
+            modelBuilder.Entity<Role>().HasQueryFilter(r => r.TenantId == _tenantContext.TenantId);
             modelBuilder.Entity<Book>().HasQueryFilter(e => e.TenantId == _tenantContext.TenantId);
             modelBuilder.Entity<ReadingLog>().HasQueryFilter(e => e.TenantId == _tenantContext.TenantId);
             modelBuilder.Entity<Wishlist>().HasQueryFilter(e => e.TenantId == _tenantContext.TenantId);

--- a/BookReadingTrackerLibrary/src/BookReadingTrackerLibrary.Infrastructure/Data/SeedData.cs
+++ b/BookReadingTrackerLibrary/src/BookReadingTrackerLibrary.Infrastructure/Data/SeedData.cs
@@ -21,7 +21,7 @@ public static class SeedData
     /// <param name="context">The database context.</param>
     /// <param name="logger">The logger.</param>
     /// <returns>A task representing the asynchronous operation.</returns>
-    public static async Task SeedAsync(BookReadingTrackerLibraryContext context context, ILogger logger, IPasswordHasher passwordHasher)
+    public static async Task SeedAsync(BookReadingTrackerLibraryContext context, ILogger logger, IPasswordHasher passwordHasher)
     {
         ArgumentNullException.ThrowIfNull(context);
         ArgumentNullException.ThrowIfNull(logger);

--- a/BucketListManager/src/BucketListManager.Infrastructure/BucketListManager.Infrastructure.csproj
+++ b/BucketListManager/src/BucketListManager.Infrastructure/BucketListManager.Infrastructure.csproj
@@ -7,6 +7,16 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <FrameworkReference Include="Microsoft.AspNetCore.App" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="8.0.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="8.0.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="8.0.0" />
+  </ItemGroup>
+
+  <ItemGroup>
     <ProjectReference Include="..\BucketListManager.Core\BucketListManager.Core.csproj" />
   </ItemGroup>
 

--- a/BucketListManager/src/BucketListManager.Infrastructure/Data/BucketListManagerContext.cs
+++ b/BucketListManager/src/BucketListManager.Infrastructure/Data/BucketListManagerContext.cs
@@ -52,18 +52,13 @@ public class BucketListManagerContext : DbContext, IBucketListManagerContext
     /// <inheritdoc/>
     protected override void OnModelCreating(ModelBuilder modelBuilder)
     {
-        
-        // Apply tenant filter to User
-        modelBuilder.Entity<User>().HasQueryFilter(u => u.TenantId == _tenantContext.TenantId);
-
-        // Apply tenant filter to Role
-        modelBuilder.Entity<Role>().HasQueryFilter(r => r.TenantId == _tenantContext.TenantId);
-
         base.OnModelCreating(modelBuilder);
 
         // Apply tenant isolation filters
         if (_tenantContext != null)
         {
+            modelBuilder.Entity<User>().HasQueryFilter(u => u.TenantId == _tenantContext.TenantId);
+            modelBuilder.Entity<Role>().HasQueryFilter(r => r.TenantId == _tenantContext.TenantId);
             modelBuilder.Entity<BucketListItem>().HasQueryFilter(e => e.TenantId == _tenantContext.TenantId);
             modelBuilder.Entity<Milestone>().HasQueryFilter(e => e.TenantId == _tenantContext.TenantId);
             modelBuilder.Entity<Memory>().HasQueryFilter(e => e.TenantId == _tenantContext.TenantId);

--- a/BucketListManager/src/BucketListManager.Infrastructure/Data/SeedData.cs
+++ b/BucketListManager/src/BucketListManager.Infrastructure/Data/SeedData.cs
@@ -21,7 +21,7 @@ public static class SeedData
     /// <param name="context">The database context.</param>
     /// <param name="logger">The logger.</param>
     /// <returns>A task representing the asynchronous operation.</returns>
-    public static async Task SeedAsync(BucketListManagerContext context context, ILogger logger, IPasswordHasher passwordHasher)
+    public static async Task SeedAsync(BucketListManagerContext context, ILogger logger, IPasswordHasher passwordHasher)
     {
         ArgumentNullException.ThrowIfNull(context);
         ArgumentNullException.ThrowIfNull(logger);

--- a/CampingTripPlanner/src/CampingTripPlanner.Infrastructure/CampingTripPlanner.Infrastructure.csproj
+++ b/CampingTripPlanner/src/CampingTripPlanner.Infrastructure/CampingTripPlanner.Infrastructure.csproj
@@ -7,6 +7,16 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <FrameworkReference Include="Microsoft.AspNetCore.App" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="8.0.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="8.0.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="8.0.0" />
+  </ItemGroup>
+
+  <ItemGroup>
     <ProjectReference Include="..\CampingTripPlanner.Core\CampingTripPlanner.Core.csproj" />
   </ItemGroup>
 

--- a/CampingTripPlanner/src/CampingTripPlanner.Infrastructure/Data/CampingTripPlannerContext.cs
+++ b/CampingTripPlanner/src/CampingTripPlanner.Infrastructure/Data/CampingTripPlannerContext.cs
@@ -55,18 +55,13 @@ public class CampingTripPlannerContext : DbContext, ICampingTripPlannerContext
     /// <inheritdoc/>
     protected override void OnModelCreating(ModelBuilder modelBuilder)
     {
-        
-        // Apply tenant filter to User
-        modelBuilder.Entity<User>().HasQueryFilter(u => u.TenantId == _tenantContext.TenantId);
-
-        // Apply tenant filter to Role
-        modelBuilder.Entity<Role>().HasQueryFilter(r => r.TenantId == _tenantContext.TenantId);
-
         base.OnModelCreating(modelBuilder);
 
         // Apply tenant isolation filters
         if (_tenantContext != null)
         {
+            modelBuilder.Entity<User>().HasQueryFilter(u => u.TenantId == _tenantContext.TenantId);
+            modelBuilder.Entity<Role>().HasQueryFilter(r => r.TenantId == _tenantContext.TenantId);
             modelBuilder.Entity<Trip>().HasQueryFilter(e => e.TenantId == _tenantContext.TenantId);
             modelBuilder.Entity<Campsite>().HasQueryFilter(e => e.TenantId == _tenantContext.TenantId);
             modelBuilder.Entity<GearChecklist>().HasQueryFilter(e => e.TenantId == _tenantContext.TenantId);

--- a/CampingTripPlanner/src/CampingTripPlanner.Infrastructure/Data/SeedData.cs
+++ b/CampingTripPlanner/src/CampingTripPlanner.Infrastructure/Data/SeedData.cs
@@ -21,7 +21,7 @@ public static class SeedData
     /// <param name="context">The database context.</param>
     /// <param name="logger">The logger.</param>
     /// <returns>A task representing the asynchronous operation.</returns>
-    public static async Task SeedAsync(CampingTripPlannerContext context context, ILogger logger, IPasswordHasher passwordHasher)
+    public static async Task SeedAsync(CampingTripPlannerContext context, ILogger logger, IPasswordHasher passwordHasher)
     {
         ArgumentNullException.ThrowIfNull(context);
         ArgumentNullException.ThrowIfNull(logger);

--- a/CarModificationPartsDatabase/src/CarModificationPartsDatabase.Infrastructure/CarModificationPartsDatabase.Infrastructure.csproj
+++ b/CarModificationPartsDatabase/src/CarModificationPartsDatabase.Infrastructure/CarModificationPartsDatabase.Infrastructure.csproj
@@ -7,6 +7,16 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <FrameworkReference Include="Microsoft.AspNetCore.App" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="8.0.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="8.0.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="8.0.0" />
+  </ItemGroup>
+
+  <ItemGroup>
     <ProjectReference Include="..\CarModificationPartsDatabase.Core\CarModificationPartsDatabase.Core.csproj" />
   </ItemGroup>
 

--- a/CarModificationPartsDatabase/src/CarModificationPartsDatabase.Infrastructure/Data/CarModificationPartsDatabaseContext.cs
+++ b/CarModificationPartsDatabase/src/CarModificationPartsDatabase.Infrastructure/Data/CarModificationPartsDatabaseContext.cs
@@ -52,18 +52,13 @@ public class CarModificationPartsDatabaseContext : DbContext, ICarModificationPa
     /// <inheritdoc/>
     protected override void OnModelCreating(ModelBuilder modelBuilder)
     {
-        
-        // Apply tenant filter to User
-        modelBuilder.Entity<User>().HasQueryFilter(u => u.TenantId == _tenantContext.TenantId);
-
-        // Apply tenant filter to Role
-        modelBuilder.Entity<Role>().HasQueryFilter(r => r.TenantId == _tenantContext.TenantId);
-
         base.OnModelCreating(modelBuilder);
 
         // Apply tenant isolation filters
         if (_tenantContext != null)
         {
+            modelBuilder.Entity<User>().HasQueryFilter(u => u.TenantId == _tenantContext.TenantId);
+            modelBuilder.Entity<Role>().HasQueryFilter(r => r.TenantId == _tenantContext.TenantId);
             modelBuilder.Entity<Modification>().HasQueryFilter(e => e.TenantId == _tenantContext.TenantId);
             modelBuilder.Entity<Part>().HasQueryFilter(e => e.TenantId == _tenantContext.TenantId);
             modelBuilder.Entity<Installation>().HasQueryFilter(e => e.TenantId == _tenantContext.TenantId);

--- a/CarModificationPartsDatabase/src/CarModificationPartsDatabase.Infrastructure/Data/SeedData.cs
+++ b/CarModificationPartsDatabase/src/CarModificationPartsDatabase.Infrastructure/Data/SeedData.cs
@@ -21,7 +21,7 @@ public static class SeedData
     /// <param name="context">The database context.</param>
     /// <param name="logger">The logger.</param>
     /// <returns>A task representing the asynchronous operation.</returns>
-    public static async Task SeedAsync(CarModificationPartsDatabaseContext context context, ILogger logger, IPasswordHasher passwordHasher)
+    public static async Task SeedAsync(CarModificationPartsDatabaseContext context, ILogger logger, IPasswordHasher passwordHasher)
     {
         ArgumentNullException.ThrowIfNull(context);
         ArgumentNullException.ThrowIfNull(logger);

--- a/CharitableGivingTracker/src/CharitableGivingTracker.Infrastructure/CharitableGivingTracker.Infrastructure.csproj
+++ b/CharitableGivingTracker/src/CharitableGivingTracker.Infrastructure/CharitableGivingTracker.Infrastructure.csproj
@@ -7,6 +7,16 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <FrameworkReference Include="Microsoft.AspNetCore.App" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="8.0.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="8.0.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="8.0.0" />
+  </ItemGroup>
+
+  <ItemGroup>
     <ProjectReference Include="..\CharitableGivingTracker.Core\CharitableGivingTracker.Core.csproj" />
   </ItemGroup>
 

--- a/CharitableGivingTracker/src/CharitableGivingTracker.Infrastructure/Data/CharitableGivingTrackerContext.cs
+++ b/CharitableGivingTracker/src/CharitableGivingTracker.Infrastructure/Data/CharitableGivingTrackerContext.cs
@@ -52,18 +52,13 @@ public class CharitableGivingTrackerContext : DbContext, ICharitableGivingTracke
     /// <inheritdoc/>
     protected override void OnModelCreating(ModelBuilder modelBuilder)
     {
-        
-        // Apply tenant filter to User
-        modelBuilder.Entity<User>().HasQueryFilter(u => u.TenantId == _tenantContext.TenantId);
-
-        // Apply tenant filter to Role
-        modelBuilder.Entity<Role>().HasQueryFilter(r => r.TenantId == _tenantContext.TenantId);
-
         base.OnModelCreating(modelBuilder);
 
         // Apply tenant isolation filters
         if (_tenantContext != null)
         {
+            modelBuilder.Entity<User>().HasQueryFilter(u => u.TenantId == _tenantContext.TenantId);
+            modelBuilder.Entity<Role>().HasQueryFilter(r => r.TenantId == _tenantContext.TenantId);
             modelBuilder.Entity<Donation>().HasQueryFilter(e => e.TenantId == _tenantContext.TenantId);
             modelBuilder.Entity<Organization>().HasQueryFilter(e => e.TenantId == _tenantContext.TenantId);
             modelBuilder.Entity<TaxReport>().HasQueryFilter(e => e.TenantId == _tenantContext.TenantId);

--- a/CharitableGivingTracker/src/CharitableGivingTracker.Infrastructure/Data/SeedData.cs
+++ b/CharitableGivingTracker/src/CharitableGivingTracker.Infrastructure/Data/SeedData.cs
@@ -21,7 +21,7 @@ public static class SeedData
     /// <param name="context">The database context.</param>
     /// <param name="logger">The logger.</param>
     /// <returns>A task representing the asynchronous operation.</returns>
-    public static async Task SeedAsync(CharitableGivingTrackerContext context context, ILogger logger, IPasswordHasher passwordHasher)
+    public static async Task SeedAsync(CharitableGivingTrackerContext context, ILogger logger, IPasswordHasher passwordHasher)
     {
         ArgumentNullException.ThrowIfNull(context);
         ArgumentNullException.ThrowIfNull(logger);

--- a/ChoreAssignmentTracker/src/ChoreAssignmentTracker.Infrastructure/ChoreAssignmentTracker.Infrastructure.csproj
+++ b/ChoreAssignmentTracker/src/ChoreAssignmentTracker.Infrastructure/ChoreAssignmentTracker.Infrastructure.csproj
@@ -7,6 +7,10 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <FrameworkReference Include="Microsoft.AspNetCore.App" />
+  </ItemGroup>
+
+  <ItemGroup>
     <PackageReference Include="Microsoft.EntityFrameworkCore" Version="8.0.0" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="8.0.0" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="8.0.0" />

--- a/ChoreAssignmentTracker/src/ChoreAssignmentTracker.Infrastructure/Data/ChoreAssignmentTrackerContext.cs
+++ b/ChoreAssignmentTracker/src/ChoreAssignmentTracker.Infrastructure/Data/ChoreAssignmentTrackerContext.cs
@@ -66,18 +66,13 @@ public class ChoreAssignmentTrackerContext : DbContext, IChoreAssignmentTrackerC
     /// <param name="modelBuilder">The builder being used to construct the model for this context.</param>
     protected override void OnModelCreating(ModelBuilder modelBuilder)
     {
-        
-        // Apply tenant filter to User
-        modelBuilder.Entity<User>().HasQueryFilter(u => u.TenantId == _tenantContext.TenantId);
-
-        // Apply tenant filter to Role
-        modelBuilder.Entity<Role>().HasQueryFilter(r => r.TenantId == _tenantContext.TenantId);
-
         base.OnModelCreating(modelBuilder);
 
         // Apply tenant isolation filters
         if (_tenantContext != null)
         {
+            modelBuilder.Entity<User>().HasQueryFilter(u => u.TenantId == _tenantContext.TenantId);
+            modelBuilder.Entity<Role>().HasQueryFilter(r => r.TenantId == _tenantContext.TenantId);
             modelBuilder.Entity<Chore>().HasQueryFilter(e => e.TenantId == _tenantContext.TenantId);
             modelBuilder.Entity<Assignment>().HasQueryFilter(e => e.TenantId == _tenantContext.TenantId);
             modelBuilder.Entity<Reward>().HasQueryFilter(e => e.TenantId == _tenantContext.TenantId);

--- a/CollegeSavingsPlanner/src/CollegeSavingsPlanner.Infrastructure/CollegeSavingsPlanner.Infrastructure.csproj
+++ b/CollegeSavingsPlanner/src/CollegeSavingsPlanner.Infrastructure/CollegeSavingsPlanner.Infrastructure.csproj
@@ -7,6 +7,10 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <FrameworkReference Include="Microsoft.AspNetCore.App" />
+  </ItemGroup>
+
+  <ItemGroup>
     <PackageReference Include="Microsoft.EntityFrameworkCore" Version="8.0.0" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="8.0.0" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="8.0.0" />

--- a/CollegeSavingsPlanner/src/CollegeSavingsPlanner.Infrastructure/Data/CollegeSavingsPlannerContext.cs
+++ b/CollegeSavingsPlanner/src/CollegeSavingsPlanner.Infrastructure/Data/CollegeSavingsPlannerContext.cs
@@ -66,18 +66,13 @@ public class CollegeSavingsPlannerContext : DbContext, ICollegeSavingsPlannerCon
     /// <param name="modelBuilder">The builder being used to construct the model for this context.</param>
     protected override void OnModelCreating(ModelBuilder modelBuilder)
     {
-        
-        // Apply tenant filter to User
-        modelBuilder.Entity<User>().HasQueryFilter(u => u.TenantId == _tenantContext.TenantId);
-
-        // Apply tenant filter to Role
-        modelBuilder.Entity<Role>().HasQueryFilter(r => r.TenantId == _tenantContext.TenantId);
-
         base.OnModelCreating(modelBuilder);
 
         // Apply tenant isolation filters
         if (_tenantContext != null)
         {
+            modelBuilder.Entity<User>().HasQueryFilter(u => u.TenantId == _tenantContext.TenantId);
+            modelBuilder.Entity<Role>().HasQueryFilter(r => r.TenantId == _tenantContext.TenantId);
             modelBuilder.Entity<Plan>().HasQueryFilter(e => e.TenantId == _tenantContext.TenantId);
             modelBuilder.Entity<Contribution>().HasQueryFilter(e => e.TenantId == _tenantContext.TenantId);
             modelBuilder.Entity<Beneficiary>().HasQueryFilter(e => e.TenantId == _tenantContext.TenantId);

--- a/ConferenceEventManager/src/ConferenceEventManager.Infrastructure/ConferenceEventManager.Infrastructure.csproj
+++ b/ConferenceEventManager/src/ConferenceEventManager.Infrastructure/ConferenceEventManager.Infrastructure.csproj
@@ -7,6 +7,10 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <FrameworkReference Include="Microsoft.AspNetCore.App" />
+  </ItemGroup>
+
+  <ItemGroup>
     <PackageReference Include="Microsoft.EntityFrameworkCore" Version="8.0.0" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="8.0.0" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="8.0.0" />

--- a/ConferenceEventManager/src/ConferenceEventManager.Infrastructure/Data/ConferenceEventManagerContext.cs
+++ b/ConferenceEventManager/src/ConferenceEventManager.Infrastructure/Data/ConferenceEventManagerContext.cs
@@ -66,18 +66,13 @@ public class ConferenceEventManagerContext : DbContext, IConferenceEventManagerC
     /// <param name="modelBuilder">The builder being used to construct the model for this context.</param>
     protected override void OnModelCreating(ModelBuilder modelBuilder)
     {
-        
-        // Apply tenant filter to User
-        modelBuilder.Entity<User>().HasQueryFilter(u => u.TenantId == _tenantContext.TenantId);
-
-        // Apply tenant filter to Role
-        modelBuilder.Entity<Role>().HasQueryFilter(r => r.TenantId == _tenantContext.TenantId);
-
         base.OnModelCreating(modelBuilder);
 
         // Apply tenant isolation filters
         if (_tenantContext != null)
         {
+            modelBuilder.Entity<User>().HasQueryFilter(u => u.TenantId == _tenantContext.TenantId);
+            modelBuilder.Entity<Role>().HasQueryFilter(r => r.TenantId == _tenantContext.TenantId);
             modelBuilder.Entity<Event>().HasQueryFilter(e => e.TenantId == _tenantContext.TenantId);
             modelBuilder.Entity<Session>().HasQueryFilter(e => e.TenantId == _tenantContext.TenantId);
             modelBuilder.Entity<Contact>().HasQueryFilter(e => e.TenantId == _tenantContext.TenantId);

--- a/ConversationStarterApp/src/ConversationStarterApp.Infrastructure/ConversationStarterApp.Infrastructure.csproj
+++ b/ConversationStarterApp/src/ConversationStarterApp.Infrastructure/ConversationStarterApp.Infrastructure.csproj
@@ -7,6 +7,10 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <FrameworkReference Include="Microsoft.AspNetCore.App" />
+  </ItemGroup>
+
+  <ItemGroup>
     <PackageReference Include="Microsoft.EntityFrameworkCore" Version="8.0.0" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="8.0.0" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="8.0.0" />

--- a/ConversationStarterApp/src/ConversationStarterApp.Infrastructure/Data/ConversationStarterAppContext.cs
+++ b/ConversationStarterApp/src/ConversationStarterApp.Infrastructure/Data/ConversationStarterAppContext.cs
@@ -61,18 +61,13 @@ public class ConversationStarterAppContext : DbContext, IConversationStarterAppC
     /// <param name="modelBuilder">The builder being used to construct the model for this context.</param>
     protected override void OnModelCreating(ModelBuilder modelBuilder)
     {
-        
-        // Apply tenant filter to User
-        modelBuilder.Entity<User>().HasQueryFilter(u => u.TenantId == _tenantContext.TenantId);
-
-        // Apply tenant filter to Role
-        modelBuilder.Entity<Role>().HasQueryFilter(r => r.TenantId == _tenantContext.TenantId);
-
         base.OnModelCreating(modelBuilder);
 
         // Apply tenant isolation filters
         if (_tenantContext != null)
         {
+            modelBuilder.Entity<User>().HasQueryFilter(u => u.TenantId == _tenantContext.TenantId);
+            modelBuilder.Entity<Role>().HasQueryFilter(r => r.TenantId == _tenantContext.TenantId);
             modelBuilder.Entity<Prompt>().HasQueryFilter(e => e.TenantId == _tenantContext.TenantId);
             modelBuilder.Entity<Favorite>().HasQueryFilter(e => e.TenantId == _tenantContext.TenantId);
             modelBuilder.Entity<Session>().HasQueryFilter(e => e.TenantId == _tenantContext.TenantId);

--- a/CouplesGoalTracker/src/CouplesGoalTracker.Infrastructure/CouplesGoalTracker.Infrastructure.csproj
+++ b/CouplesGoalTracker/src/CouplesGoalTracker.Infrastructure/CouplesGoalTracker.Infrastructure.csproj
@@ -7,6 +7,16 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <FrameworkReference Include="Microsoft.AspNetCore.App" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="8.0.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="8.0.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="8.0.0" />
+  </ItemGroup>
+
+  <ItemGroup>
     <ProjectReference Include="..\CouplesGoalTracker.Core\CouplesGoalTracker.Core.csproj" />
   </ItemGroup>
 

--- a/CouplesGoalTracker/src/CouplesGoalTracker.Infrastructure/Data/CouplesGoalTrackerContext.cs
+++ b/CouplesGoalTracker/src/CouplesGoalTracker.Infrastructure/Data/CouplesGoalTrackerContext.cs
@@ -52,18 +52,13 @@ public class CouplesGoalTrackerContext : DbContext, ICouplesGoalTrackerContext
     /// <inheritdoc/>
     protected override void OnModelCreating(ModelBuilder modelBuilder)
     {
-        
-        // Apply tenant filter to User
-        modelBuilder.Entity<User>().HasQueryFilter(u => u.TenantId == _tenantContext.TenantId);
-
-        // Apply tenant filter to Role
-        modelBuilder.Entity<Role>().HasQueryFilter(r => r.TenantId == _tenantContext.TenantId);
-
         base.OnModelCreating(modelBuilder);
 
         // Apply tenant isolation filters
         if (_tenantContext != null)
         {
+            modelBuilder.Entity<User>().HasQueryFilter(u => u.TenantId == _tenantContext.TenantId);
+            modelBuilder.Entity<Role>().HasQueryFilter(r => r.TenantId == _tenantContext.TenantId);
             modelBuilder.Entity<Goal>().HasQueryFilter(e => e.TenantId == _tenantContext.TenantId);
             modelBuilder.Entity<Milestone>().HasQueryFilter(e => e.TenantId == _tenantContext.TenantId);
             modelBuilder.Entity<Progress>().HasQueryFilter(e => e.TenantId == _tenantContext.TenantId);

--- a/CouplesGoalTracker/src/CouplesGoalTracker.Infrastructure/Data/SeedData.cs
+++ b/CouplesGoalTracker/src/CouplesGoalTracker.Infrastructure/Data/SeedData.cs
@@ -21,7 +21,7 @@ public static class SeedData
     /// <param name="context">The database context.</param>
     /// <param name="logger">The logger.</param>
     /// <returns>A task representing the asynchronous operation.</returns>
-    public static async Task SeedAsync(CouplesGoalTrackerContext context context, ILogger logger, IPasswordHasher passwordHasher)
+    public static async Task SeedAsync(CouplesGoalTrackerContext context, ILogger logger, IPasswordHasher passwordHasher)
     {
         ArgumentNullException.ThrowIfNull(context);
         ArgumentNullException.ThrowIfNull(logger);

--- a/DailyJournalingApp/src/DailyJournalingApp.Infrastructure/DailyJournalingApp.Infrastructure.csproj
+++ b/DailyJournalingApp/src/DailyJournalingApp.Infrastructure/DailyJournalingApp.Infrastructure.csproj
@@ -7,6 +7,16 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <FrameworkReference Include="Microsoft.AspNetCore.App" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="8.0.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="8.0.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="8.0.0" />
+  </ItemGroup>
+
+  <ItemGroup>
     <ProjectReference Include="..\DailyJournalingApp.Core\DailyJournalingApp.Core.csproj" />
   </ItemGroup>
 

--- a/DailyJournalingApp/src/DailyJournalingApp.Infrastructure/Data/DailyJournalingAppContext.cs
+++ b/DailyJournalingApp/src/DailyJournalingApp.Infrastructure/Data/DailyJournalingAppContext.cs
@@ -52,18 +52,13 @@ public class DailyJournalingAppContext : DbContext, IDailyJournalingAppContext
     /// <inheritdoc/>
     protected override void OnModelCreating(ModelBuilder modelBuilder)
     {
-        
-        // Apply tenant filter to User
-        modelBuilder.Entity<User>().HasQueryFilter(u => u.TenantId == _tenantContext.TenantId);
-
-        // Apply tenant filter to Role
-        modelBuilder.Entity<Role>().HasQueryFilter(r => r.TenantId == _tenantContext.TenantId);
-
         base.OnModelCreating(modelBuilder);
 
         // Apply tenant isolation filters
         if (_tenantContext != null)
         {
+            modelBuilder.Entity<User>().HasQueryFilter(u => u.TenantId == _tenantContext.TenantId);
+            modelBuilder.Entity<Role>().HasQueryFilter(r => r.TenantId == _tenantContext.TenantId);
             modelBuilder.Entity<JournalEntry>().HasQueryFilter(e => e.TenantId == _tenantContext.TenantId);
             modelBuilder.Entity<Prompt>().HasQueryFilter(e => e.TenantId == _tenantContext.TenantId);
             modelBuilder.Entity<Tag>().HasQueryFilter(e => e.TenantId == _tenantContext.TenantId);

--- a/DailyJournalingApp/src/DailyJournalingApp.Infrastructure/Data/SeedData.cs
+++ b/DailyJournalingApp/src/DailyJournalingApp.Infrastructure/Data/SeedData.cs
@@ -21,7 +21,7 @@ public static class SeedData
     /// <param name="context">The database context.</param>
     /// <param name="logger">The logger.</param>
     /// <returns>A task representing the asynchronous operation.</returns>
-    public static async Task SeedAsync(DailyJournalingAppContext context context, ILogger logger, IPasswordHasher passwordHasher)
+    public static async Task SeedAsync(DailyJournalingAppContext context, ILogger logger, IPasswordHasher passwordHasher)
     {
         ArgumentNullException.ThrowIfNull(context);
         ArgumentNullException.ThrowIfNull(logger);

--- a/DateNightIdeaGenerator/src/DateNightIdeaGenerator.Infrastructure/Data/DateNightIdeaGeneratorContext.cs
+++ b/DateNightIdeaGenerator/src/DateNightIdeaGenerator.Infrastructure/Data/DateNightIdeaGeneratorContext.cs
@@ -57,12 +57,8 @@ public class DateNightIdeaGeneratorContext : DbContext, IDateNightIdeaGeneratorC
         // Apply tenant isolation filters
         if (_tenantContext != null)
         {
-            // Apply tenant filter to User
             modelBuilder.Entity<User>().HasQueryFilter(u => u.TenantId == _tenantContext.TenantId);
-
-            // Apply tenant filter to Role
             modelBuilder.Entity<Role>().HasQueryFilter(r => r.TenantId == _tenantContext.TenantId);
-
             modelBuilder.Entity<DateIdea>().HasQueryFilter(e => e.TenantId == _tenantContext.TenantId);
             modelBuilder.Entity<Experience>().HasQueryFilter(e => e.TenantId == _tenantContext.TenantId);
             modelBuilder.Entity<Rating>().HasQueryFilter(e => e.TenantId == _tenantContext.TenantId);

--- a/DateNightIdeaGenerator/src/DateNightIdeaGenerator.Infrastructure/DateNightIdeaGenerator.Infrastructure.csproj
+++ b/DateNightIdeaGenerator/src/DateNightIdeaGenerator.Infrastructure/DateNightIdeaGenerator.Infrastructure.csproj
@@ -7,6 +7,16 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <FrameworkReference Include="Microsoft.AspNetCore.App" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="8.0.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="8.0.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="8.0.0" />
+  </ItemGroup>
+
+  <ItemGroup>
     <ProjectReference Include="..\DateNightIdeaGenerator.Core\DateNightIdeaGenerator.Core.csproj" />
   </ItemGroup>
 

--- a/DigitalLegacyPlanner/src/DigitalLegacyPlanner.Infrastructure/Data/DigitalLegacyPlannerContext.cs
+++ b/DigitalLegacyPlanner/src/DigitalLegacyPlanner.Infrastructure/Data/DigitalLegacyPlannerContext.cs
@@ -55,18 +55,13 @@ public class DigitalLegacyPlannerContext : DbContext, IDigitalLegacyPlannerConte
     /// <inheritdoc/>
     protected override void OnModelCreating(ModelBuilder modelBuilder)
     {
-        
-        // Apply tenant filter to User
-        modelBuilder.Entity<User>().HasQueryFilter(u => u.TenantId == _tenantContext.TenantId);
-
-        // Apply tenant filter to Role
-        modelBuilder.Entity<Role>().HasQueryFilter(r => r.TenantId == _tenantContext.TenantId);
-
         base.OnModelCreating(modelBuilder);
 
         // Apply tenant isolation filters
         if (_tenantContext != null)
         {
+            modelBuilder.Entity<User>().HasQueryFilter(u => u.TenantId == _tenantContext.TenantId);
+            modelBuilder.Entity<Role>().HasQueryFilter(r => r.TenantId == _tenantContext.TenantId);
             modelBuilder.Entity<DigitalAccount>().HasQueryFilter(e => e.TenantId == _tenantContext.TenantId);
             modelBuilder.Entity<LegacyInstruction>().HasQueryFilter(e => e.TenantId == _tenantContext.TenantId);
             modelBuilder.Entity<TrustedContact>().HasQueryFilter(e => e.TenantId == _tenantContext.TenantId);

--- a/DigitalLegacyPlanner/src/DigitalLegacyPlanner.Infrastructure/Data/SeedData.cs
+++ b/DigitalLegacyPlanner/src/DigitalLegacyPlanner.Infrastructure/Data/SeedData.cs
@@ -21,7 +21,7 @@ public static class SeedData
     /// <param name="context">The database context.</param>
     /// <param name="logger">The logger.</param>
     /// <returns>A task representing the asynchronous operation.</returns>
-    public static async Task SeedAsync(DigitalLegacyPlannerContext context context, ILogger logger, IPasswordHasher passwordHasher)
+    public static async Task SeedAsync(DigitalLegacyPlannerContext context, ILogger logger, IPasswordHasher passwordHasher)
     {
         ArgumentNullException.ThrowIfNull(context);
         ArgumentNullException.ThrowIfNull(logger);

--- a/DigitalLegacyPlanner/src/DigitalLegacyPlanner.Infrastructure/DigitalLegacyPlanner.Infrastructure.csproj
+++ b/DigitalLegacyPlanner/src/DigitalLegacyPlanner.Infrastructure/DigitalLegacyPlanner.Infrastructure.csproj
@@ -7,6 +7,16 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <FrameworkReference Include="Microsoft.AspNetCore.App" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="8.0.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="8.0.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="8.0.0" />
+  </ItemGroup>
+
+  <ItemGroup>
     <ProjectReference Include="..\DigitalLegacyPlanner.Core\DigitalLegacyPlanner.Core.csproj" />
   </ItemGroup>
 

--- a/FamilyCalendarEventPlanner/src/FamilyCalendarEventPlanner.Infrastructure/FamilyCalendarEventPlanner.Infrastructure.csproj
+++ b/FamilyCalendarEventPlanner/src/FamilyCalendarEventPlanner.Infrastructure/FamilyCalendarEventPlanner.Infrastructure.csproj
@@ -7,8 +7,13 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <FrameworkReference Include="Microsoft.AspNetCore.App" />
+  </ItemGroup>
+
+  <ItemGroup>
     <PackageReference Include="Microsoft.EntityFrameworkCore" Version="8.0.0" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="8.0.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="8.0.0" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="8.0.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/FamilyPhotoAlbumOrganizer/src/FamilyPhotoAlbumOrganizer.Infrastructure/Data/FamilyPhotoAlbumOrganizerContext.cs
+++ b/FamilyPhotoAlbumOrganizer/src/FamilyPhotoAlbumOrganizer.Infrastructure/Data/FamilyPhotoAlbumOrganizerContext.cs
@@ -55,18 +55,13 @@ public class FamilyPhotoAlbumOrganizerContext : DbContext, IFamilyPhotoAlbumOrga
     /// <inheritdoc/>
     protected override void OnModelCreating(ModelBuilder modelBuilder)
     {
-        
-        // Apply tenant filter to User
-        modelBuilder.Entity<User>().HasQueryFilter(u => u.TenantId == _tenantContext.TenantId);
-
-        // Apply tenant filter to Role
-        modelBuilder.Entity<Role>().HasQueryFilter(r => r.TenantId == _tenantContext.TenantId);
-
         base.OnModelCreating(modelBuilder);
 
         // Apply tenant isolation filters
         if (_tenantContext != null)
         {
+            modelBuilder.Entity<User>().HasQueryFilter(u => u.TenantId == _tenantContext.TenantId);
+            modelBuilder.Entity<Role>().HasQueryFilter(r => r.TenantId == _tenantContext.TenantId);
             modelBuilder.Entity<Photo>().HasQueryFilter(e => e.TenantId == _tenantContext.TenantId);
             modelBuilder.Entity<Album>().HasQueryFilter(e => e.TenantId == _tenantContext.TenantId);
             modelBuilder.Entity<Tag>().HasQueryFilter(e => e.TenantId == _tenantContext.TenantId);

--- a/FamilyPhotoAlbumOrganizer/src/FamilyPhotoAlbumOrganizer.Infrastructure/Data/SeedData.cs
+++ b/FamilyPhotoAlbumOrganizer/src/FamilyPhotoAlbumOrganizer.Infrastructure/Data/SeedData.cs
@@ -21,7 +21,7 @@ public static class SeedData
     /// <param name="context">The database context.</param>
     /// <param name="logger">The logger.</param>
     /// <returns>A task representing the asynchronous operation.</returns>
-    public static async Task SeedAsync(FamilyPhotoAlbumOrganizerContext context context, ILogger logger, IPasswordHasher passwordHasher)
+    public static async Task SeedAsync(FamilyPhotoAlbumOrganizerContext context, ILogger logger, IPasswordHasher passwordHasher)
     {
         ArgumentNullException.ThrowIfNull(context);
         ArgumentNullException.ThrowIfNull(logger);

--- a/FamilyPhotoAlbumOrganizer/src/FamilyPhotoAlbumOrganizer.Infrastructure/FamilyPhotoAlbumOrganizer.Infrastructure.csproj
+++ b/FamilyPhotoAlbumOrganizer/src/FamilyPhotoAlbumOrganizer.Infrastructure/FamilyPhotoAlbumOrganizer.Infrastructure.csproj
@@ -7,6 +7,16 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <FrameworkReference Include="Microsoft.AspNetCore.App" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="8.0.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="8.0.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="8.0.0" />
+  </ItemGroup>
+
+  <ItemGroup>
     <ProjectReference Include="..\FamilyPhotoAlbumOrganizer.Core\FamilyPhotoAlbumOrganizer.Core.csproj" />
   </ItemGroup>
 

--- a/FamilyTreeBuilder/src/FamilyTreeBuilder.Infrastructure/Data/FamilyTreeBuilderContext.cs
+++ b/FamilyTreeBuilder/src/FamilyTreeBuilder.Infrastructure/Data/FamilyTreeBuilderContext.cs
@@ -55,18 +55,13 @@ public class FamilyTreeBuilderContext : DbContext, IFamilyTreeBuilderContext
     /// <inheritdoc/>
     protected override void OnModelCreating(ModelBuilder modelBuilder)
     {
-        
-        // Apply tenant filter to User
-        modelBuilder.Entity<User>().HasQueryFilter(u => u.TenantId == _tenantContext.TenantId);
-
-        // Apply tenant filter to Role
-        modelBuilder.Entity<Role>().HasQueryFilter(r => r.TenantId == _tenantContext.TenantId);
-
         base.OnModelCreating(modelBuilder);
 
         // Apply tenant isolation filters
         if (_tenantContext != null)
         {
+            modelBuilder.Entity<User>().HasQueryFilter(u => u.TenantId == _tenantContext.TenantId);
+            modelBuilder.Entity<Role>().HasQueryFilter(r => r.TenantId == _tenantContext.TenantId);
             modelBuilder.Entity<Person>().HasQueryFilter(e => e.TenantId == _tenantContext.TenantId);
             modelBuilder.Entity<Relationship>().HasQueryFilter(e => e.TenantId == _tenantContext.TenantId);
             modelBuilder.Entity<Story>().HasQueryFilter(e => e.TenantId == _tenantContext.TenantId);

--- a/FamilyTreeBuilder/src/FamilyTreeBuilder.Infrastructure/Data/SeedData.cs
+++ b/FamilyTreeBuilder/src/FamilyTreeBuilder.Infrastructure/Data/SeedData.cs
@@ -21,7 +21,7 @@ public static class SeedData
     /// <param name="context">The database context.</param>
     /// <param name="logger">The logger.</param>
     /// <returns>A task representing the asynchronous operation.</returns>
-    public static async Task SeedAsync(FamilyTreeBuilderContext context context, ILogger logger, IPasswordHasher passwordHasher)
+    public static async Task SeedAsync(FamilyTreeBuilderContext context, ILogger logger, IPasswordHasher passwordHasher)
     {
         ArgumentNullException.ThrowIfNull(context);
         ArgumentNullException.ThrowIfNull(logger);

--- a/FamilyTreeBuilder/src/FamilyTreeBuilder.Infrastructure/FamilyTreeBuilder.Infrastructure.csproj
+++ b/FamilyTreeBuilder/src/FamilyTreeBuilder.Infrastructure/FamilyTreeBuilder.Infrastructure.csproj
@@ -7,6 +7,16 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <FrameworkReference Include="Microsoft.AspNetCore.App" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="8.0.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="8.0.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="8.0.0" />
+  </ItemGroup>
+
+  <ItemGroup>
     <ProjectReference Include="..\FamilyTreeBuilder.Core\FamilyTreeBuilder.Core.csproj" />
   </ItemGroup>
 

--- a/FamilyVacationPlanner/src/FamilyVacationPlanner.Infrastructure/Data/FamilyVacationPlannerContext.cs
+++ b/FamilyVacationPlanner/src/FamilyVacationPlanner.Infrastructure/Data/FamilyVacationPlannerContext.cs
@@ -58,18 +58,13 @@ public class FamilyVacationPlannerContext : DbContext, IFamilyVacationPlannerCon
     /// <inheritdoc/>
     protected override void OnModelCreating(ModelBuilder modelBuilder)
     {
-        
-        // Apply tenant filter to User
-        modelBuilder.Entity<User>().HasQueryFilter(u => u.TenantId == _tenantContext.TenantId);
-
-        // Apply tenant filter to Role
-        modelBuilder.Entity<Role>().HasQueryFilter(r => r.TenantId == _tenantContext.TenantId);
-
         base.OnModelCreating(modelBuilder);
 
         // Apply tenant isolation filters
         if (_tenantContext != null)
         {
+            modelBuilder.Entity<User>().HasQueryFilter(u => u.TenantId == _tenantContext.TenantId);
+            modelBuilder.Entity<Role>().HasQueryFilter(r => r.TenantId == _tenantContext.TenantId);
             modelBuilder.Entity<Trip>().HasQueryFilter(e => e.TenantId == _tenantContext.TenantId);
             modelBuilder.Entity<Itinerary>().HasQueryFilter(e => e.TenantId == _tenantContext.TenantId);
             modelBuilder.Entity<Booking>().HasQueryFilter(e => e.TenantId == _tenantContext.TenantId);

--- a/FamilyVacationPlanner/src/FamilyVacationPlanner.Infrastructure/Data/SeedData.cs
+++ b/FamilyVacationPlanner/src/FamilyVacationPlanner.Infrastructure/Data/SeedData.cs
@@ -21,7 +21,7 @@ public static class SeedData
     /// <param name="context">The database context.</param>
     /// <param name="logger">The logger.</param>
     /// <returns>A task representing the asynchronous operation.</returns>
-    public static async Task SeedAsync(FamilyVacationPlannerContext context context, ILogger logger, IPasswordHasher passwordHasher)
+    public static async Task SeedAsync(FamilyVacationPlannerContext context, ILogger logger, IPasswordHasher passwordHasher)
     {
         ArgumentNullException.ThrowIfNull(context);
         ArgumentNullException.ThrowIfNull(logger);

--- a/FamilyVacationPlanner/src/FamilyVacationPlanner.Infrastructure/FamilyVacationPlanner.Infrastructure.csproj
+++ b/FamilyVacationPlanner/src/FamilyVacationPlanner.Infrastructure/FamilyVacationPlanner.Infrastructure.csproj
@@ -7,6 +7,16 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <FrameworkReference Include="Microsoft.AspNetCore.App" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="8.0.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="8.0.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="8.0.0" />
+  </ItemGroup>
+
+  <ItemGroup>
     <ProjectReference Include="..\FamilyVacationPlanner.Core\FamilyVacationPlanner.Core.csproj" />
   </ItemGroup>
 

--- a/FinancialGoalTracker/src/FinancialGoalTracker.Infrastructure/Data/FinancialGoalTrackerContext.cs
+++ b/FinancialGoalTracker/src/FinancialGoalTracker.Infrastructure/Data/FinancialGoalTrackerContext.cs
@@ -52,18 +52,13 @@ public class FinancialGoalTrackerContext : DbContext, IFinancialGoalTrackerConte
     /// <inheritdoc/>
     protected override void OnModelCreating(ModelBuilder modelBuilder)
     {
-        
-        // Apply tenant filter to User
-        modelBuilder.Entity<User>().HasQueryFilter(u => u.TenantId == _tenantContext.TenantId);
-
-        // Apply tenant filter to Role
-        modelBuilder.Entity<Role>().HasQueryFilter(r => r.TenantId == _tenantContext.TenantId);
-
         base.OnModelCreating(modelBuilder);
 
         // Apply tenant isolation filters
         if (_tenantContext != null)
         {
+            modelBuilder.Entity<User>().HasQueryFilter(u => u.TenantId == _tenantContext.TenantId);
+            modelBuilder.Entity<Role>().HasQueryFilter(r => r.TenantId == _tenantContext.TenantId);
             modelBuilder.Entity<Goal>().HasQueryFilter(e => e.TenantId == _tenantContext.TenantId);
             modelBuilder.Entity<Milestone>().HasQueryFilter(e => e.TenantId == _tenantContext.TenantId);
             modelBuilder.Entity<Contribution>().HasQueryFilter(e => e.TenantId == _tenantContext.TenantId);

--- a/FinancialGoalTracker/src/FinancialGoalTracker.Infrastructure/Data/SeedData.cs
+++ b/FinancialGoalTracker/src/FinancialGoalTracker.Infrastructure/Data/SeedData.cs
@@ -21,7 +21,7 @@ public static class SeedData
     /// <param name="context">The database context.</param>
     /// <param name="logger">The logger.</param>
     /// <returns>A task representing the asynchronous operation.</returns>
-    public static async Task SeedAsync(FinancialGoalTrackerContext context context, ILogger logger, IPasswordHasher passwordHasher)
+    public static async Task SeedAsync(FinancialGoalTrackerContext context, ILogger logger, IPasswordHasher passwordHasher)
     {
         ArgumentNullException.ThrowIfNull(context);
         ArgumentNullException.ThrowIfNull(logger);

--- a/FinancialGoalTracker/src/FinancialGoalTracker.Infrastructure/FinancialGoalTracker.Infrastructure.csproj
+++ b/FinancialGoalTracker/src/FinancialGoalTracker.Infrastructure/FinancialGoalTracker.Infrastructure.csproj
@@ -7,6 +7,16 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <FrameworkReference Include="Microsoft.AspNetCore.App" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="8.0.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="8.0.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="8.0.0" />
+  </ItemGroup>
+
+  <ItemGroup>
     <ProjectReference Include="..\FinancialGoalTracker.Core\FinancialGoalTracker.Core.csproj" />
   </ItemGroup>
 

--- a/FocusSessionTracker/src/FocusSessionTracker.Infrastructure/Data/FocusSessionTrackerContext.cs
+++ b/FocusSessionTracker/src/FocusSessionTracker.Infrastructure/Data/FocusSessionTrackerContext.cs
@@ -52,18 +52,13 @@ public class FocusSessionTrackerContext : DbContext, IFocusSessionTrackerContext
     /// <inheritdoc/>
     protected override void OnModelCreating(ModelBuilder modelBuilder)
     {
-        
-        // Apply tenant filter to User
-        modelBuilder.Entity<User>().HasQueryFilter(u => u.TenantId == _tenantContext.TenantId);
-
-        // Apply tenant filter to Role
-        modelBuilder.Entity<Role>().HasQueryFilter(r => r.TenantId == _tenantContext.TenantId);
-
         base.OnModelCreating(modelBuilder);
 
         // Apply tenant isolation filters
         if (_tenantContext != null)
         {
+            modelBuilder.Entity<User>().HasQueryFilter(u => u.TenantId == _tenantContext.TenantId);
+            modelBuilder.Entity<Role>().HasQueryFilter(r => r.TenantId == _tenantContext.TenantId);
             modelBuilder.Entity<FocusSession>().HasQueryFilter(e => e.TenantId == _tenantContext.TenantId);
             modelBuilder.Entity<Distraction>().HasQueryFilter(e => e.TenantId == _tenantContext.TenantId);
             modelBuilder.Entity<SessionAnalytics>().HasQueryFilter(e => e.TenantId == _tenantContext.TenantId);

--- a/FocusSessionTracker/src/FocusSessionTracker.Infrastructure/Data/SeedData.cs
+++ b/FocusSessionTracker/src/FocusSessionTracker.Infrastructure/Data/SeedData.cs
@@ -21,7 +21,7 @@ public static class SeedData
     /// <param name="context">The database context.</param>
     /// <param name="logger">The logger.</param>
     /// <returns>A task representing the asynchronous operation.</returns>
-    public static async Task SeedAsync(FocusSessionTrackerContext context context, ILogger logger, IPasswordHasher passwordHasher)
+    public static async Task SeedAsync(FocusSessionTrackerContext context, ILogger logger, IPasswordHasher passwordHasher)
     {
         ArgumentNullException.ThrowIfNull(context);
         ArgumentNullException.ThrowIfNull(logger);

--- a/FocusSessionTracker/src/FocusSessionTracker.Infrastructure/FocusSessionTracker.Infrastructure.csproj
+++ b/FocusSessionTracker/src/FocusSessionTracker.Infrastructure/FocusSessionTracker.Infrastructure.csproj
@@ -7,6 +7,16 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <FrameworkReference Include="Microsoft.AspNetCore.App" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="8.0.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="8.0.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="8.0.0" />
+  </ItemGroup>
+
+  <ItemGroup>
     <ProjectReference Include="..\FocusSessionTracker.Core\FocusSessionTracker.Core.csproj" />
   </ItemGroup>
 

--- a/FreelanceProjectManager/src/FreelanceProjectManager.Infrastructure/Data/FreelanceProjectManagerContext.cs
+++ b/FreelanceProjectManager/src/FreelanceProjectManager.Infrastructure/Data/FreelanceProjectManagerContext.cs
@@ -55,18 +55,13 @@ public class FreelanceProjectManagerContext : DbContext, IFreelanceProjectManage
     /// <inheritdoc/>
     protected override void OnModelCreating(ModelBuilder modelBuilder)
     {
-        
-        // Apply tenant filter to User
-        modelBuilder.Entity<User>().HasQueryFilter(u => u.TenantId == _tenantContext.TenantId);
-
-        // Apply tenant filter to Role
-        modelBuilder.Entity<Role>().HasQueryFilter(r => r.TenantId == _tenantContext.TenantId);
-
         base.OnModelCreating(modelBuilder);
 
         // Apply tenant isolation filters
         if (_tenantContext != null)
         {
+            modelBuilder.Entity<User>().HasQueryFilter(u => u.TenantId == _tenantContext.TenantId);
+            modelBuilder.Entity<Role>().HasQueryFilter(r => r.TenantId == _tenantContext.TenantId);
             modelBuilder.Entity<Project>().HasQueryFilter(e => e.TenantId == _tenantContext.TenantId);
             modelBuilder.Entity<Client>().HasQueryFilter(e => e.TenantId == _tenantContext.TenantId);
             modelBuilder.Entity<TimeEntry>().HasQueryFilter(e => e.TenantId == _tenantContext.TenantId);

--- a/FreelanceProjectManager/src/FreelanceProjectManager.Infrastructure/Data/SeedData.cs
+++ b/FreelanceProjectManager/src/FreelanceProjectManager.Infrastructure/Data/SeedData.cs
@@ -21,7 +21,7 @@ public static class SeedData
     /// <param name="context">The database context.</param>
     /// <param name="logger">The logger.</param>
     /// <returns>A task representing the asynchronous operation.</returns>
-    public static async Task SeedAsync(FreelanceProjectManagerContext context context, ILogger logger, IPasswordHasher passwordHasher)
+    public static async Task SeedAsync(FreelanceProjectManagerContext context, ILogger logger, IPasswordHasher passwordHasher)
     {
         ArgumentNullException.ThrowIfNull(context);
         ArgumentNullException.ThrowIfNull(logger);

--- a/FreelanceProjectManager/src/FreelanceProjectManager.Infrastructure/FreelanceProjectManager.Infrastructure.csproj
+++ b/FreelanceProjectManager/src/FreelanceProjectManager.Infrastructure/FreelanceProjectManager.Infrastructure.csproj
@@ -7,6 +7,16 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <FrameworkReference Include="Microsoft.AspNetCore.App" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="8.0.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="8.0.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="8.0.0" />
+  </ItemGroup>
+
+  <ItemGroup>
     <ProjectReference Include="..\FreelanceProjectManager.Core\FreelanceProjectManager.Core.csproj" />
   </ItemGroup>
 

--- a/FriendGroupEventCoordinator/src/FriendGroupEventCoordinator.Infrastructure/Data/FriendGroupEventCoordinatorContext.cs
+++ b/FriendGroupEventCoordinator/src/FriendGroupEventCoordinator.Infrastructure/Data/FriendGroupEventCoordinatorContext.cs
@@ -55,18 +55,13 @@ public class FriendGroupEventCoordinatorContext : DbContext, IFriendGroupEventCo
     /// <inheritdoc/>
     protected override void OnModelCreating(ModelBuilder modelBuilder)
     {
-        
-        // Apply tenant filter to User
-        modelBuilder.Entity<User>().HasQueryFilter(u => u.TenantId == _tenantContext.TenantId);
-
-        // Apply tenant filter to Role
-        modelBuilder.Entity<Role>().HasQueryFilter(r => r.TenantId == _tenantContext.TenantId);
-
         base.OnModelCreating(modelBuilder);
 
         // Apply tenant isolation filters
         if (_tenantContext != null)
         {
+            modelBuilder.Entity<User>().HasQueryFilter(u => u.TenantId == _tenantContext.TenantId);
+            modelBuilder.Entity<Role>().HasQueryFilter(r => r.TenantId == _tenantContext.TenantId);
             modelBuilder.Entity<Event>().HasQueryFilter(e => e.TenantId == _tenantContext.TenantId);
             modelBuilder.Entity<RSVP>().HasQueryFilter(e => e.TenantId == _tenantContext.TenantId);
             modelBuilder.Entity<Group>().HasQueryFilter(e => e.TenantId == _tenantContext.TenantId);

--- a/FriendGroupEventCoordinator/src/FriendGroupEventCoordinator.Infrastructure/Data/SeedData.cs
+++ b/FriendGroupEventCoordinator/src/FriendGroupEventCoordinator.Infrastructure/Data/SeedData.cs
@@ -21,7 +21,7 @@ public static class SeedData
     /// <param name="context">The database context.</param>
     /// <param name="logger">The logger.</param>
     /// <returns>A task representing the asynchronous operation.</returns>
-    public static async Task SeedAsync(FriendGroupEventCoordinatorContext context context, ILogger logger, IPasswordHasher passwordHasher)
+    public static async Task SeedAsync(FriendGroupEventCoordinatorContext context, ILogger logger, IPasswordHasher passwordHasher)
     {
         ArgumentNullException.ThrowIfNull(context);
         ArgumentNullException.ThrowIfNull(logger);

--- a/FriendGroupEventCoordinator/src/FriendGroupEventCoordinator.Infrastructure/FriendGroupEventCoordinator.Infrastructure.csproj
+++ b/FriendGroupEventCoordinator/src/FriendGroupEventCoordinator.Infrastructure/FriendGroupEventCoordinator.Infrastructure.csproj
@@ -7,6 +7,16 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <FrameworkReference Include="Microsoft.AspNetCore.App" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="8.0.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="8.0.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="8.0.0" />
+  </ItemGroup>
+
+  <ItemGroup>
     <ProjectReference Include="..\FriendGroupEventCoordinator.Core\FriendGroupEventCoordinator.Core.csproj" />
   </ItemGroup>
 

--- a/FuelEconomyTracker/src/FuelEconomyTracker.Infrastructure/Data/FuelEconomyTrackerContext.cs
+++ b/FuelEconomyTracker/src/FuelEconomyTracker.Infrastructure/Data/FuelEconomyTrackerContext.cs
@@ -55,18 +55,13 @@ public class FuelEconomyTrackerContext : DbContext, IFuelEconomyTrackerContext
     /// <inheritdoc/>
     protected override void OnModelCreating(ModelBuilder modelBuilder)
     {
-        
-        // Apply tenant filter to User
-        modelBuilder.Entity<User>().HasQueryFilter(u => u.TenantId == _tenantContext.TenantId);
-
-        // Apply tenant filter to Role
-        modelBuilder.Entity<Role>().HasQueryFilter(r => r.TenantId == _tenantContext.TenantId);
-
         base.OnModelCreating(modelBuilder);
 
         // Apply tenant isolation filters
         if (_tenantContext != null)
         {
+            modelBuilder.Entity<User>().HasQueryFilter(u => u.TenantId == _tenantContext.TenantId);
+            modelBuilder.Entity<Role>().HasQueryFilter(r => r.TenantId == _tenantContext.TenantId);
             modelBuilder.Entity<FillUp>().HasQueryFilter(e => e.TenantId == _tenantContext.TenantId);
             modelBuilder.Entity<Trip>().HasQueryFilter(e => e.TenantId == _tenantContext.TenantId);
             modelBuilder.Entity<Vehicle>().HasQueryFilter(e => e.TenantId == _tenantContext.TenantId);

--- a/FuelEconomyTracker/src/FuelEconomyTracker.Infrastructure/Data/SeedData.cs
+++ b/FuelEconomyTracker/src/FuelEconomyTracker.Infrastructure/Data/SeedData.cs
@@ -21,7 +21,7 @@ public static class SeedData
     /// <param name="context">The database context.</param>
     /// <param name="logger">The logger.</param>
     /// <returns>A task representing the asynchronous operation.</returns>
-    public static async Task SeedAsync(FuelEconomyTrackerContext context context, ILogger logger, IPasswordHasher passwordHasher)
+    public static async Task SeedAsync(FuelEconomyTrackerContext context, ILogger logger, IPasswordHasher passwordHasher)
     {
         ArgumentNullException.ThrowIfNull(context);
         ArgumentNullException.ThrowIfNull(logger);

--- a/FuelEconomyTracker/src/FuelEconomyTracker.Infrastructure/FuelEconomyTracker.Infrastructure.csproj
+++ b/FuelEconomyTracker/src/FuelEconomyTracker.Infrastructure/FuelEconomyTracker.Infrastructure.csproj
@@ -7,6 +7,16 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <FrameworkReference Include="Microsoft.AspNetCore.App" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="8.0.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="8.0.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="8.0.0" />
+  </ItemGroup>
+
+  <ItemGroup>
     <ProjectReference Include="..\FuelEconomyTracker.Core\FuelEconomyTracker.Core.csproj" />
   </ItemGroup>
 

--- a/GiftIdeaTracker/src/GiftIdeaTracker.Infrastructure/Data/GiftIdeaTrackerContext.cs
+++ b/GiftIdeaTracker/src/GiftIdeaTracker.Infrastructure/Data/GiftIdeaTrackerContext.cs
@@ -52,18 +52,13 @@ public class GiftIdeaTrackerContext : DbContext, IGiftIdeaTrackerContext
     /// <inheritdoc/>
     protected override void OnModelCreating(ModelBuilder modelBuilder)
     {
-        
-        // Apply tenant filter to User
-        modelBuilder.Entity<User>().HasQueryFilter(u => u.TenantId == _tenantContext.TenantId);
-
-        // Apply tenant filter to Role
-        modelBuilder.Entity<Role>().HasQueryFilter(r => r.TenantId == _tenantContext.TenantId);
-
         base.OnModelCreating(modelBuilder);
 
         // Apply tenant isolation filters
         if (_tenantContext != null)
         {
+            modelBuilder.Entity<User>().HasQueryFilter(u => u.TenantId == _tenantContext.TenantId);
+            modelBuilder.Entity<Role>().HasQueryFilter(r => r.TenantId == _tenantContext.TenantId);
             modelBuilder.Entity<GiftIdea>().HasQueryFilter(e => e.TenantId == _tenantContext.TenantId);
             modelBuilder.Entity<Recipient>().HasQueryFilter(e => e.TenantId == _tenantContext.TenantId);
             modelBuilder.Entity<Purchase>().HasQueryFilter(e => e.TenantId == _tenantContext.TenantId);

--- a/GiftIdeaTracker/src/GiftIdeaTracker.Infrastructure/Data/SeedData.cs
+++ b/GiftIdeaTracker/src/GiftIdeaTracker.Infrastructure/Data/SeedData.cs
@@ -21,7 +21,7 @@ public static class SeedData
     /// <param name="context">The database context.</param>
     /// <param name="logger">The logger.</param>
     /// <returns>A task representing the asynchronous operation.</returns>
-    public static async Task SeedAsync(GiftIdeaTrackerContext context context, ILogger logger, IPasswordHasher passwordHasher)
+    public static async Task SeedAsync(GiftIdeaTrackerContext context, ILogger logger, IPasswordHasher passwordHasher)
     {
         ArgumentNullException.ThrowIfNull(context);
         ArgumentNullException.ThrowIfNull(logger);

--- a/GiftIdeaTracker/src/GiftIdeaTracker.Infrastructure/GiftIdeaTracker.Infrastructure.csproj
+++ b/GiftIdeaTracker/src/GiftIdeaTracker.Infrastructure/GiftIdeaTracker.Infrastructure.csproj
@@ -7,6 +7,16 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <FrameworkReference Include="Microsoft.AspNetCore.App" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="8.0.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="8.0.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="8.0.0" />
+  </ItemGroup>
+
+  <ItemGroup>
     <ProjectReference Include="..\GiftIdeaTracker.Core\GiftIdeaTracker.Core.csproj" />
   </ItemGroup>
 

--- a/GolfScoreTracker/src/GolfScoreTracker.Infrastructure/Data/GolfScoreTrackerContext.cs
+++ b/GolfScoreTracker/src/GolfScoreTracker.Infrastructure/Data/GolfScoreTrackerContext.cs
@@ -55,18 +55,13 @@ public class GolfScoreTrackerContext : DbContext, IGolfScoreTrackerContext
     /// <inheritdoc/>
     protected override void OnModelCreating(ModelBuilder modelBuilder)
     {
-        
-        // Apply tenant filter to User
-        modelBuilder.Entity<User>().HasQueryFilter(u => u.TenantId == _tenantContext.TenantId);
-
-        // Apply tenant filter to Role
-        modelBuilder.Entity<Role>().HasQueryFilter(r => r.TenantId == _tenantContext.TenantId);
-
         base.OnModelCreating(modelBuilder);
 
         // Apply tenant isolation filters
         if (_tenantContext != null)
         {
+            modelBuilder.Entity<User>().HasQueryFilter(u => u.TenantId == _tenantContext.TenantId);
+            modelBuilder.Entity<Role>().HasQueryFilter(r => r.TenantId == _tenantContext.TenantId);
             modelBuilder.Entity<Round>().HasQueryFilter(e => e.TenantId == _tenantContext.TenantId);
             modelBuilder.Entity<HoleScore>().HasQueryFilter(e => e.TenantId == _tenantContext.TenantId);
             modelBuilder.Entity<Handicap>().HasQueryFilter(e => e.TenantId == _tenantContext.TenantId);

--- a/GolfScoreTracker/src/GolfScoreTracker.Infrastructure/Data/SeedData.cs
+++ b/GolfScoreTracker/src/GolfScoreTracker.Infrastructure/Data/SeedData.cs
@@ -21,7 +21,7 @@ public static class SeedData
     /// <param name="context">The database context.</param>
     /// <param name="logger">The logger.</param>
     /// <returns>A task representing the asynchronous operation.</returns>
-    public static async Task SeedAsync(GolfScoreTrackerContext context context, ILogger logger, IPasswordHasher passwordHasher)
+    public static async Task SeedAsync(GolfScoreTrackerContext context, ILogger logger, IPasswordHasher passwordHasher)
     {
         ArgumentNullException.ThrowIfNull(context);
         ArgumentNullException.ThrowIfNull(logger);

--- a/GolfScoreTracker/src/GolfScoreTracker.Infrastructure/GolfScoreTracker.Infrastructure.csproj
+++ b/GolfScoreTracker/src/GolfScoreTracker.Infrastructure/GolfScoreTracker.Infrastructure.csproj
@@ -7,6 +7,16 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <FrameworkReference Include="Microsoft.AspNetCore.App" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="8.0.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="8.0.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="8.0.0" />
+  </ItemGroup>
+
+  <ItemGroup>
     <ProjectReference Include="..\GolfScoreTracker.Core\GolfScoreTracker.Core.csproj" />
   </ItemGroup>
 

--- a/GroceryShoppingListApp/src/GroceryShoppingListApp.Infrastructure/Data/GroceryShoppingListAppContext.cs
+++ b/GroceryShoppingListApp/src/GroceryShoppingListApp.Infrastructure/Data/GroceryShoppingListAppContext.cs
@@ -57,11 +57,6 @@ public class GroceryShoppingListAppContext : DbContext, IGroceryShoppingListAppC
     protected override void OnModelCreating(ModelBuilder modelBuilder)
     {
         
-        // Apply tenant filter to User
-        modelBuilder.Entity<User>().HasQueryFilter(u => u.TenantId == _tenantContext.TenantId);
-
-        // Apply tenant filter to Role
-        modelBuilder.Entity<Role>().HasQueryFilter(r => r.TenantId == _tenantContext.TenantId);
 
         base.OnModelCreating(modelBuilder);
 

--- a/GroceryShoppingListApp/src/GroceryShoppingListApp.Infrastructure/Data/SeedData.cs
+++ b/GroceryShoppingListApp/src/GroceryShoppingListApp.Infrastructure/Data/SeedData.cs
@@ -21,7 +21,7 @@ public static class SeedData
     /// <param name="context">The database context.</param>
     /// <param name="logger">The logger.</param>
     /// <returns>A task representing the asynchronous operation.</returns>
-    public static async Task SeedAsync(GroceryShoppingListAppContext context context, ILogger logger, IPasswordHasher passwordHasher)
+    public static async Task SeedAsync(GroceryShoppingListAppContext context, ILogger logger, IPasswordHasher passwordHasher)
     {
         ArgumentNullException.ThrowIfNull(context);
         ArgumentNullException.ThrowIfNull(logger);

--- a/GroceryShoppingListApp/src/GroceryShoppingListApp.Infrastructure/GroceryShoppingListApp.Infrastructure.csproj
+++ b/GroceryShoppingListApp/src/GroceryShoppingListApp.Infrastructure/GroceryShoppingListApp.Infrastructure.csproj
@@ -7,22 +7,28 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\GroceryShoppingListApp.Core\GroceryShoppingListApp.Core.csproj" />
+    <FrameworkReference Include="Microsoft.AspNetCore.App" />
   </ItemGroup>
 
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.Http" Version="2.2.2" />
     <PackageReference Include="Microsoft.AspNetCore.Http.Abstractions" Version="2.3.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="8.0.0" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="8.0.0">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="8.0.0" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="8.0.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="8.0.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="10.0.1" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.1" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.1" />
     <PackageReference Include="Microsoft.Extensions.Http" Version="10.0.1" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\GroceryShoppingListApp.Core\GroceryShoppingListApp.Core.csproj" />
   </ItemGroup>
 
 </Project>

--- a/HabitFormationApp/src/HabitFormationApp.Infrastructure/Data/HabitFormationAppContext.cs
+++ b/HabitFormationApp/src/HabitFormationApp.Infrastructure/Data/HabitFormationAppContext.cs
@@ -52,18 +52,13 @@ public class HabitFormationAppContext : DbContext, IHabitFormationAppContext
     /// <inheritdoc/>
     protected override void OnModelCreating(ModelBuilder modelBuilder)
     {
-        
-        // Apply tenant filter to User
-        modelBuilder.Entity<User>().HasQueryFilter(u => u.TenantId == _tenantContext.TenantId);
-
-        // Apply tenant filter to Role
-        modelBuilder.Entity<Role>().HasQueryFilter(r => r.TenantId == _tenantContext.TenantId);
-
         base.OnModelCreating(modelBuilder);
 
         // Apply tenant isolation filters
         if (_tenantContext != null)
         {
+            modelBuilder.Entity<User>().HasQueryFilter(u => u.TenantId == _tenantContext.TenantId);
+            modelBuilder.Entity<Role>().HasQueryFilter(r => r.TenantId == _tenantContext.TenantId);
             modelBuilder.Entity<Habit>().HasQueryFilter(e => e.TenantId == _tenantContext.TenantId);
             modelBuilder.Entity<Streak>().HasQueryFilter(e => e.TenantId == _tenantContext.TenantId);
             modelBuilder.Entity<Reminder>().HasQueryFilter(e => e.TenantId == _tenantContext.TenantId);

--- a/HabitFormationApp/src/HabitFormationApp.Infrastructure/Data/SeedData.cs
+++ b/HabitFormationApp/src/HabitFormationApp.Infrastructure/Data/SeedData.cs
@@ -21,7 +21,7 @@ public static class SeedData
     /// <param name="context">The database context.</param>
     /// <param name="logger">The logger.</param>
     /// <returns>A task representing the asynchronous operation.</returns>
-    public static async Task SeedAsync(HabitFormationAppContext context context, ILogger logger, IPasswordHasher passwordHasher)
+    public static async Task SeedAsync(HabitFormationAppContext context, ILogger logger, IPasswordHasher passwordHasher)
     {
         ArgumentNullException.ThrowIfNull(context);
         ArgumentNullException.ThrowIfNull(logger);

--- a/HabitFormationApp/src/HabitFormationApp.Infrastructure/HabitFormationApp.Infrastructure.csproj
+++ b/HabitFormationApp/src/HabitFormationApp.Infrastructure/HabitFormationApp.Infrastructure.csproj
@@ -7,6 +7,16 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <FrameworkReference Include="Microsoft.AspNetCore.App" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="8.0.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="8.0.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="8.0.0" />
+  </ItemGroup>
+
+  <ItemGroup>
     <ProjectReference Include="..\HabitFormationApp.Core\HabitFormationApp.Core.csproj" />
   </ItemGroup>
 

--- a/HomeGymEquipmentManager/src/HomeGymEquipmentManager.Infrastructure/Data/HomeGymEquipmentManagerContext.cs
+++ b/HomeGymEquipmentManager/src/HomeGymEquipmentManager.Infrastructure/Data/HomeGymEquipmentManagerContext.cs
@@ -52,18 +52,13 @@ public class HomeGymEquipmentManagerContext : DbContext, IHomeGymEquipmentManage
     /// <inheritdoc/>
     protected override void OnModelCreating(ModelBuilder modelBuilder)
     {
-        
-        // Apply tenant filter to User
-        modelBuilder.Entity<User>().HasQueryFilter(u => u.TenantId == _tenantContext.TenantId);
-
-        // Apply tenant filter to Role
-        modelBuilder.Entity<Role>().HasQueryFilter(r => r.TenantId == _tenantContext.TenantId);
-
         base.OnModelCreating(modelBuilder);
 
         // Apply tenant isolation filters
         if (_tenantContext != null)
         {
+            modelBuilder.Entity<User>().HasQueryFilter(u => u.TenantId == _tenantContext.TenantId);
+            modelBuilder.Entity<Role>().HasQueryFilter(r => r.TenantId == _tenantContext.TenantId);
             modelBuilder.Entity<Equipment>().HasQueryFilter(e => e.TenantId == _tenantContext.TenantId);
             modelBuilder.Entity<Maintenance>().HasQueryFilter(e => e.TenantId == _tenantContext.TenantId);
             modelBuilder.Entity<WorkoutMapping>().HasQueryFilter(e => e.TenantId == _tenantContext.TenantId);

--- a/HomeGymEquipmentManager/src/HomeGymEquipmentManager.Infrastructure/Data/SeedData.cs
+++ b/HomeGymEquipmentManager/src/HomeGymEquipmentManager.Infrastructure/Data/SeedData.cs
@@ -21,7 +21,7 @@ public static class SeedData
     /// <param name="context">The database context.</param>
     /// <param name="logger">The logger.</param>
     /// <returns>A task representing the asynchronous operation.</returns>
-    public static async Task SeedAsync(HomeGymEquipmentManagerContext context context, ILogger logger, IPasswordHasher passwordHasher)
+    public static async Task SeedAsync(HomeGymEquipmentManagerContext context, ILogger logger, IPasswordHasher passwordHasher)
     {
         ArgumentNullException.ThrowIfNull(context);
         ArgumentNullException.ThrowIfNull(logger);

--- a/HomeGymEquipmentManager/src/HomeGymEquipmentManager.Infrastructure/HomeGymEquipmentManager.Infrastructure.csproj
+++ b/HomeGymEquipmentManager/src/HomeGymEquipmentManager.Infrastructure/HomeGymEquipmentManager.Infrastructure.csproj
@@ -7,6 +7,16 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <FrameworkReference Include="Microsoft.AspNetCore.App" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="8.0.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="8.0.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="8.0.0" />
+  </ItemGroup>
+
+  <ItemGroup>
     <ProjectReference Include="..\HomeGymEquipmentManager.Core\HomeGymEquipmentManager.Core.csproj" />
   </ItemGroup>
 

--- a/HomeInventoryManager/src/HomeInventoryManager.Infrastructure/Data/HomeInventoryManagerContext.cs
+++ b/HomeInventoryManager/src/HomeInventoryManager.Infrastructure/Data/HomeInventoryManagerContext.cs
@@ -49,18 +49,13 @@ public class HomeInventoryManagerContext : DbContext, IHomeInventoryManagerConte
     /// <inheritdoc/>
     protected override void OnModelCreating(ModelBuilder modelBuilder)
     {
-        
-        // Apply tenant filter to User
-        modelBuilder.Entity<User>().HasQueryFilter(u => u.TenantId == _tenantContext.TenantId);
-
-        // Apply tenant filter to Role
-        modelBuilder.Entity<Role>().HasQueryFilter(r => r.TenantId == _tenantContext.TenantId);
-
         base.OnModelCreating(modelBuilder);
 
         // Apply tenant isolation filters
         if (_tenantContext != null)
         {
+            modelBuilder.Entity<User>().HasQueryFilter(u => u.TenantId == _tenantContext.TenantId);
+            modelBuilder.Entity<Role>().HasQueryFilter(r => r.TenantId == _tenantContext.TenantId);
             modelBuilder.Entity<Item>().HasQueryFilter(e => e.TenantId == _tenantContext.TenantId);
             modelBuilder.Entity<ValueEstimate>().HasQueryFilter(e => e.TenantId == _tenantContext.TenantId);
         }

--- a/HomeInventoryManager/src/HomeInventoryManager.Infrastructure/Data/SeedData.cs
+++ b/HomeInventoryManager/src/HomeInventoryManager.Infrastructure/Data/SeedData.cs
@@ -21,7 +21,7 @@ public static class SeedData
     /// <param name="context">The database context.</param>
     /// <param name="logger">The logger.</param>
     /// <returns>A task representing the asynchronous operation.</returns>
-    public static async Task SeedAsync(HomeInventoryManagerContext context context, ILogger logger, IPasswordHasher passwordHasher)
+    public static async Task SeedAsync(HomeInventoryManagerContext context, ILogger logger, IPasswordHasher passwordHasher)
     {
         ArgumentNullException.ThrowIfNull(context);
         ArgumentNullException.ThrowIfNull(logger);

--- a/HomeInventoryManager/src/HomeInventoryManager.Infrastructure/HomeInventoryManager.Infrastructure.csproj
+++ b/HomeInventoryManager/src/HomeInventoryManager.Infrastructure/HomeInventoryManager.Infrastructure.csproj
@@ -7,6 +7,16 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <FrameworkReference Include="Microsoft.AspNetCore.App" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="8.0.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="8.0.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="8.0.0" />
+  </ItemGroup>
+
+  <ItemGroup>
     <ProjectReference Include="..\HomeInventoryManager.Core\HomeInventoryManager.Core.csproj" />
   </ItemGroup>
 

--- a/HouseholdBudgetManager/src/HouseholdBudgetManager.Infrastructure/Data/HouseholdBudgetManagerContext.cs
+++ b/HouseholdBudgetManager/src/HouseholdBudgetManager.Infrastructure/Data/HouseholdBudgetManagerContext.cs
@@ -52,18 +52,13 @@ public class HouseholdBudgetManagerContext : DbContext, IHouseholdBudgetManagerC
     /// <inheritdoc/>
     protected override void OnModelCreating(ModelBuilder modelBuilder)
     {
-        
-        // Apply tenant filter to User
-        modelBuilder.Entity<User>().HasQueryFilter(u => u.TenantId == _tenantContext.TenantId);
-
-        // Apply tenant filter to Role
-        modelBuilder.Entity<Role>().HasQueryFilter(r => r.TenantId == _tenantContext.TenantId);
-
         base.OnModelCreating(modelBuilder);
 
         // Apply tenant isolation filters
         if (_tenantContext != null)
         {
+            modelBuilder.Entity<User>().HasQueryFilter(u => u.TenantId == _tenantContext.TenantId);
+            modelBuilder.Entity<Role>().HasQueryFilter(r => r.TenantId == _tenantContext.TenantId);
             modelBuilder.Entity<Budget>().HasQueryFilter(e => e.TenantId == _tenantContext.TenantId);
             modelBuilder.Entity<Expense>().HasQueryFilter(e => e.TenantId == _tenantContext.TenantId);
             modelBuilder.Entity<Income>().HasQueryFilter(e => e.TenantId == _tenantContext.TenantId);

--- a/HouseholdBudgetManager/src/HouseholdBudgetManager.Infrastructure/Data/SeedData.cs
+++ b/HouseholdBudgetManager/src/HouseholdBudgetManager.Infrastructure/Data/SeedData.cs
@@ -21,7 +21,7 @@ public static class SeedData
     /// <param name="context">The database context.</param>
     /// <param name="logger">The logger.</param>
     /// <returns>A task representing the asynchronous operation.</returns>
-    public static async Task SeedAsync(HouseholdBudgetManagerContext context context, ILogger logger, IPasswordHasher passwordHasher)
+    public static async Task SeedAsync(HouseholdBudgetManagerContext context, ILogger logger, IPasswordHasher passwordHasher)
     {
         ArgumentNullException.ThrowIfNull(context);
         ArgumentNullException.ThrowIfNull(logger);

--- a/HouseholdBudgetManager/src/HouseholdBudgetManager.Infrastructure/HouseholdBudgetManager.Infrastructure.csproj
+++ b/HouseholdBudgetManager/src/HouseholdBudgetManager.Infrastructure/HouseholdBudgetManager.Infrastructure.csproj
@@ -7,6 +7,16 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <FrameworkReference Include="Microsoft.AspNetCore.App" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="8.0.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="8.0.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="8.0.0" />
+  </ItemGroup>
+
+  <ItemGroup>
     <ProjectReference Include="..\HouseholdBudgetManager.Core\HouseholdBudgetManager.Core.csproj" />
   </ItemGroup>
 

--- a/HydrationTracker/src/HydrationTracker.Infrastructure/Data/HydrationTrackerContext.cs
+++ b/HydrationTracker/src/HydrationTracker.Infrastructure/Data/HydrationTrackerContext.cs
@@ -52,18 +52,13 @@ public class HydrationTrackerContext : DbContext, IHydrationTrackerContext
     /// <inheritdoc/>
     protected override void OnModelCreating(ModelBuilder modelBuilder)
     {
-        
-        // Apply tenant filter to User
-        modelBuilder.Entity<User>().HasQueryFilter(u => u.TenantId == _tenantContext.TenantId);
-
-        // Apply tenant filter to Role
-        modelBuilder.Entity<Role>().HasQueryFilter(r => r.TenantId == _tenantContext.TenantId);
-
         base.OnModelCreating(modelBuilder);
 
         // Apply tenant isolation filters
         if (_tenantContext != null)
         {
+            modelBuilder.Entity<User>().HasQueryFilter(u => u.TenantId == _tenantContext.TenantId);
+            modelBuilder.Entity<Role>().HasQueryFilter(r => r.TenantId == _tenantContext.TenantId);
             modelBuilder.Entity<Intake>().HasQueryFilter(e => e.TenantId == _tenantContext.TenantId);
             modelBuilder.Entity<Goal>().HasQueryFilter(e => e.TenantId == _tenantContext.TenantId);
             modelBuilder.Entity<Reminder>().HasQueryFilter(e => e.TenantId == _tenantContext.TenantId);

--- a/HydrationTracker/src/HydrationTracker.Infrastructure/Data/SeedData.cs
+++ b/HydrationTracker/src/HydrationTracker.Infrastructure/Data/SeedData.cs
@@ -21,7 +21,7 @@ public static class SeedData
     /// <param name="context">The database context.</param>
     /// <param name="logger">The logger.</param>
     /// <returns>A task representing the asynchronous operation.</returns>
-    public static async Task SeedAsync(HydrationTrackerContext context context, ILogger logger, IPasswordHasher passwordHasher)
+    public static async Task SeedAsync(HydrationTrackerContext context, ILogger logger, IPasswordHasher passwordHasher)
     {
         ArgumentNullException.ThrowIfNull(context);
         ArgumentNullException.ThrowIfNull(logger);

--- a/HydrationTracker/src/HydrationTracker.Infrastructure/HydrationTracker.Infrastructure.csproj
+++ b/HydrationTracker/src/HydrationTracker.Infrastructure/HydrationTracker.Infrastructure.csproj
@@ -7,6 +7,16 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <FrameworkReference Include="Microsoft.AspNetCore.App" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="8.0.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="8.0.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="8.0.0" />
+  </ItemGroup>
+
+  <ItemGroup>
     <ProjectReference Include="..\HydrationTracker.Core\HydrationTracker.Core.csproj" />
   </ItemGroup>
 

--- a/InjuryPreventionRecoveryTracker/src/InjuryPreventionRecoveryTracker.Infrastructure/Data/InjuryPreventionRecoveryTrackerContext.cs
+++ b/InjuryPreventionRecoveryTracker/src/InjuryPreventionRecoveryTracker.Infrastructure/Data/InjuryPreventionRecoveryTrackerContext.cs
@@ -52,18 +52,13 @@ public class InjuryPreventionRecoveryTrackerContext : DbContext, IInjuryPreventi
     /// <inheritdoc/>
     protected override void OnModelCreating(ModelBuilder modelBuilder)
     {
-        
-        // Apply tenant filter to User
-        modelBuilder.Entity<User>().HasQueryFilter(u => u.TenantId == _tenantContext.TenantId);
-
-        // Apply tenant filter to Role
-        modelBuilder.Entity<Role>().HasQueryFilter(r => r.TenantId == _tenantContext.TenantId);
-
         base.OnModelCreating(modelBuilder);
 
         // Apply tenant isolation filters
         if (_tenantContext != null)
         {
+            modelBuilder.Entity<User>().HasQueryFilter(u => u.TenantId == _tenantContext.TenantId);
+            modelBuilder.Entity<Role>().HasQueryFilter(r => r.TenantId == _tenantContext.TenantId);
             modelBuilder.Entity<Injury>().HasQueryFilter(e => e.TenantId == _tenantContext.TenantId);
             modelBuilder.Entity<RecoveryExercise>().HasQueryFilter(e => e.TenantId == _tenantContext.TenantId);
             modelBuilder.Entity<Milestone>().HasQueryFilter(e => e.TenantId == _tenantContext.TenantId);

--- a/InjuryPreventionRecoveryTracker/src/InjuryPreventionRecoveryTracker.Infrastructure/Data/SeedData.cs
+++ b/InjuryPreventionRecoveryTracker/src/InjuryPreventionRecoveryTracker.Infrastructure/Data/SeedData.cs
@@ -21,7 +21,7 @@ public static class SeedData
     /// <param name="context">The database context.</param>
     /// <param name="logger">The logger.</param>
     /// <returns>A task representing the asynchronous operation.</returns>
-    public static async Task SeedAsync(InjuryPreventionRecoveryTrackerContext context context, ILogger logger, IPasswordHasher passwordHasher)
+    public static async Task SeedAsync(InjuryPreventionRecoveryTrackerContext context, ILogger logger, IPasswordHasher passwordHasher)
     {
         ArgumentNullException.ThrowIfNull(context);
         ArgumentNullException.ThrowIfNull(logger);

--- a/InjuryPreventionRecoveryTracker/src/InjuryPreventionRecoveryTracker.Infrastructure/InjuryPreventionRecoveryTracker.Infrastructure.csproj
+++ b/InjuryPreventionRecoveryTracker/src/InjuryPreventionRecoveryTracker.Infrastructure/InjuryPreventionRecoveryTracker.Infrastructure.csproj
@@ -7,6 +7,16 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <FrameworkReference Include="Microsoft.AspNetCore.App" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="8.0.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="8.0.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="8.0.0" />
+  </ItemGroup>
+
+  <ItemGroup>
     <ProjectReference Include="..\InjuryPreventionRecoveryTracker.Core\InjuryPreventionRecoveryTracker.Core.csproj" />
   </ItemGroup>
 

--- a/InvestmentPortfolioTracker/src/InvestmentPortfolioTracker.Infrastructure/Data/InvestmentPortfolioTrackerContext.cs
+++ b/InvestmentPortfolioTracker/src/InvestmentPortfolioTracker.Infrastructure/Data/InvestmentPortfolioTrackerContext.cs
@@ -55,18 +55,13 @@ public class InvestmentPortfolioTrackerContext : DbContext, IInvestmentPortfolio
     /// <inheritdoc/>
     protected override void OnModelCreating(ModelBuilder modelBuilder)
     {
-        
-        // Apply tenant filter to User
-        modelBuilder.Entity<User>().HasQueryFilter(u => u.TenantId == _tenantContext.TenantId);
-
-        // Apply tenant filter to Role
-        modelBuilder.Entity<Role>().HasQueryFilter(r => r.TenantId == _tenantContext.TenantId);
-
         base.OnModelCreating(modelBuilder);
 
         // Apply tenant isolation filters
         if (_tenantContext != null)
         {
+            modelBuilder.Entity<User>().HasQueryFilter(u => u.TenantId == _tenantContext.TenantId);
+            modelBuilder.Entity<Role>().HasQueryFilter(r => r.TenantId == _tenantContext.TenantId);
             modelBuilder.Entity<Account>().HasQueryFilter(e => e.TenantId == _tenantContext.TenantId);
             modelBuilder.Entity<Holding>().HasQueryFilter(e => e.TenantId == _tenantContext.TenantId);
             modelBuilder.Entity<Transaction>().HasQueryFilter(e => e.TenantId == _tenantContext.TenantId);

--- a/InvestmentPortfolioTracker/src/InvestmentPortfolioTracker.Infrastructure/Data/SeedData.cs
+++ b/InvestmentPortfolioTracker/src/InvestmentPortfolioTracker.Infrastructure/Data/SeedData.cs
@@ -21,7 +21,7 @@ public static class SeedData
     /// <param name="context">The database context.</param>
     /// <param name="logger">The logger.</param>
     /// <returns>A task representing the asynchronous operation.</returns>
-    public static async Task SeedAsync(InvestmentPortfolioTrackerContext context context, ILogger logger, IPasswordHasher passwordHasher)
+    public static async Task SeedAsync(InvestmentPortfolioTrackerContext context, ILogger logger, IPasswordHasher passwordHasher)
     {
         ArgumentNullException.ThrowIfNull(context);
         ArgumentNullException.ThrowIfNull(logger);

--- a/InvestmentPortfolioTracker/src/InvestmentPortfolioTracker.Infrastructure/InvestmentPortfolioTracker.Infrastructure.csproj
+++ b/InvestmentPortfolioTracker/src/InvestmentPortfolioTracker.Infrastructure/InvestmentPortfolioTracker.Infrastructure.csproj
@@ -7,6 +7,16 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <FrameworkReference Include="Microsoft.AspNetCore.App" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="8.0.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="8.0.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="8.0.0" />
+  </ItemGroup>
+
+  <ItemGroup>
     <ProjectReference Include="..\InvestmentPortfolioTracker.Core\InvestmentPortfolioTracker.Core.csproj" />
   </ItemGroup>
 

--- a/JobSearchOrganizer/src/JobSearchOrganizer.Infrastructure/Data/JobSearchOrganizerContext.cs
+++ b/JobSearchOrganizer/src/JobSearchOrganizer.Infrastructure/Data/JobSearchOrganizerContext.cs
@@ -55,18 +55,13 @@ public class JobSearchOrganizerContext : DbContext, IJobSearchOrganizerContext
     /// <inheritdoc/>
     protected override void OnModelCreating(ModelBuilder modelBuilder)
     {
-        
-        // Apply tenant filter to User
-        modelBuilder.Entity<User>().HasQueryFilter(u => u.TenantId == _tenantContext.TenantId);
-
-        // Apply tenant filter to Role
-        modelBuilder.Entity<Role>().HasQueryFilter(r => r.TenantId == _tenantContext.TenantId);
-
         base.OnModelCreating(modelBuilder);
 
         // Apply tenant isolation filters
         if (_tenantContext != null)
         {
+            modelBuilder.Entity<User>().HasQueryFilter(u => u.TenantId == _tenantContext.TenantId);
+            modelBuilder.Entity<Role>().HasQueryFilter(r => r.TenantId == _tenantContext.TenantId);
             modelBuilder.Entity<Application>().HasQueryFilter(e => e.TenantId == _tenantContext.TenantId);
             modelBuilder.Entity<Company>().HasQueryFilter(e => e.TenantId == _tenantContext.TenantId);
             modelBuilder.Entity<Interview>().HasQueryFilter(e => e.TenantId == _tenantContext.TenantId);

--- a/JobSearchOrganizer/src/JobSearchOrganizer.Infrastructure/Data/SeedData.cs
+++ b/JobSearchOrganizer/src/JobSearchOrganizer.Infrastructure/Data/SeedData.cs
@@ -21,7 +21,7 @@ public static class SeedData
     /// <param name="context">The database context.</param>
     /// <param name="logger">The logger.</param>
     /// <returns>A task representing the asynchronous operation.</returns>
-    public static async Task SeedAsync(JobSearchOrganizerContext context context, ILogger logger, IPasswordHasher passwordHasher)
+    public static async Task SeedAsync(JobSearchOrganizerContext context, ILogger logger, IPasswordHasher passwordHasher)
     {
         ArgumentNullException.ThrowIfNull(context);
         ArgumentNullException.ThrowIfNull(logger);

--- a/JobSearchOrganizer/src/JobSearchOrganizer.Infrastructure/JobSearchOrganizer.Infrastructure.csproj
+++ b/JobSearchOrganizer/src/JobSearchOrganizer.Infrastructure/JobSearchOrganizer.Infrastructure.csproj
@@ -7,6 +7,16 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <FrameworkReference Include="Microsoft.AspNetCore.App" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="8.0.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="8.0.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="8.0.0" />
+  </ItemGroup>
+
+  <ItemGroup>
     <ProjectReference Include="..\JobSearchOrganizer.Core\JobSearchOrganizer.Core.csproj" />
   </ItemGroup>
 

--- a/KidsActivitySportsTracker/src/KidsActivitySportsTracker.Infrastructure/Data/KidsActivitySportsTrackerContext.cs
+++ b/KidsActivitySportsTracker/src/KidsActivitySportsTracker.Infrastructure/Data/KidsActivitySportsTrackerContext.cs
@@ -52,18 +52,13 @@ public class KidsActivitySportsTrackerContext : DbContext, IKidsActivitySportsTr
     /// <inheritdoc/>
     protected override void OnModelCreating(ModelBuilder modelBuilder)
     {
-        
-        // Apply tenant filter to User
-        modelBuilder.Entity<User>().HasQueryFilter(u => u.TenantId == _tenantContext.TenantId);
-
-        // Apply tenant filter to Role
-        modelBuilder.Entity<Role>().HasQueryFilter(r => r.TenantId == _tenantContext.TenantId);
-
         base.OnModelCreating(modelBuilder);
 
         // Apply tenant isolation filters
         if (_tenantContext != null)
         {
+            modelBuilder.Entity<User>().HasQueryFilter(u => u.TenantId == _tenantContext.TenantId);
+            modelBuilder.Entity<Role>().HasQueryFilter(r => r.TenantId == _tenantContext.TenantId);
             modelBuilder.Entity<Activity>().HasQueryFilter(e => e.TenantId == _tenantContext.TenantId);
             modelBuilder.Entity<Schedule>().HasQueryFilter(e => e.TenantId == _tenantContext.TenantId);
             modelBuilder.Entity<Carpool>().HasQueryFilter(e => e.TenantId == _tenantContext.TenantId);

--- a/KidsActivitySportsTracker/src/KidsActivitySportsTracker.Infrastructure/Data/SeedData.cs
+++ b/KidsActivitySportsTracker/src/KidsActivitySportsTracker.Infrastructure/Data/SeedData.cs
@@ -21,7 +21,7 @@ public static class SeedData
     /// <param name="context">The database context.</param>
     /// <param name="logger">The logger.</param>
     /// <returns>A task representing the asynchronous operation.</returns>
-    public static async Task SeedAsync(KidsActivitySportsTrackerContext context context, ILogger logger, IPasswordHasher passwordHasher)
+    public static async Task SeedAsync(KidsActivitySportsTrackerContext context, ILogger logger, IPasswordHasher passwordHasher)
     {
         ArgumentNullException.ThrowIfNull(context);
         ArgumentNullException.ThrowIfNull(logger);

--- a/KidsActivitySportsTracker/src/KidsActivitySportsTracker.Infrastructure/KidsActivitySportsTracker.Infrastructure.csproj
+++ b/KidsActivitySportsTracker/src/KidsActivitySportsTracker.Infrastructure/KidsActivitySportsTracker.Infrastructure.csproj
@@ -7,6 +7,16 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <FrameworkReference Include="Microsoft.AspNetCore.App" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="8.0.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="8.0.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="8.0.0" />
+  </ItemGroup>
+
+  <ItemGroup>
     <ProjectReference Include="..\KidsActivitySportsTracker.Core\KidsActivitySportsTracker.Core.csproj" />
   </ItemGroup>
 

--- a/KnowledgeBaseSecondBrain/src/KnowledgeBaseSecondBrain.Infrastructure/Data/KnowledgeBaseSecondBrainContext.cs
+++ b/KnowledgeBaseSecondBrain/src/KnowledgeBaseSecondBrain.Infrastructure/Data/KnowledgeBaseSecondBrainContext.cs
@@ -55,18 +55,13 @@ public class KnowledgeBaseSecondBrainContext : DbContext, IKnowledgeBaseSecondBr
     /// <inheritdoc/>
     protected override void OnModelCreating(ModelBuilder modelBuilder)
     {
-        
-        // Apply tenant filter to User
-        modelBuilder.Entity<User>().HasQueryFilter(u => u.TenantId == _tenantContext.TenantId);
-
-        // Apply tenant filter to Role
-        modelBuilder.Entity<Role>().HasQueryFilter(r => r.TenantId == _tenantContext.TenantId);
-
         base.OnModelCreating(modelBuilder);
 
         // Apply tenant isolation filters
         if (_tenantContext != null)
         {
+            modelBuilder.Entity<User>().HasQueryFilter(u => u.TenantId == _tenantContext.TenantId);
+            modelBuilder.Entity<Role>().HasQueryFilter(r => r.TenantId == _tenantContext.TenantId);
             modelBuilder.Entity<Note>().HasQueryFilter(e => e.TenantId == _tenantContext.TenantId);
             modelBuilder.Entity<Tag>().HasQueryFilter(e => e.TenantId == _tenantContext.TenantId);
             modelBuilder.Entity<NoteLink>().HasQueryFilter(e => e.TenantId == _tenantContext.TenantId);

--- a/KnowledgeBaseSecondBrain/src/KnowledgeBaseSecondBrain.Infrastructure/Data/SeedData.cs
+++ b/KnowledgeBaseSecondBrain/src/KnowledgeBaseSecondBrain.Infrastructure/Data/SeedData.cs
@@ -21,7 +21,7 @@ public static class SeedData
     /// <param name="context">The database context.</param>
     /// <param name="logger">The logger.</param>
     /// <returns>A task representing the asynchronous operation.</returns>
-    public static async Task SeedAsync(KnowledgeBaseSecondBrainContext context context, ILogger logger, IPasswordHasher passwordHasher)
+    public static async Task SeedAsync(KnowledgeBaseSecondBrainContext context, ILogger logger, IPasswordHasher passwordHasher)
     {
         ArgumentNullException.ThrowIfNull(context);
         ArgumentNullException.ThrowIfNull(logger);

--- a/KnowledgeBaseSecondBrain/src/KnowledgeBaseSecondBrain.Infrastructure/KnowledgeBaseSecondBrain.Infrastructure.csproj
+++ b/KnowledgeBaseSecondBrain/src/KnowledgeBaseSecondBrain.Infrastructure/KnowledgeBaseSecondBrain.Infrastructure.csproj
@@ -7,6 +7,16 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <FrameworkReference Include="Microsoft.AspNetCore.App" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="8.0.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="8.0.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="8.0.0" />
+  </ItemGroup>
+
+  <ItemGroup>
     <ProjectReference Include="..\KnowledgeBaseSecondBrain.Core\KnowledgeBaseSecondBrain.Core.csproj" />
   </ItemGroup>
 

--- a/LetterToFutureSelf/src/LetterToFutureSelf.Infrastructure/Data/LetterToFutureSelfContext.cs
+++ b/LetterToFutureSelf/src/LetterToFutureSelf.Infrastructure/Data/LetterToFutureSelfContext.cs
@@ -49,18 +49,13 @@ public class LetterToFutureSelfContext : DbContext, ILetterToFutureSelfContext
     /// <inheritdoc/>
     protected override void OnModelCreating(ModelBuilder modelBuilder)
     {
-        
-        // Apply tenant filter to User
-        modelBuilder.Entity<User>().HasQueryFilter(u => u.TenantId == _tenantContext.TenantId);
-
-        // Apply tenant filter to Role
-        modelBuilder.Entity<Role>().HasQueryFilter(r => r.TenantId == _tenantContext.TenantId);
-
         base.OnModelCreating(modelBuilder);
 
         // Apply tenant isolation filters
         if (_tenantContext != null)
         {
+            modelBuilder.Entity<User>().HasQueryFilter(u => u.TenantId == _tenantContext.TenantId);
+            modelBuilder.Entity<Role>().HasQueryFilter(r => r.TenantId == _tenantContext.TenantId);
             modelBuilder.Entity<Letter>().HasQueryFilter(e => e.TenantId == _tenantContext.TenantId);
             modelBuilder.Entity<DeliverySchedule>().HasQueryFilter(e => e.TenantId == _tenantContext.TenantId);
         }

--- a/LetterToFutureSelf/src/LetterToFutureSelf.Infrastructure/Data/SeedData.cs
+++ b/LetterToFutureSelf/src/LetterToFutureSelf.Infrastructure/Data/SeedData.cs
@@ -21,7 +21,7 @@ public static class SeedData
     /// <param name="context">The database context.</param>
     /// <param name="logger">The logger.</param>
     /// <returns>A task representing the asynchronous operation.</returns>
-    public static async Task SeedAsync(LetterToFutureSelfContext context context, ILogger logger, IPasswordHasher passwordHasher)
+    public static async Task SeedAsync(LetterToFutureSelfContext context, ILogger logger, IPasswordHasher passwordHasher)
     {
         ArgumentNullException.ThrowIfNull(context);
         ArgumentNullException.ThrowIfNull(logger);

--- a/LetterToFutureSelf/src/LetterToFutureSelf.Infrastructure/LetterToFutureSelf.Infrastructure.csproj
+++ b/LetterToFutureSelf/src/LetterToFutureSelf.Infrastructure/LetterToFutureSelf.Infrastructure.csproj
@@ -7,6 +7,16 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <FrameworkReference Include="Microsoft.AspNetCore.App" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="8.0.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="8.0.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="8.0.0" />
+  </ItemGroup>
+
+  <ItemGroup>
     <ProjectReference Include="..\LetterToFutureSelf.Core\LetterToFutureSelf.Core.csproj" />
   </ItemGroup>
 

--- a/LifeAdminDashboard/src/LifeAdminDashboard.Infrastructure/Data/LifeAdminDashboardContext.cs
+++ b/LifeAdminDashboard/src/LifeAdminDashboard.Infrastructure/Data/LifeAdminDashboardContext.cs
@@ -52,18 +52,13 @@ public class LifeAdminDashboardContext : DbContext, ILifeAdminDashboardContext
     /// <inheritdoc/>
     protected override void OnModelCreating(ModelBuilder modelBuilder)
     {
-        
-        // Apply tenant filter to User
-        modelBuilder.Entity<User>().HasQueryFilter(u => u.TenantId == _tenantContext.TenantId);
-
-        // Apply tenant filter to Role
-        modelBuilder.Entity<Role>().HasQueryFilter(r => r.TenantId == _tenantContext.TenantId);
-
         base.OnModelCreating(modelBuilder);
 
         // Apply tenant isolation filters
         if (_tenantContext != null)
         {
+            modelBuilder.Entity<User>().HasQueryFilter(u => u.TenantId == _tenantContext.TenantId);
+            modelBuilder.Entity<Role>().HasQueryFilter(r => r.TenantId == _tenantContext.TenantId);
             modelBuilder.Entity<AdminTask>().HasQueryFilter(e => e.TenantId == _tenantContext.TenantId);
             modelBuilder.Entity<Renewal>().HasQueryFilter(e => e.TenantId == _tenantContext.TenantId);
             modelBuilder.Entity<Deadline>().HasQueryFilter(e => e.TenantId == _tenantContext.TenantId);

--- a/LifeAdminDashboard/src/LifeAdminDashboard.Infrastructure/Data/SeedData.cs
+++ b/LifeAdminDashboard/src/LifeAdminDashboard.Infrastructure/Data/SeedData.cs
@@ -21,7 +21,7 @@ public static class SeedData
     /// <param name="context">The database context.</param>
     /// <param name="logger">The logger.</param>
     /// <returns>A task representing the asynchronous operation.</returns>
-    public static async Task SeedAsync(LifeAdminDashboardContext context context, ILogger logger, IPasswordHasher passwordHasher)
+    public static async Task SeedAsync(LifeAdminDashboardContext context, ILogger logger, IPasswordHasher passwordHasher)
     {
         ArgumentNullException.ThrowIfNull(context);
         ArgumentNullException.ThrowIfNull(logger);

--- a/LifeAdminDashboard/src/LifeAdminDashboard.Infrastructure/LifeAdminDashboard.Infrastructure.csproj
+++ b/LifeAdminDashboard/src/LifeAdminDashboard.Infrastructure/LifeAdminDashboard.Infrastructure.csproj
@@ -7,6 +7,16 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <FrameworkReference Include="Microsoft.AspNetCore.App" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="8.0.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="8.0.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="8.0.0" />
+  </ItemGroup>
+
+  <ItemGroup>
     <ProjectReference Include="..\LifeAdminDashboard.Core\LifeAdminDashboard.Core.csproj" />
   </ItemGroup>
 

--- a/MarriageEnrichmentJournal/src/MarriageEnrichmentJournal.Infrastructure/Data/MarriageEnrichmentJournalContext.cs
+++ b/MarriageEnrichmentJournal/src/MarriageEnrichmentJournal.Infrastructure/Data/MarriageEnrichmentJournalContext.cs
@@ -52,18 +52,13 @@ public class MarriageEnrichmentJournalContext : DbContext, IMarriageEnrichmentJo
     /// <inheritdoc/>
     protected override void OnModelCreating(ModelBuilder modelBuilder)
     {
-        
-        // Apply tenant filter to User
-        modelBuilder.Entity<User>().HasQueryFilter(u => u.TenantId == _tenantContext.TenantId);
-
-        // Apply tenant filter to Role
-        modelBuilder.Entity<Role>().HasQueryFilter(r => r.TenantId == _tenantContext.TenantId);
-
         base.OnModelCreating(modelBuilder);
 
         // Apply tenant isolation filters
         if (_tenantContext != null)
         {
+            modelBuilder.Entity<User>().HasQueryFilter(u => u.TenantId == _tenantContext.TenantId);
+            modelBuilder.Entity<Role>().HasQueryFilter(r => r.TenantId == _tenantContext.TenantId);
             modelBuilder.Entity<JournalEntry>().HasQueryFilter(e => e.TenantId == _tenantContext.TenantId);
             modelBuilder.Entity<Gratitude>().HasQueryFilter(e => e.TenantId == _tenantContext.TenantId);
             modelBuilder.Entity<Reflection>().HasQueryFilter(e => e.TenantId == _tenantContext.TenantId);

--- a/MarriageEnrichmentJournal/src/MarriageEnrichmentJournal.Infrastructure/Data/SeedData.cs
+++ b/MarriageEnrichmentJournal/src/MarriageEnrichmentJournal.Infrastructure/Data/SeedData.cs
@@ -21,7 +21,7 @@ public static class SeedData
     /// <param name="context">The database context.</param>
     /// <param name="logger">The logger.</param>
     /// <returns>A task representing the asynchronous operation.</returns>
-    public static async Task SeedAsync(MarriageEnrichmentJournalContext context context, ILogger logger, IPasswordHasher passwordHasher)
+    public static async Task SeedAsync(MarriageEnrichmentJournalContext context, ILogger logger, IPasswordHasher passwordHasher)
     {
         ArgumentNullException.ThrowIfNull(context);
         ArgumentNullException.ThrowIfNull(logger);

--- a/MarriageEnrichmentJournal/src/MarriageEnrichmentJournal.Infrastructure/MarriageEnrichmentJournal.Infrastructure.csproj
+++ b/MarriageEnrichmentJournal/src/MarriageEnrichmentJournal.Infrastructure/MarriageEnrichmentJournal.Infrastructure.csproj
@@ -7,6 +7,16 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <FrameworkReference Include="Microsoft.AspNetCore.App" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="8.0.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="8.0.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="8.0.0" />
+  </ItemGroup>
+
+  <ItemGroup>
     <ProjectReference Include="..\MarriageEnrichmentJournal.Core\MarriageEnrichmentJournal.Core.csproj" />
   </ItemGroup>
 

--- a/MealPrepPlanner/src/MealPrepPlanner.Infrastructure/Data/MealPrepPlannerContext.cs
+++ b/MealPrepPlanner/src/MealPrepPlanner.Infrastructure/Data/MealPrepPlannerContext.cs
@@ -55,18 +55,13 @@ public class MealPrepPlannerContext : DbContext, IMealPrepPlannerContext
     /// <inheritdoc/>
     protected override void OnModelCreating(ModelBuilder modelBuilder)
     {
-        
-        // Apply tenant filter to User
-        modelBuilder.Entity<User>().HasQueryFilter(u => u.TenantId == _tenantContext.TenantId);
-
-        // Apply tenant filter to Role
-        modelBuilder.Entity<Role>().HasQueryFilter(r => r.TenantId == _tenantContext.TenantId);
-
         base.OnModelCreating(modelBuilder);
 
         // Apply tenant isolation filters
         if (_tenantContext != null)
         {
+            modelBuilder.Entity<User>().HasQueryFilter(u => u.TenantId == _tenantContext.TenantId);
+            modelBuilder.Entity<Role>().HasQueryFilter(r => r.TenantId == _tenantContext.TenantId);
             modelBuilder.Entity<MealPlan>().HasQueryFilter(e => e.TenantId == _tenantContext.TenantId);
             modelBuilder.Entity<Recipe>().HasQueryFilter(e => e.TenantId == _tenantContext.TenantId);
             modelBuilder.Entity<GroceryList>().HasQueryFilter(e => e.TenantId == _tenantContext.TenantId);

--- a/MealPrepPlanner/src/MealPrepPlanner.Infrastructure/Data/SeedData.cs
+++ b/MealPrepPlanner/src/MealPrepPlanner.Infrastructure/Data/SeedData.cs
@@ -21,7 +21,7 @@ public static class SeedData
     /// <param name="context">The database context.</param>
     /// <param name="logger">The logger.</param>
     /// <returns>A task representing the asynchronous operation.</returns>
-    public static async Task SeedAsync(MealPrepPlannerContext context context, ILogger logger, IPasswordHasher passwordHasher)
+    public static async Task SeedAsync(MealPrepPlannerContext context, ILogger logger, IPasswordHasher passwordHasher)
     {
         ArgumentNullException.ThrowIfNull(context);
         ArgumentNullException.ThrowIfNull(logger);

--- a/MealPrepPlanner/src/MealPrepPlanner.Infrastructure/MealPrepPlanner.Infrastructure.csproj
+++ b/MealPrepPlanner/src/MealPrepPlanner.Infrastructure/MealPrepPlanner.Infrastructure.csproj
@@ -7,6 +7,16 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <FrameworkReference Include="Microsoft.AspNetCore.App" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="8.0.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="8.0.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="8.0.0" />
+  </ItemGroup>
+
+  <ItemGroup>
     <ProjectReference Include="..\MealPrepPlanner.Core\MealPrepPlanner.Core.csproj" />
   </ItemGroup>
 

--- a/MeetingNotesActionItemTracker/src/MeetingNotesActionItemTracker.Infrastructure/Data/MeetingNotesActionItemTrackerContext.cs
+++ b/MeetingNotesActionItemTracker/src/MeetingNotesActionItemTracker.Infrastructure/Data/MeetingNotesActionItemTrackerContext.cs
@@ -52,18 +52,13 @@ public class MeetingNotesActionItemTrackerContext : DbContext, IMeetingNotesActi
     /// <inheritdoc/>
     protected override void OnModelCreating(ModelBuilder modelBuilder)
     {
-        
-        // Apply tenant filter to User
-        modelBuilder.Entity<User>().HasQueryFilter(u => u.TenantId == _tenantContext.TenantId);
-
-        // Apply tenant filter to Role
-        modelBuilder.Entity<Role>().HasQueryFilter(r => r.TenantId == _tenantContext.TenantId);
-
         base.OnModelCreating(modelBuilder);
 
         // Apply tenant isolation filters
         if (_tenantContext != null)
         {
+            modelBuilder.Entity<User>().HasQueryFilter(u => u.TenantId == _tenantContext.TenantId);
+            modelBuilder.Entity<Role>().HasQueryFilter(r => r.TenantId == _tenantContext.TenantId);
             modelBuilder.Entity<Meeting>().HasQueryFilter(e => e.TenantId == _tenantContext.TenantId);
             modelBuilder.Entity<Note>().HasQueryFilter(e => e.TenantId == _tenantContext.TenantId);
             modelBuilder.Entity<ActionItem>().HasQueryFilter(e => e.TenantId == _tenantContext.TenantId);

--- a/MeetingNotesActionItemTracker/src/MeetingNotesActionItemTracker.Infrastructure/Data/SeedData.cs
+++ b/MeetingNotesActionItemTracker/src/MeetingNotesActionItemTracker.Infrastructure/Data/SeedData.cs
@@ -21,7 +21,7 @@ public static class SeedData
     /// <param name="context">The database context.</param>
     /// <param name="logger">The logger.</param>
     /// <returns>A task representing the asynchronous operation.</returns>
-    public static async Task SeedAsync(MeetingNotesActionItemTrackerContext context context, ILogger logger, IPasswordHasher passwordHasher)
+    public static async Task SeedAsync(MeetingNotesActionItemTrackerContext context, ILogger logger, IPasswordHasher passwordHasher)
     {
         ArgumentNullException.ThrowIfNull(context);
         ArgumentNullException.ThrowIfNull(logger);

--- a/MeetingNotesActionItemTracker/src/MeetingNotesActionItemTracker.Infrastructure/MeetingNotesActionItemTracker.Infrastructure.csproj
+++ b/MeetingNotesActionItemTracker/src/MeetingNotesActionItemTracker.Infrastructure/MeetingNotesActionItemTracker.Infrastructure.csproj
@@ -7,6 +7,16 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <FrameworkReference Include="Microsoft.AspNetCore.App" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="8.0.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="8.0.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="8.0.0" />
+  </ItemGroup>
+
+  <ItemGroup>
     <ProjectReference Include="..\MeetingNotesActionItemTracker.Core\MeetingNotesActionItemTracker.Core.csproj" />
   </ItemGroup>
 

--- a/MensGroupDiscussionTracker/src/MensGroupDiscussionTracker.Infrastructure/Data/MensGroupDiscussionTrackerContext.cs
+++ b/MensGroupDiscussionTracker/src/MensGroupDiscussionTracker.Infrastructure/Data/MensGroupDiscussionTrackerContext.cs
@@ -55,18 +55,13 @@ public class MensGroupDiscussionTrackerContext : DbContext, IMensGroupDiscussion
     /// <inheritdoc/>
     protected override void OnModelCreating(ModelBuilder modelBuilder)
     {
-        
-        // Apply tenant filter to User
-        modelBuilder.Entity<User>().HasQueryFilter(u => u.TenantId == _tenantContext.TenantId);
-
-        // Apply tenant filter to Role
-        modelBuilder.Entity<Role>().HasQueryFilter(r => r.TenantId == _tenantContext.TenantId);
-
         base.OnModelCreating(modelBuilder);
 
         // Apply tenant isolation filters
         if (_tenantContext != null)
         {
+            modelBuilder.Entity<User>().HasQueryFilter(u => u.TenantId == _tenantContext.TenantId);
+            modelBuilder.Entity<Role>().HasQueryFilter(r => r.TenantId == _tenantContext.TenantId);
             modelBuilder.Entity<Group>().HasQueryFilter(e => e.TenantId == _tenantContext.TenantId);
             modelBuilder.Entity<Meeting>().HasQueryFilter(e => e.TenantId == _tenantContext.TenantId);
             modelBuilder.Entity<Topic>().HasQueryFilter(e => e.TenantId == _tenantContext.TenantId);

--- a/MensGroupDiscussionTracker/src/MensGroupDiscussionTracker.Infrastructure/Data/SeedData.cs
+++ b/MensGroupDiscussionTracker/src/MensGroupDiscussionTracker.Infrastructure/Data/SeedData.cs
@@ -21,7 +21,7 @@ public static class SeedData
     /// <param name="context">The database context.</param>
     /// <param name="logger">The logger.</param>
     /// <returns>A task representing the asynchronous operation.</returns>
-    public static async Task SeedAsync(MensGroupDiscussionTrackerContext context context, ILogger logger, IPasswordHasher passwordHasher)
+    public static async Task SeedAsync(MensGroupDiscussionTrackerContext context, ILogger logger, IPasswordHasher passwordHasher)
     {
         ArgumentNullException.ThrowIfNull(context);
         ArgumentNullException.ThrowIfNull(logger);

--- a/MensGroupDiscussionTracker/src/MensGroupDiscussionTracker.Infrastructure/MensGroupDiscussionTracker.Infrastructure.csproj
+++ b/MensGroupDiscussionTracker/src/MensGroupDiscussionTracker.Infrastructure/MensGroupDiscussionTracker.Infrastructure.csproj
@@ -7,6 +7,16 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <FrameworkReference Include="Microsoft.AspNetCore.App" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="8.0.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="8.0.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="8.0.0" />
+  </ItemGroup>
+
+  <ItemGroup>
     <ProjectReference Include="..\MensGroupDiscussionTracker.Core\MensGroupDiscussionTracker.Core.csproj" />
   </ItemGroup>
 

--- a/MorningRoutineBuilder/src/MorningRoutineBuilder.Infrastructure/Data/MorningRoutineBuilderContext.cs
+++ b/MorningRoutineBuilder/src/MorningRoutineBuilder.Infrastructure/Data/MorningRoutineBuilderContext.cs
@@ -55,18 +55,13 @@ public class MorningRoutineBuilderContext : DbContext, IMorningRoutineBuilderCon
     /// <inheritdoc/>
     protected override void OnModelCreating(ModelBuilder modelBuilder)
     {
-        
-        // Apply tenant filter to User
-        modelBuilder.Entity<User>().HasQueryFilter(u => u.TenantId == _tenantContext.TenantId);
-
-        // Apply tenant filter to Role
-        modelBuilder.Entity<Role>().HasQueryFilter(r => r.TenantId == _tenantContext.TenantId);
-
         base.OnModelCreating(modelBuilder);
 
         // Apply tenant isolation filters
         if (_tenantContext != null)
         {
+            modelBuilder.Entity<User>().HasQueryFilter(u => u.TenantId == _tenantContext.TenantId);
+            modelBuilder.Entity<Role>().HasQueryFilter(r => r.TenantId == _tenantContext.TenantId);
             modelBuilder.Entity<Routine>().HasQueryFilter(e => e.TenantId == _tenantContext.TenantId);
             modelBuilder.Entity<RoutineTask>().HasQueryFilter(e => e.TenantId == _tenantContext.TenantId);
             modelBuilder.Entity<CompletionLog>().HasQueryFilter(e => e.TenantId == _tenantContext.TenantId);

--- a/MorningRoutineBuilder/src/MorningRoutineBuilder.Infrastructure/Data/SeedData.cs
+++ b/MorningRoutineBuilder/src/MorningRoutineBuilder.Infrastructure/Data/SeedData.cs
@@ -21,7 +21,7 @@ public static class SeedData
     /// <param name="context">The database context.</param>
     /// <param name="logger">The logger.</param>
     /// <returns>A task representing the asynchronous operation.</returns>
-    public static async Task SeedAsync(MorningRoutineBuilderContext context context, ILogger logger, IPasswordHasher passwordHasher)
+    public static async Task SeedAsync(MorningRoutineBuilderContext context, ILogger logger, IPasswordHasher passwordHasher)
     {
         ArgumentNullException.ThrowIfNull(context);
         ArgumentNullException.ThrowIfNull(logger);

--- a/MorningRoutineBuilder/src/MorningRoutineBuilder.Infrastructure/MorningRoutineBuilder.Infrastructure.csproj
+++ b/MorningRoutineBuilder/src/MorningRoutineBuilder.Infrastructure/MorningRoutineBuilder.Infrastructure.csproj
@@ -7,6 +7,16 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <FrameworkReference Include="Microsoft.AspNetCore.App" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="8.0.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="8.0.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="8.0.0" />
+  </ItemGroup>
+
+  <ItemGroup>
     <ProjectReference Include="..\MorningRoutineBuilder.Core\MorningRoutineBuilder.Core.csproj" />
   </ItemGroup>
 

--- a/MovieTVShowWatchlist/src/MovieTVShowWatchlist.Infrastructure/Data/SeedData.cs
+++ b/MovieTVShowWatchlist/src/MovieTVShowWatchlist.Infrastructure/Data/SeedData.cs
@@ -21,7 +21,7 @@ public static class SeedData
     /// <param name="context">The database context.</param>
     /// <param name="logger">The logger.</param>
     /// <returns>A task representing the asynchronous operation.</returns>
-    public static async Task SeedAsync(MovieTVShowWatchlistContext context context, ILogger logger, IPasswordHasher passwordHasher)
+    public static async Task SeedAsync(MovieTVShowWatchlistContext context, ILogger logger, IPasswordHasher passwordHasher)
     {
         ArgumentNullException.ThrowIfNull(context);
         ArgumentNullException.ThrowIfNull(logger);

--- a/MovieTVShowWatchlist/src/MovieTVShowWatchlist.Infrastructure/MovieTVShowWatchlist.Infrastructure.csproj
+++ b/MovieTVShowWatchlist/src/MovieTVShowWatchlist.Infrastructure/MovieTVShowWatchlist.Infrastructure.csproj
@@ -7,8 +7,14 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <FrameworkReference Include="Microsoft.AspNetCore.App" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="8.0.0" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="8.0.0" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="8.0.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="8.0.0" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="8.0.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/NeighborhoodSocialNetwork/src/NeighborhoodSocialNetwork.Infrastructure/Data/NeighborhoodSocialNetworkContext.cs
+++ b/NeighborhoodSocialNetwork/src/NeighborhoodSocialNetwork.Infrastructure/Data/NeighborhoodSocialNetworkContext.cs
@@ -55,18 +55,13 @@ public class NeighborhoodSocialNetworkContext : DbContext, INeighborhoodSocialNe
     /// <inheritdoc/>
     protected override void OnModelCreating(ModelBuilder modelBuilder)
     {
-        
-        // Apply tenant filter to User
-        modelBuilder.Entity<User>().HasQueryFilter(u => u.TenantId == _tenantContext.TenantId);
-
-        // Apply tenant filter to Role
-        modelBuilder.Entity<Role>().HasQueryFilter(r => r.TenantId == _tenantContext.TenantId);
-
         base.OnModelCreating(modelBuilder);
 
         // Apply tenant isolation filters
         if (_tenantContext != null)
         {
+            modelBuilder.Entity<User>().HasQueryFilter(u => u.TenantId == _tenantContext.TenantId);
+            modelBuilder.Entity<Role>().HasQueryFilter(r => r.TenantId == _tenantContext.TenantId);
             modelBuilder.Entity<Neighbor>().HasQueryFilter(e => e.TenantId == _tenantContext.TenantId);
             modelBuilder.Entity<Event>().HasQueryFilter(e => e.TenantId == _tenantContext.TenantId);
             modelBuilder.Entity<Recommendation>().HasQueryFilter(e => e.TenantId == _tenantContext.TenantId);

--- a/NeighborhoodSocialNetwork/src/NeighborhoodSocialNetwork.Infrastructure/Data/SeedData.cs
+++ b/NeighborhoodSocialNetwork/src/NeighborhoodSocialNetwork.Infrastructure/Data/SeedData.cs
@@ -21,7 +21,7 @@ public static class SeedData
     /// <param name="context">The database context.</param>
     /// <param name="logger">The logger.</param>
     /// <returns>A task representing the asynchronous operation.</returns>
-    public static async Task SeedAsync(NeighborhoodSocialNetworkContext context context, ILogger logger, IPasswordHasher passwordHasher)
+    public static async Task SeedAsync(NeighborhoodSocialNetworkContext context, ILogger logger, IPasswordHasher passwordHasher)
     {
         ArgumentNullException.ThrowIfNull(context);
         ArgumentNullException.ThrowIfNull(logger);

--- a/NeighborhoodSocialNetwork/src/NeighborhoodSocialNetwork.Infrastructure/NeighborhoodSocialNetwork.Infrastructure.csproj
+++ b/NeighborhoodSocialNetwork/src/NeighborhoodSocialNetwork.Infrastructure/NeighborhoodSocialNetwork.Infrastructure.csproj
@@ -7,6 +7,16 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <FrameworkReference Include="Microsoft.AspNetCore.App" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="8.0.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="8.0.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="8.0.0" />
+  </ItemGroup>
+
+  <ItemGroup>
     <ProjectReference Include="..\NeighborhoodSocialNetwork.Core\NeighborhoodSocialNetwork.Core.csproj" />
   </ItemGroup>
 

--- a/NutritionLabelScanner/src/NutritionLabelScanner.Infrastructure/Data/NutritionLabelScannerContext.cs
+++ b/NutritionLabelScanner/src/NutritionLabelScanner.Infrastructure/Data/NutritionLabelScannerContext.cs
@@ -52,18 +52,13 @@ public class NutritionLabelScannerContext : DbContext, INutritionLabelScannerCon
     /// <inheritdoc/>
     protected override void OnModelCreating(ModelBuilder modelBuilder)
     {
-        
-        // Apply tenant filter to User
-        modelBuilder.Entity<User>().HasQueryFilter(u => u.TenantId == _tenantContext.TenantId);
-
-        // Apply tenant filter to Role
-        modelBuilder.Entity<Role>().HasQueryFilter(r => r.TenantId == _tenantContext.TenantId);
-
         base.OnModelCreating(modelBuilder);
 
         // Apply tenant isolation filters
         if (_tenantContext != null)
         {
+            modelBuilder.Entity<User>().HasQueryFilter(u => u.TenantId == _tenantContext.TenantId);
+            modelBuilder.Entity<Role>().HasQueryFilter(r => r.TenantId == _tenantContext.TenantId);
             modelBuilder.Entity<Product>().HasQueryFilter(e => e.TenantId == _tenantContext.TenantId);
             modelBuilder.Entity<NutritionInfo>().HasQueryFilter(e => e.TenantId == _tenantContext.TenantId);
             modelBuilder.Entity<Comparison>().HasQueryFilter(e => e.TenantId == _tenantContext.TenantId);

--- a/NutritionLabelScanner/src/NutritionLabelScanner.Infrastructure/Data/SeedData.cs
+++ b/NutritionLabelScanner/src/NutritionLabelScanner.Infrastructure/Data/SeedData.cs
@@ -21,7 +21,7 @@ public static class SeedData
     /// <param name="context">The database context.</param>
     /// <param name="logger">The logger.</param>
     /// <returns>A task representing the asynchronous operation.</returns>
-    public static async Task SeedAsync(NutritionLabelScannerContext context context, ILogger logger, IPasswordHasher passwordHasher)
+    public static async Task SeedAsync(NutritionLabelScannerContext context, ILogger logger, IPasswordHasher passwordHasher)
     {
         ArgumentNullException.ThrowIfNull(context);
         ArgumentNullException.ThrowIfNull(logger);

--- a/NutritionLabelScanner/src/NutritionLabelScanner.Infrastructure/NutritionLabelScanner.Infrastructure.csproj
+++ b/NutritionLabelScanner/src/NutritionLabelScanner.Infrastructure/NutritionLabelScanner.Infrastructure.csproj
@@ -7,6 +7,16 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <FrameworkReference Include="Microsoft.AspNetCore.App" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="8.0.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="8.0.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="8.0.0" />
+  </ItemGroup>
+
+  <ItemGroup>
     <ProjectReference Include="..\NutritionLabelScanner.Core\NutritionLabelScanner.Core.csproj" />
   </ItemGroup>
 

--- a/PersonalHealthDashboard/src/PersonalHealthDashboard.Infrastructure/Data/PersonalHealthDashboardContext.cs
+++ b/PersonalHealthDashboard/src/PersonalHealthDashboard.Infrastructure/Data/PersonalHealthDashboardContext.cs
@@ -52,18 +52,13 @@ public class PersonalHealthDashboardContext : DbContext, IPersonalHealthDashboar
     /// <inheritdoc/>
     protected override void OnModelCreating(ModelBuilder modelBuilder)
     {
-        
-        // Apply tenant filter to User
-        modelBuilder.Entity<User>().HasQueryFilter(u => u.TenantId == _tenantContext.TenantId);
-
-        // Apply tenant filter to Role
-        modelBuilder.Entity<Role>().HasQueryFilter(r => r.TenantId == _tenantContext.TenantId);
-
         base.OnModelCreating(modelBuilder);
 
         // Apply tenant isolation filters
         if (_tenantContext != null)
         {
+            modelBuilder.Entity<User>().HasQueryFilter(u => u.TenantId == _tenantContext.TenantId);
+            modelBuilder.Entity<Role>().HasQueryFilter(r => r.TenantId == _tenantContext.TenantId);
             modelBuilder.Entity<Vital>().HasQueryFilter(e => e.TenantId == _tenantContext.TenantId);
             modelBuilder.Entity<WearableData>().HasQueryFilter(e => e.TenantId == _tenantContext.TenantId);
             modelBuilder.Entity<HealthTrend>().HasQueryFilter(e => e.TenantId == _tenantContext.TenantId);

--- a/PersonalHealthDashboard/src/PersonalHealthDashboard.Infrastructure/Data/SeedData.cs
+++ b/PersonalHealthDashboard/src/PersonalHealthDashboard.Infrastructure/Data/SeedData.cs
@@ -21,7 +21,7 @@ public static class SeedData
     /// <param name="context">The database context.</param>
     /// <param name="logger">The logger.</param>
     /// <returns>A task representing the asynchronous operation.</returns>
-    public static async Task SeedAsync(PersonalHealthDashboardContext context context, ILogger logger, IPasswordHasher passwordHasher)
+    public static async Task SeedAsync(PersonalHealthDashboardContext context, ILogger logger, IPasswordHasher passwordHasher)
     {
         ArgumentNullException.ThrowIfNull(context);
         ArgumentNullException.ThrowIfNull(logger);

--- a/PersonalHealthDashboard/src/PersonalHealthDashboard.Infrastructure/PersonalHealthDashboard.Infrastructure.csproj
+++ b/PersonalHealthDashboard/src/PersonalHealthDashboard.Infrastructure/PersonalHealthDashboard.Infrastructure.csproj
@@ -7,6 +7,16 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <FrameworkReference Include="Microsoft.AspNetCore.App" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="8.0.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="8.0.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="8.0.0" />
+  </ItemGroup>
+
+  <ItemGroup>
     <ProjectReference Include="..\PersonalHealthDashboard.Core\PersonalHealthDashboard.Core.csproj" />
   </ItemGroup>
 

--- a/PersonalLibraryLessonsLearned/src/PersonalLibraryLessonsLearned.Infrastructure/Data/PersonalLibraryLessonsLearnedContext.cs
+++ b/PersonalLibraryLessonsLearned/src/PersonalLibraryLessonsLearned.Infrastructure/Data/PersonalLibraryLessonsLearnedContext.cs
@@ -52,18 +52,13 @@ public class PersonalLibraryLessonsLearnedContext : DbContext, IPersonalLibraryL
     /// <inheritdoc/>
     protected override void OnModelCreating(ModelBuilder modelBuilder)
     {
-        
-        // Apply tenant filter to User
-        modelBuilder.Entity<User>().HasQueryFilter(u => u.TenantId == _tenantContext.TenantId);
-
-        // Apply tenant filter to Role
-        modelBuilder.Entity<Role>().HasQueryFilter(r => r.TenantId == _tenantContext.TenantId);
-
         base.OnModelCreating(modelBuilder);
 
         // Apply tenant isolation filters
         if (_tenantContext != null)
         {
+            modelBuilder.Entity<User>().HasQueryFilter(u => u.TenantId == _tenantContext.TenantId);
+            modelBuilder.Entity<Role>().HasQueryFilter(r => r.TenantId == _tenantContext.TenantId);
             modelBuilder.Entity<Lesson>().HasQueryFilter(e => e.TenantId == _tenantContext.TenantId);
             modelBuilder.Entity<Source>().HasQueryFilter(e => e.TenantId == _tenantContext.TenantId);
             modelBuilder.Entity<LessonReminder>().HasQueryFilter(e => e.TenantId == _tenantContext.TenantId);

--- a/PersonalLibraryLessonsLearned/src/PersonalLibraryLessonsLearned.Infrastructure/Data/SeedData.cs
+++ b/PersonalLibraryLessonsLearned/src/PersonalLibraryLessonsLearned.Infrastructure/Data/SeedData.cs
@@ -21,7 +21,7 @@ public static class SeedData
     /// <param name="context">The database context.</param>
     /// <param name="logger">The logger.</param>
     /// <returns>A task representing the asynchronous operation.</returns>
-    public static async Task SeedAsync(PersonalLibraryLessonsLearnedContext context context, ILogger logger, IPasswordHasher passwordHasher)
+    public static async Task SeedAsync(PersonalLibraryLessonsLearnedContext context, ILogger logger, IPasswordHasher passwordHasher)
     {
         ArgumentNullException.ThrowIfNull(context);
         ArgumentNullException.ThrowIfNull(logger);

--- a/PersonalLibraryLessonsLearned/src/PersonalLibraryLessonsLearned.Infrastructure/PersonalLibraryLessonsLearned.Infrastructure.csproj
+++ b/PersonalLibraryLessonsLearned/src/PersonalLibraryLessonsLearned.Infrastructure/PersonalLibraryLessonsLearned.Infrastructure.csproj
@@ -7,6 +7,16 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <FrameworkReference Include="Microsoft.AspNetCore.App" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="8.0.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="8.0.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="8.0.0" />
+  </ItemGroup>
+
+  <ItemGroup>
     <ProjectReference Include="..\PersonalLibraryLessonsLearned.Core\PersonalLibraryLessonsLearned.Core.csproj" />
   </ItemGroup>
 

--- a/PersonalLoanComparisonTool/src/PersonalLoanComparisonTool.Infrastructure/Data/PersonalLoanComparisonToolContext.cs
+++ b/PersonalLoanComparisonTool/src/PersonalLoanComparisonTool.Infrastructure/Data/PersonalLoanComparisonToolContext.cs
@@ -52,18 +52,13 @@ public class PersonalLoanComparisonToolContext : DbContext, IPersonalLoanCompari
     /// <inheritdoc/>
     protected override void OnModelCreating(ModelBuilder modelBuilder)
     {
-        
-        // Apply tenant filter to User
-        modelBuilder.Entity<User>().HasQueryFilter(u => u.TenantId == _tenantContext.TenantId);
-
-        // Apply tenant filter to Role
-        modelBuilder.Entity<Role>().HasQueryFilter(r => r.TenantId == _tenantContext.TenantId);
-
         base.OnModelCreating(modelBuilder);
 
         // Apply tenant isolation filters
         if (_tenantContext != null)
         {
+            modelBuilder.Entity<User>().HasQueryFilter(u => u.TenantId == _tenantContext.TenantId);
+            modelBuilder.Entity<Role>().HasQueryFilter(r => r.TenantId == _tenantContext.TenantId);
             modelBuilder.Entity<Loan>().HasQueryFilter(e => e.TenantId == _tenantContext.TenantId);
             modelBuilder.Entity<Offer>().HasQueryFilter(e => e.TenantId == _tenantContext.TenantId);
             modelBuilder.Entity<PaymentSchedule>().HasQueryFilter(e => e.TenantId == _tenantContext.TenantId);

--- a/PersonalLoanComparisonTool/src/PersonalLoanComparisonTool.Infrastructure/Data/SeedData.cs
+++ b/PersonalLoanComparisonTool/src/PersonalLoanComparisonTool.Infrastructure/Data/SeedData.cs
@@ -21,7 +21,7 @@ public static class SeedData
     /// <param name="context">The database context.</param>
     /// <param name="logger">The logger.</param>
     /// <returns>A task representing the asynchronous operation.</returns>
-    public static async Task SeedAsync(PersonalLoanComparisonToolContext context context, ILogger logger, IPasswordHasher passwordHasher)
+    public static async Task SeedAsync(PersonalLoanComparisonToolContext context, ILogger logger, IPasswordHasher passwordHasher)
     {
         ArgumentNullException.ThrowIfNull(context);
         ArgumentNullException.ThrowIfNull(logger);

--- a/PersonalLoanComparisonTool/src/PersonalLoanComparisonTool.Infrastructure/PersonalLoanComparisonTool.Infrastructure.csproj
+++ b/PersonalLoanComparisonTool/src/PersonalLoanComparisonTool.Infrastructure/PersonalLoanComparisonTool.Infrastructure.csproj
@@ -7,6 +7,16 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <FrameworkReference Include="Microsoft.AspNetCore.App" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="8.0.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="8.0.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="8.0.0" />
+  </ItemGroup>
+
+  <ItemGroup>
     <ProjectReference Include="..\PersonalLoanComparisonTool.Core\PersonalLoanComparisonTool.Core.csproj" />
   </ItemGroup>
 

--- a/PersonalMissionStatementBuilder/src/PersonalMissionStatementBuilder.Infrastructure/Data/PersonalMissionStatementBuilderContext.cs
+++ b/PersonalMissionStatementBuilder/src/PersonalMissionStatementBuilder.Infrastructure/Data/PersonalMissionStatementBuilderContext.cs
@@ -55,18 +55,13 @@ public class PersonalMissionStatementBuilderContext : DbContext, IPersonalMissio
     /// <inheritdoc/>
     protected override void OnModelCreating(ModelBuilder modelBuilder)
     {
-        
-        // Apply tenant filter to User
-        modelBuilder.Entity<User>().HasQueryFilter(u => u.TenantId == _tenantContext.TenantId);
-
-        // Apply tenant filter to Role
-        modelBuilder.Entity<Role>().HasQueryFilter(r => r.TenantId == _tenantContext.TenantId);
-
         base.OnModelCreating(modelBuilder);
 
         // Apply tenant isolation filters
         if (_tenantContext != null)
         {
+            modelBuilder.Entity<User>().HasQueryFilter(u => u.TenantId == _tenantContext.TenantId);
+            modelBuilder.Entity<Role>().HasQueryFilter(r => r.TenantId == _tenantContext.TenantId);
             modelBuilder.Entity<MissionStatement>().HasQueryFilter(e => e.TenantId == _tenantContext.TenantId);
             modelBuilder.Entity<Value>().HasQueryFilter(e => e.TenantId == _tenantContext.TenantId);
             modelBuilder.Entity<Goal>().HasQueryFilter(e => e.TenantId == _tenantContext.TenantId);

--- a/PersonalMissionStatementBuilder/src/PersonalMissionStatementBuilder.Infrastructure/Data/SeedData.cs
+++ b/PersonalMissionStatementBuilder/src/PersonalMissionStatementBuilder.Infrastructure/Data/SeedData.cs
@@ -21,7 +21,7 @@ public static class SeedData
     /// <param name="context">The database context.</param>
     /// <param name="logger">The logger.</param>
     /// <returns>A task representing the asynchronous operation.</returns>
-    public static async Task SeedAsync(PersonalMissionStatementBuilderContext context context, ILogger logger, IPasswordHasher passwordHasher)
+    public static async Task SeedAsync(PersonalMissionStatementBuilderContext context, ILogger logger, IPasswordHasher passwordHasher)
     {
         ArgumentNullException.ThrowIfNull(context);
         ArgumentNullException.ThrowIfNull(logger);

--- a/PersonalMissionStatementBuilder/src/PersonalMissionStatementBuilder.Infrastructure/PersonalMissionStatementBuilder.Infrastructure.csproj
+++ b/PersonalMissionStatementBuilder/src/PersonalMissionStatementBuilder.Infrastructure/PersonalMissionStatementBuilder.Infrastructure.csproj
@@ -7,6 +7,16 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <FrameworkReference Include="Microsoft.AspNetCore.App" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="8.0.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="8.0.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="8.0.0" />
+  </ItemGroup>
+
+  <ItemGroup>
     <ProjectReference Include="..\PersonalMissionStatementBuilder.Core\PersonalMissionStatementBuilder.Core.csproj" />
   </ItemGroup>
 

--- a/PersonalNetWorthDashboard/src/PersonalNetWorthDashboard.Infrastructure/Data/PersonalNetWorthDashboardContext.cs
+++ b/PersonalNetWorthDashboard/src/PersonalNetWorthDashboard.Infrastructure/Data/PersonalNetWorthDashboardContext.cs
@@ -52,18 +52,13 @@ public class PersonalNetWorthDashboardContext : DbContext, IPersonalNetWorthDash
     /// <inheritdoc/>
     protected override void OnModelCreating(ModelBuilder modelBuilder)
     {
-        
-        // Apply tenant filter to User
-        modelBuilder.Entity<User>().HasQueryFilter(u => u.TenantId == _tenantContext.TenantId);
-
-        // Apply tenant filter to Role
-        modelBuilder.Entity<Role>().HasQueryFilter(r => r.TenantId == _tenantContext.TenantId);
-
         base.OnModelCreating(modelBuilder);
 
         // Apply tenant isolation filters
         if (_tenantContext != null)
         {
+            modelBuilder.Entity<User>().HasQueryFilter(u => u.TenantId == _tenantContext.TenantId);
+            modelBuilder.Entity<Role>().HasQueryFilter(r => r.TenantId == _tenantContext.TenantId);
             modelBuilder.Entity<Asset>().HasQueryFilter(e => e.TenantId == _tenantContext.TenantId);
             modelBuilder.Entity<Liability>().HasQueryFilter(e => e.TenantId == _tenantContext.TenantId);
             modelBuilder.Entity<NetWorthSnapshot>().HasQueryFilter(e => e.TenantId == _tenantContext.TenantId);

--- a/PersonalNetWorthDashboard/src/PersonalNetWorthDashboard.Infrastructure/Data/SeedData.cs
+++ b/PersonalNetWorthDashboard/src/PersonalNetWorthDashboard.Infrastructure/Data/SeedData.cs
@@ -21,7 +21,7 @@ public static class SeedData
     /// <param name="context">The database context.</param>
     /// <param name="logger">The logger.</param>
     /// <returns>A task representing the asynchronous operation.</returns>
-    public static async Task SeedAsync(PersonalNetWorthDashboardContext context context, ILogger logger, IPasswordHasher passwordHasher)
+    public static async Task SeedAsync(PersonalNetWorthDashboardContext context, ILogger logger, IPasswordHasher passwordHasher)
     {
         ArgumentNullException.ThrowIfNull(context);
         ArgumentNullException.ThrowIfNull(logger);

--- a/PersonalNetWorthDashboard/src/PersonalNetWorthDashboard.Infrastructure/PersonalNetWorthDashboard.Infrastructure.csproj
+++ b/PersonalNetWorthDashboard/src/PersonalNetWorthDashboard.Infrastructure/PersonalNetWorthDashboard.Infrastructure.csproj
@@ -7,6 +7,16 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <FrameworkReference Include="Microsoft.AspNetCore.App" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="8.0.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="8.0.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="8.0.0" />
+  </ItemGroup>
+
+  <ItemGroup>
     <ProjectReference Include="..\PersonalNetWorthDashboard.Core\PersonalNetWorthDashboard.Core.csproj" />
   </ItemGroup>
 

--- a/PersonalProjectPipeline/src/PersonalProjectPipeline.Infrastructure/Data/PersonalProjectPipelineContext.cs
+++ b/PersonalProjectPipeline/src/PersonalProjectPipeline.Infrastructure/Data/PersonalProjectPipelineContext.cs
@@ -52,18 +52,13 @@ public class PersonalProjectPipelineContext : DbContext, IPersonalProjectPipelin
     /// <inheritdoc/>
     protected override void OnModelCreating(ModelBuilder modelBuilder)
     {
-        
-        // Apply tenant filter to User
-        modelBuilder.Entity<User>().HasQueryFilter(u => u.TenantId == _tenantContext.TenantId);
-
-        // Apply tenant filter to Role
-        modelBuilder.Entity<Role>().HasQueryFilter(r => r.TenantId == _tenantContext.TenantId);
-
         base.OnModelCreating(modelBuilder);
 
         // Apply tenant isolation filters
         if (_tenantContext != null)
         {
+            modelBuilder.Entity<User>().HasQueryFilter(u => u.TenantId == _tenantContext.TenantId);
+            modelBuilder.Entity<Role>().HasQueryFilter(r => r.TenantId == _tenantContext.TenantId);
             modelBuilder.Entity<Project>().HasQueryFilter(e => e.TenantId == _tenantContext.TenantId);
             modelBuilder.Entity<ProjectTask>().HasQueryFilter(e => e.TenantId == _tenantContext.TenantId);
             modelBuilder.Entity<Milestone>().HasQueryFilter(e => e.TenantId == _tenantContext.TenantId);

--- a/PersonalProjectPipeline/src/PersonalProjectPipeline.Infrastructure/Data/SeedData.cs
+++ b/PersonalProjectPipeline/src/PersonalProjectPipeline.Infrastructure/Data/SeedData.cs
@@ -21,7 +21,7 @@ public static class SeedData
     /// <param name="context">The database context.</param>
     /// <param name="logger">The logger.</param>
     /// <returns>A task representing the asynchronous operation.</returns>
-    public static async Task SeedAsync(PersonalProjectPipelineContext context context, ILogger logger, IPasswordHasher passwordHasher)
+    public static async Task SeedAsync(PersonalProjectPipelineContext context, ILogger logger, IPasswordHasher passwordHasher)
     {
         ArgumentNullException.ThrowIfNull(context);
         ArgumentNullException.ThrowIfNull(logger);

--- a/PersonalProjectPipeline/src/PersonalProjectPipeline.Infrastructure/PersonalProjectPipeline.Infrastructure.csproj
+++ b/PersonalProjectPipeline/src/PersonalProjectPipeline.Infrastructure/PersonalProjectPipeline.Infrastructure.csproj
@@ -7,6 +7,16 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <FrameworkReference Include="Microsoft.AspNetCore.App" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="8.0.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="8.0.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="8.0.0" />
+  </ItemGroup>
+
+  <ItemGroup>
     <ProjectReference Include="..\PersonalProjectPipeline.Core\PersonalProjectPipeline.Core.csproj" />
   </ItemGroup>
 

--- a/PersonalWiki/src/PersonalWiki.Infrastructure/Data/PersonalWikiContext.cs
+++ b/PersonalWiki/src/PersonalWiki.Infrastructure/Data/PersonalWikiContext.cs
@@ -55,18 +55,13 @@ public class PersonalWikiContext : DbContext, IPersonalWikiContext
     /// <inheritdoc/>
     protected override void OnModelCreating(ModelBuilder modelBuilder)
     {
-        
-        // Apply tenant filter to User
-        modelBuilder.Entity<User>().HasQueryFilter(u => u.TenantId == _tenantContext.TenantId);
-
-        // Apply tenant filter to Role
-        modelBuilder.Entity<Role>().HasQueryFilter(r => r.TenantId == _tenantContext.TenantId);
-
         base.OnModelCreating(modelBuilder);
 
         // Apply tenant isolation filters
         if (_tenantContext != null)
         {
+            modelBuilder.Entity<User>().HasQueryFilter(u => u.TenantId == _tenantContext.TenantId);
+            modelBuilder.Entity<Role>().HasQueryFilter(r => r.TenantId == _tenantContext.TenantId);
             modelBuilder.Entity<WikiPage>().HasQueryFilter(e => e.TenantId == _tenantContext.TenantId);
             modelBuilder.Entity<PageRevision>().HasQueryFilter(e => e.TenantId == _tenantContext.TenantId);
             modelBuilder.Entity<WikiCategory>().HasQueryFilter(e => e.TenantId == _tenantContext.TenantId);

--- a/PersonalWiki/src/PersonalWiki.Infrastructure/Data/SeedData.cs
+++ b/PersonalWiki/src/PersonalWiki.Infrastructure/Data/SeedData.cs
@@ -21,7 +21,7 @@ public static class SeedData
     /// <param name="context">The database context.</param>
     /// <param name="logger">The logger.</param>
     /// <returns>A task representing the asynchronous operation.</returns>
-    public static async Task SeedAsync(PersonalWikiContext context context, ILogger logger, IPasswordHasher passwordHasher)
+    public static async Task SeedAsync(PersonalWikiContext context, ILogger logger, IPasswordHasher passwordHasher)
     {
         ArgumentNullException.ThrowIfNull(context);
         ArgumentNullException.ThrowIfNull(logger);

--- a/PersonalWiki/src/PersonalWiki.Infrastructure/PersonalWiki.Infrastructure.csproj
+++ b/PersonalWiki/src/PersonalWiki.Infrastructure/PersonalWiki.Infrastructure.csproj
@@ -7,6 +7,16 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <FrameworkReference Include="Microsoft.AspNetCore.App" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="8.0.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="8.0.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="8.0.0" />
+  </ItemGroup>
+
+  <ItemGroup>
     <ProjectReference Include="..\PersonalWiki.Core\PersonalWiki.Core.csproj" />
   </ItemGroup>
 

--- a/PhotographySessionLogger/src/PhotographySessionLogger.Infrastructure/Data/PhotographySessionLoggerContext.cs
+++ b/PhotographySessionLogger/src/PhotographySessionLogger.Infrastructure/Data/PhotographySessionLoggerContext.cs
@@ -55,18 +55,13 @@ public class PhotographySessionLoggerContext : DbContext, IPhotographySessionLog
     /// <inheritdoc/>
     protected override void OnModelCreating(ModelBuilder modelBuilder)
     {
-        
-        // Apply tenant filter to User
-        modelBuilder.Entity<User>().HasQueryFilter(u => u.TenantId == _tenantContext.TenantId);
-
-        // Apply tenant filter to Role
-        modelBuilder.Entity<Role>().HasQueryFilter(r => r.TenantId == _tenantContext.TenantId);
-
         base.OnModelCreating(modelBuilder);
 
         // Apply tenant isolation filters
         if (_tenantContext != null)
         {
+            modelBuilder.Entity<User>().HasQueryFilter(u => u.TenantId == _tenantContext.TenantId);
+            modelBuilder.Entity<Role>().HasQueryFilter(r => r.TenantId == _tenantContext.TenantId);
             modelBuilder.Entity<Session>().HasQueryFilter(e => e.TenantId == _tenantContext.TenantId);
             modelBuilder.Entity<Photo>().HasQueryFilter(e => e.TenantId == _tenantContext.TenantId);
             modelBuilder.Entity<Gear>().HasQueryFilter(e => e.TenantId == _tenantContext.TenantId);

--- a/PhotographySessionLogger/src/PhotographySessionLogger.Infrastructure/Data/SeedData.cs
+++ b/PhotographySessionLogger/src/PhotographySessionLogger.Infrastructure/Data/SeedData.cs
@@ -21,7 +21,7 @@ public static class SeedData
     /// <param name="context">The database context.</param>
     /// <param name="logger">The logger.</param>
     /// <returns>A task representing the asynchronous operation.</returns>
-    public static async Task SeedAsync(PhotographySessionLoggerContext context context, ILogger logger, IPasswordHasher passwordHasher)
+    public static async Task SeedAsync(PhotographySessionLoggerContext context, ILogger logger, IPasswordHasher passwordHasher)
     {
         ArgumentNullException.ThrowIfNull(context);
         ArgumentNullException.ThrowIfNull(logger);

--- a/PhotographySessionLogger/src/PhotographySessionLogger.Infrastructure/PhotographySessionLogger.Infrastructure.csproj
+++ b/PhotographySessionLogger/src/PhotographySessionLogger.Infrastructure/PhotographySessionLogger.Infrastructure.csproj
@@ -7,6 +7,16 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <FrameworkReference Include="Microsoft.AspNetCore.App" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="8.0.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="8.0.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="8.0.0" />
+  </ItemGroup>
+
+  <ItemGroup>
     <ProjectReference Include="..\PhotographySessionLogger.Core\PhotographySessionLogger.Core.csproj" />
   </ItemGroup>
 

--- a/ProfessionalNetworkCRM/src/ProfessionalNetworkCRM.Infrastructure/Data/ProfessionalNetworkCRMContext.cs
+++ b/ProfessionalNetworkCRM/src/ProfessionalNetworkCRM.Infrastructure/Data/ProfessionalNetworkCRMContext.cs
@@ -52,18 +52,13 @@ public class ProfessionalNetworkCRMContext : DbContext, IProfessionalNetworkCRMC
     /// <inheritdoc/>
     protected override void OnModelCreating(ModelBuilder modelBuilder)
     {
-        
-        // Apply tenant filter to User
-        modelBuilder.Entity<User>().HasQueryFilter(u => u.TenantId == _tenantContext.TenantId);
-
-        // Apply tenant filter to Role
-        modelBuilder.Entity<Role>().HasQueryFilter(r => r.TenantId == _tenantContext.TenantId);
-
         base.OnModelCreating(modelBuilder);
 
         // Apply tenant isolation filters
         if (_tenantContext != null)
         {
+            modelBuilder.Entity<User>().HasQueryFilter(u => u.TenantId == _tenantContext.TenantId);
+            modelBuilder.Entity<Role>().HasQueryFilter(r => r.TenantId == _tenantContext.TenantId);
             modelBuilder.Entity<Contact>().HasQueryFilter(e => e.TenantId == _tenantContext.TenantId);
             modelBuilder.Entity<Interaction>().HasQueryFilter(e => e.TenantId == _tenantContext.TenantId);
             modelBuilder.Entity<FollowUp>().HasQueryFilter(e => e.TenantId == _tenantContext.TenantId);

--- a/ProfessionalNetworkCRM/src/ProfessionalNetworkCRM.Infrastructure/Data/SeedData.cs
+++ b/ProfessionalNetworkCRM/src/ProfessionalNetworkCRM.Infrastructure/Data/SeedData.cs
@@ -21,7 +21,7 @@ public static class SeedData
     /// <param name="context">The database context.</param>
     /// <param name="logger">The logger.</param>
     /// <returns>A task representing the asynchronous operation.</returns>
-    public static async Task SeedAsync(ProfessionalNetworkCRMContext context context, ILogger logger, IPasswordHasher passwordHasher)
+    public static async Task SeedAsync(ProfessionalNetworkCRMContext context, ILogger logger, IPasswordHasher passwordHasher)
     {
         ArgumentNullException.ThrowIfNull(context);
         ArgumentNullException.ThrowIfNull(logger);

--- a/ProfessionalNetworkCRM/src/ProfessionalNetworkCRM.Infrastructure/ProfessionalNetworkCRM.Infrastructure.csproj
+++ b/ProfessionalNetworkCRM/src/ProfessionalNetworkCRM.Infrastructure/ProfessionalNetworkCRM.Infrastructure.csproj
@@ -7,6 +7,16 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <FrameworkReference Include="Microsoft.AspNetCore.App" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="8.0.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="8.0.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="8.0.0" />
+  </ItemGroup>
+
+  <ItemGroup>
     <ProjectReference Include="..\ProfessionalNetworkCRM.Core\ProfessionalNetworkCRM.Core.csproj" />
   </ItemGroup>
 

--- a/ProfessionalReadingList/src/ProfessionalReadingList.Infrastructure/Data/ProfessionalReadingListContext.cs
+++ b/ProfessionalReadingList/src/ProfessionalReadingList.Infrastructure/Data/ProfessionalReadingListContext.cs
@@ -52,18 +52,13 @@ public class ProfessionalReadingListContext : DbContext, IProfessionalReadingLis
     /// <inheritdoc/>
     protected override void OnModelCreating(ModelBuilder modelBuilder)
     {
-        
-        // Apply tenant filter to User
-        modelBuilder.Entity<User>().HasQueryFilter(u => u.TenantId == _tenantContext.TenantId);
-
-        // Apply tenant filter to Role
-        modelBuilder.Entity<Role>().HasQueryFilter(r => r.TenantId == _tenantContext.TenantId);
-
         base.OnModelCreating(modelBuilder);
 
         // Apply tenant isolation filters
         if (_tenantContext != null)
         {
+            modelBuilder.Entity<User>().HasQueryFilter(u => u.TenantId == _tenantContext.TenantId);
+            modelBuilder.Entity<Role>().HasQueryFilter(r => r.TenantId == _tenantContext.TenantId);
             modelBuilder.Entity<Resource>().HasQueryFilter(e => e.TenantId == _tenantContext.TenantId);
             modelBuilder.Entity<ReadingProgress>().HasQueryFilter(e => e.TenantId == _tenantContext.TenantId);
             modelBuilder.Entity<Note>().HasQueryFilter(e => e.TenantId == _tenantContext.TenantId);

--- a/ProfessionalReadingList/src/ProfessionalReadingList.Infrastructure/Data/SeedData.cs
+++ b/ProfessionalReadingList/src/ProfessionalReadingList.Infrastructure/Data/SeedData.cs
@@ -21,7 +21,7 @@ public static class SeedData
     /// <param name="context">The database context.</param>
     /// <param name="logger">The logger.</param>
     /// <returns>A task representing the asynchronous operation.</returns>
-    public static async Task SeedAsync(ProfessionalReadingListContext context context, ILogger logger, IPasswordHasher passwordHasher)
+    public static async Task SeedAsync(ProfessionalReadingListContext context, ILogger logger, IPasswordHasher passwordHasher)
     {
         ArgumentNullException.ThrowIfNull(context);
         ArgumentNullException.ThrowIfNull(logger);

--- a/ProfessionalReadingList/src/ProfessionalReadingList.Infrastructure/ProfessionalReadingList.Infrastructure.csproj
+++ b/ProfessionalReadingList/src/ProfessionalReadingList.Infrastructure/ProfessionalReadingList.Infrastructure.csproj
@@ -7,6 +7,16 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <FrameworkReference Include="Microsoft.AspNetCore.App" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="8.0.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="8.0.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="8.0.0" />
+  </ItemGroup>
+
+  <ItemGroup>
     <ProjectReference Include="..\ProfessionalReadingList.Core\ProfessionalReadingList.Core.csproj" />
   </ItemGroup>
 

--- a/RecipeManagerMealPlanner/src/RecipeManagerMealPlanner.Infrastructure/Data/RecipeManagerMealPlannerContext.cs
+++ b/RecipeManagerMealPlanner/src/RecipeManagerMealPlanner.Infrastructure/Data/RecipeManagerMealPlannerContext.cs
@@ -55,18 +55,13 @@ public class RecipeManagerMealPlannerContext : DbContext, IRecipeManagerMealPlan
     /// <inheritdoc/>
     protected override void OnModelCreating(ModelBuilder modelBuilder)
     {
-        
-        // Apply tenant filter to User
-        modelBuilder.Entity<User>().HasQueryFilter(u => u.TenantId == _tenantContext.TenantId);
-
-        // Apply tenant filter to Role
-        modelBuilder.Entity<Role>().HasQueryFilter(r => r.TenantId == _tenantContext.TenantId);
-
         base.OnModelCreating(modelBuilder);
 
         // Apply tenant isolation filters
         if (_tenantContext != null)
         {
+            modelBuilder.Entity<User>().HasQueryFilter(u => u.TenantId == _tenantContext.TenantId);
+            modelBuilder.Entity<Role>().HasQueryFilter(r => r.TenantId == _tenantContext.TenantId);
             modelBuilder.Entity<Recipe>().HasQueryFilter(e => e.TenantId == _tenantContext.TenantId);
             modelBuilder.Entity<MealPlan>().HasQueryFilter(e => e.TenantId == _tenantContext.TenantId);
             modelBuilder.Entity<Ingredient>().HasQueryFilter(e => e.TenantId == _tenantContext.TenantId);

--- a/RecipeManagerMealPlanner/src/RecipeManagerMealPlanner.Infrastructure/Data/SeedData.cs
+++ b/RecipeManagerMealPlanner/src/RecipeManagerMealPlanner.Infrastructure/Data/SeedData.cs
@@ -21,7 +21,7 @@ public static class SeedData
     /// <param name="context">The database context.</param>
     /// <param name="logger">The logger.</param>
     /// <returns>A task representing the asynchronous operation.</returns>
-    public static async Task SeedAsync(RecipeManagerMealPlannerContext context context, ILogger logger, IPasswordHasher passwordHasher)
+    public static async Task SeedAsync(RecipeManagerMealPlannerContext context, ILogger logger, IPasswordHasher passwordHasher)
     {
         ArgumentNullException.ThrowIfNull(context);
         ArgumentNullException.ThrowIfNull(logger);

--- a/RecipeManagerMealPlanner/src/RecipeManagerMealPlanner.Infrastructure/RecipeManagerMealPlanner.Infrastructure.csproj
+++ b/RecipeManagerMealPlanner/src/RecipeManagerMealPlanner.Infrastructure/RecipeManagerMealPlanner.Infrastructure.csproj
@@ -7,6 +7,16 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <FrameworkReference Include="Microsoft.AspNetCore.App" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="8.0.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="8.0.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="8.0.0" />
+  </ItemGroup>
+
+  <ItemGroup>
     <ProjectReference Include="..\RecipeManagerMealPlanner.Core\RecipeManagerMealPlanner.Core.csproj" />
   </ItemGroup>
 

--- a/ResumeCareerAchievementTracker/src/ResumeCareerAchievementTracker.Infrastructure/Data/ResumeCareerAchievementTrackerContext.cs
+++ b/ResumeCareerAchievementTracker/src/ResumeCareerAchievementTracker.Infrastructure/Data/ResumeCareerAchievementTrackerContext.cs
@@ -52,18 +52,13 @@ public class ResumeCareerAchievementTrackerContext : DbContext, IResumeCareerAch
     /// <inheritdoc/>
     protected override void OnModelCreating(ModelBuilder modelBuilder)
     {
-        
-        // Apply tenant filter to User
-        modelBuilder.Entity<User>().HasQueryFilter(u => u.TenantId == _tenantContext.TenantId);
-
-        // Apply tenant filter to Role
-        modelBuilder.Entity<Role>().HasQueryFilter(r => r.TenantId == _tenantContext.TenantId);
-
         base.OnModelCreating(modelBuilder);
 
         // Apply tenant isolation filters
         if (_tenantContext != null)
         {
+            modelBuilder.Entity<User>().HasQueryFilter(u => u.TenantId == _tenantContext.TenantId);
+            modelBuilder.Entity<Role>().HasQueryFilter(r => r.TenantId == _tenantContext.TenantId);
             modelBuilder.Entity<Achievement>().HasQueryFilter(e => e.TenantId == _tenantContext.TenantId);
             modelBuilder.Entity<Skill>().HasQueryFilter(e => e.TenantId == _tenantContext.TenantId);
             modelBuilder.Entity<Project>().HasQueryFilter(e => e.TenantId == _tenantContext.TenantId);

--- a/ResumeCareerAchievementTracker/src/ResumeCareerAchievementTracker.Infrastructure/Data/SeedData.cs
+++ b/ResumeCareerAchievementTracker/src/ResumeCareerAchievementTracker.Infrastructure/Data/SeedData.cs
@@ -21,7 +21,7 @@ public static class SeedData
     /// <param name="context">The database context.</param>
     /// <param name="logger">The logger.</param>
     /// <returns>A task representing the asynchronous operation.</returns>
-    public static async Task SeedAsync(ResumeCareerAchievementTrackerContext context context, ILogger logger, IPasswordHasher passwordHasher)
+    public static async Task SeedAsync(ResumeCareerAchievementTrackerContext context, ILogger logger, IPasswordHasher passwordHasher)
     {
         ArgumentNullException.ThrowIfNull(context);
         ArgumentNullException.ThrowIfNull(logger);

--- a/ResumeCareerAchievementTracker/src/ResumeCareerAchievementTracker.Infrastructure/ResumeCareerAchievementTracker.Infrastructure.csproj
+++ b/ResumeCareerAchievementTracker/src/ResumeCareerAchievementTracker.Infrastructure/ResumeCareerAchievementTracker.Infrastructure.csproj
@@ -7,6 +7,16 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <FrameworkReference Include="Microsoft.AspNetCore.App" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="8.0.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="8.0.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="8.0.0" />
+  </ItemGroup>
+
+  <ItemGroup>
     <ProjectReference Include="..\ResumeCareerAchievementTracker.Core\ResumeCareerAchievementTracker.Core.csproj" />
   </ItemGroup>
 

--- a/RetirementSavingsCalculator/src/RetirementSavingsCalculator.Infrastructure/Data/RetirementSavingsCalculatorContext.cs
+++ b/RetirementSavingsCalculator/src/RetirementSavingsCalculator.Infrastructure/Data/RetirementSavingsCalculatorContext.cs
@@ -52,18 +52,13 @@ public class RetirementSavingsCalculatorContext : DbContext, IRetirementSavingsC
     /// <inheritdoc/>
     protected override void OnModelCreating(ModelBuilder modelBuilder)
     {
-        
-        // Apply tenant filter to User
-        modelBuilder.Entity<User>().HasQueryFilter(u => u.TenantId == _tenantContext.TenantId);
-
-        // Apply tenant filter to Role
-        modelBuilder.Entity<Role>().HasQueryFilter(r => r.TenantId == _tenantContext.TenantId);
-
         base.OnModelCreating(modelBuilder);
 
         // Apply tenant isolation filters
         if (_tenantContext != null)
         {
+            modelBuilder.Entity<User>().HasQueryFilter(u => u.TenantId == _tenantContext.TenantId);
+            modelBuilder.Entity<Role>().HasQueryFilter(r => r.TenantId == _tenantContext.TenantId);
             modelBuilder.Entity<RetirementScenario>().HasQueryFilter(e => e.TenantId == _tenantContext.TenantId);
             modelBuilder.Entity<Contribution>().HasQueryFilter(e => e.TenantId == _tenantContext.TenantId);
             modelBuilder.Entity<WithdrawalStrategy>().HasQueryFilter(e => e.TenantId == _tenantContext.TenantId);

--- a/RetirementSavingsCalculator/src/RetirementSavingsCalculator.Infrastructure/Data/SeedData.cs
+++ b/RetirementSavingsCalculator/src/RetirementSavingsCalculator.Infrastructure/Data/SeedData.cs
@@ -21,7 +21,7 @@ public static class SeedData
     /// <param name="context">The database context.</param>
     /// <param name="logger">The logger.</param>
     /// <returns>A task representing the asynchronous operation.</returns>
-    public static async Task SeedAsync(RetirementSavingsCalculatorContext context context, ILogger logger, IPasswordHasher passwordHasher)
+    public static async Task SeedAsync(RetirementSavingsCalculatorContext context, ILogger logger, IPasswordHasher passwordHasher)
     {
         ArgumentNullException.ThrowIfNull(context);
         ArgumentNullException.ThrowIfNull(logger);

--- a/RetirementSavingsCalculator/src/RetirementSavingsCalculator.Infrastructure/RetirementSavingsCalculator.Infrastructure.csproj
+++ b/RetirementSavingsCalculator/src/RetirementSavingsCalculator.Infrastructure/RetirementSavingsCalculator.Infrastructure.csproj
@@ -7,6 +7,16 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <FrameworkReference Include="Microsoft.AspNetCore.App" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="8.0.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="8.0.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="8.0.0" />
+  </ItemGroup>
+
+  <ItemGroup>
     <ProjectReference Include="..\RetirementSavingsCalculator.Core\RetirementSavingsCalculator.Core.csproj" />
   </ItemGroup>
 

--- a/RoadsideAssistanceInfoHub/src/RoadsideAssistanceInfoHub.Infrastructure/Data/RoadsideAssistanceInfoHubContext.cs
+++ b/RoadsideAssistanceInfoHub/src/RoadsideAssistanceInfoHub.Infrastructure/Data/RoadsideAssistanceInfoHubContext.cs
@@ -55,18 +55,13 @@ public class RoadsideAssistanceInfoHubContext : DbContext, IRoadsideAssistanceIn
     /// <inheritdoc/>
     protected override void OnModelCreating(ModelBuilder modelBuilder)
     {
-        
-        // Apply tenant filter to User
-        modelBuilder.Entity<User>().HasQueryFilter(u => u.TenantId == _tenantContext.TenantId);
-
-        // Apply tenant filter to Role
-        modelBuilder.Entity<Role>().HasQueryFilter(r => r.TenantId == _tenantContext.TenantId);
-
         base.OnModelCreating(modelBuilder);
 
         // Apply tenant isolation filters
         if (_tenantContext != null)
         {
+            modelBuilder.Entity<User>().HasQueryFilter(u => u.TenantId == _tenantContext.TenantId);
+            modelBuilder.Entity<Role>().HasQueryFilter(r => r.TenantId == _tenantContext.TenantId);
             modelBuilder.Entity<Vehicle>().HasQueryFilter(e => e.TenantId == _tenantContext.TenantId);
             modelBuilder.Entity<InsuranceInfo>().HasQueryFilter(e => e.TenantId == _tenantContext.TenantId);
             modelBuilder.Entity<EmergencyContact>().HasQueryFilter(e => e.TenantId == _tenantContext.TenantId);

--- a/RoadsideAssistanceInfoHub/src/RoadsideAssistanceInfoHub.Infrastructure/Data/SeedData.cs
+++ b/RoadsideAssistanceInfoHub/src/RoadsideAssistanceInfoHub.Infrastructure/Data/SeedData.cs
@@ -21,7 +21,7 @@ public static class SeedData
     /// <param name="context">The database context.</param>
     /// <param name="logger">The logger.</param>
     /// <returns>A task representing the asynchronous operation.</returns>
-    public static async Task SeedAsync(RoadsideAssistanceInfoHubContext context context, ILogger logger, IPasswordHasher passwordHasher)
+    public static async Task SeedAsync(RoadsideAssistanceInfoHubContext context, ILogger logger, IPasswordHasher passwordHasher)
     {
         ArgumentNullException.ThrowIfNull(context);
         ArgumentNullException.ThrowIfNull(logger);

--- a/RoadsideAssistanceInfoHub/src/RoadsideAssistanceInfoHub.Infrastructure/RoadsideAssistanceInfoHub.Infrastructure.csproj
+++ b/RoadsideAssistanceInfoHub/src/RoadsideAssistanceInfoHub.Infrastructure/RoadsideAssistanceInfoHub.Infrastructure.csproj
@@ -7,6 +7,16 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <FrameworkReference Include="Microsoft.AspNetCore.App" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="8.0.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="8.0.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="8.0.0" />
+  </ItemGroup>
+
+  <ItemGroup>
     <ProjectReference Include="..\RoadsideAssistanceInfoHub.Core\RoadsideAssistanceInfoHub.Core.csproj" />
   </ItemGroup>
 

--- a/RunningLogRaceTracker/src/RunningLogRaceTracker.Infrastructure/Data/RunningLogRaceTrackerContext.cs
+++ b/RunningLogRaceTracker/src/RunningLogRaceTracker.Infrastructure/Data/RunningLogRaceTrackerContext.cs
@@ -52,18 +52,13 @@ public class RunningLogRaceTrackerContext : DbContext, IRunningLogRaceTrackerCon
     /// <inheritdoc/>
     protected override void OnModelCreating(ModelBuilder modelBuilder)
     {
-        
-        // Apply tenant filter to User
-        modelBuilder.Entity<User>().HasQueryFilter(u => u.TenantId == _tenantContext.TenantId);
-
-        // Apply tenant filter to Role
-        modelBuilder.Entity<Role>().HasQueryFilter(r => r.TenantId == _tenantContext.TenantId);
-
         base.OnModelCreating(modelBuilder);
 
         // Apply tenant isolation filters
         if (_tenantContext != null)
         {
+            modelBuilder.Entity<User>().HasQueryFilter(u => u.TenantId == _tenantContext.TenantId);
+            modelBuilder.Entity<Role>().HasQueryFilter(r => r.TenantId == _tenantContext.TenantId);
             modelBuilder.Entity<Run>().HasQueryFilter(e => e.TenantId == _tenantContext.TenantId);
             modelBuilder.Entity<Race>().HasQueryFilter(e => e.TenantId == _tenantContext.TenantId);
             modelBuilder.Entity<TrainingPlan>().HasQueryFilter(e => e.TenantId == _tenantContext.TenantId);

--- a/RunningLogRaceTracker/src/RunningLogRaceTracker.Infrastructure/Data/SeedData.cs
+++ b/RunningLogRaceTracker/src/RunningLogRaceTracker.Infrastructure/Data/SeedData.cs
@@ -21,7 +21,7 @@ public static class SeedData
     /// <param name="context">The database context.</param>
     /// <param name="logger">The logger.</param>
     /// <returns>A task representing the asynchronous operation.</returns>
-    public static async Task SeedAsync(RunningLogRaceTrackerContext context context, ILogger logger, IPasswordHasher passwordHasher)
+    public static async Task SeedAsync(RunningLogRaceTrackerContext context, ILogger logger, IPasswordHasher passwordHasher)
     {
         ArgumentNullException.ThrowIfNull(context);
         ArgumentNullException.ThrowIfNull(logger);

--- a/RunningLogRaceTracker/src/RunningLogRaceTracker.Infrastructure/RunningLogRaceTracker.Infrastructure.csproj
+++ b/RunningLogRaceTracker/src/RunningLogRaceTracker.Infrastructure/RunningLogRaceTracker.Infrastructure.csproj
@@ -7,6 +7,16 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <FrameworkReference Include="Microsoft.AspNetCore.App" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="8.0.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="8.0.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="8.0.0" />
+  </ItemGroup>
+
+  <ItemGroup>
     <ProjectReference Include="..\RunningLogRaceTracker.Core\RunningLogRaceTracker.Core.csproj" />
   </ItemGroup>
 

--- a/SalaryCompensationTracker/src/SalaryCompensationTracker.Infrastructure/Data/SalaryCompensationTrackerContext.cs
+++ b/SalaryCompensationTracker/src/SalaryCompensationTracker.Infrastructure/Data/SalaryCompensationTrackerContext.cs
@@ -52,18 +52,13 @@ public class SalaryCompensationTrackerContext : DbContext, ISalaryCompensationTr
     /// <inheritdoc/>
     protected override void OnModelCreating(ModelBuilder modelBuilder)
     {
-        
-        // Apply tenant filter to User
-        modelBuilder.Entity<User>().HasQueryFilter(u => u.TenantId == _tenantContext.TenantId);
-
-        // Apply tenant filter to Role
-        modelBuilder.Entity<Role>().HasQueryFilter(r => r.TenantId == _tenantContext.TenantId);
-
         base.OnModelCreating(modelBuilder);
 
         // Apply tenant isolation filters
         if (_tenantContext != null)
         {
+            modelBuilder.Entity<User>().HasQueryFilter(u => u.TenantId == _tenantContext.TenantId);
+            modelBuilder.Entity<Role>().HasQueryFilter(r => r.TenantId == _tenantContext.TenantId);
             modelBuilder.Entity<Compensation>().HasQueryFilter(e => e.TenantId == _tenantContext.TenantId);
             modelBuilder.Entity<Benefit>().HasQueryFilter(e => e.TenantId == _tenantContext.TenantId);
             modelBuilder.Entity<MarketComparison>().HasQueryFilter(e => e.TenantId == _tenantContext.TenantId);

--- a/SalaryCompensationTracker/src/SalaryCompensationTracker.Infrastructure/Data/SeedData.cs
+++ b/SalaryCompensationTracker/src/SalaryCompensationTracker.Infrastructure/Data/SeedData.cs
@@ -21,7 +21,7 @@ public static class SeedData
     /// <param name="context">The database context.</param>
     /// <param name="logger">The logger.</param>
     /// <returns>A task representing the asynchronous operation.</returns>
-    public static async Task SeedAsync(SalaryCompensationTrackerContext context context, ILogger logger, IPasswordHasher passwordHasher)
+    public static async Task SeedAsync(SalaryCompensationTrackerContext context, ILogger logger, IPasswordHasher passwordHasher)
     {
         ArgumentNullException.ThrowIfNull(context);
         ArgumentNullException.ThrowIfNull(logger);

--- a/SalaryCompensationTracker/src/SalaryCompensationTracker.Infrastructure/SalaryCompensationTracker.Infrastructure.csproj
+++ b/SalaryCompensationTracker/src/SalaryCompensationTracker.Infrastructure/SalaryCompensationTracker.Infrastructure.csproj
@@ -7,6 +7,16 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <FrameworkReference Include="Microsoft.AspNetCore.App" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="8.0.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="8.0.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="8.0.0" />
+  </ItemGroup>
+
+  <ItemGroup>
     <ProjectReference Include="..\SalaryCompensationTracker.Core\SalaryCompensationTracker.Core.csproj" />
   </ItemGroup>
 

--- a/SideHustleIncomeTracker/src/SideHustleIncomeTracker.Infrastructure/Data/SeedData.cs
+++ b/SideHustleIncomeTracker/src/SideHustleIncomeTracker.Infrastructure/Data/SeedData.cs
@@ -21,7 +21,7 @@ public static class SeedData
     /// <param name="context">The database context.</param>
     /// <param name="logger">The logger.</param>
     /// <returns>A task representing the asynchronous operation.</returns>
-    public static async Task SeedAsync(SideHustleIncomeTrackerContext context context, ILogger logger, IPasswordHasher passwordHasher)
+    public static async Task SeedAsync(SideHustleIncomeTrackerContext context, ILogger logger, IPasswordHasher passwordHasher)
     {
         ArgumentNullException.ThrowIfNull(context);
         ArgumentNullException.ThrowIfNull(logger);

--- a/SideHustleIncomeTracker/src/SideHustleIncomeTracker.Infrastructure/Data/SideHustleIncomeTrackerContext.cs
+++ b/SideHustleIncomeTracker/src/SideHustleIncomeTracker.Infrastructure/Data/SideHustleIncomeTrackerContext.cs
@@ -55,18 +55,13 @@ public class SideHustleIncomeTrackerContext : DbContext, ISideHustleIncomeTracke
     /// <inheritdoc/>
     protected override void OnModelCreating(ModelBuilder modelBuilder)
     {
-        
-        // Apply tenant filter to User
-        modelBuilder.Entity<User>().HasQueryFilter(u => u.TenantId == _tenantContext.TenantId);
-
-        // Apply tenant filter to Role
-        modelBuilder.Entity<Role>().HasQueryFilter(r => r.TenantId == _tenantContext.TenantId);
-
         base.OnModelCreating(modelBuilder);
 
         // Apply tenant isolation filters
         if (_tenantContext != null)
         {
+            modelBuilder.Entity<User>().HasQueryFilter(u => u.TenantId == _tenantContext.TenantId);
+            modelBuilder.Entity<Role>().HasQueryFilter(r => r.TenantId == _tenantContext.TenantId);
             modelBuilder.Entity<Business>().HasQueryFilter(e => e.TenantId == _tenantContext.TenantId);
             modelBuilder.Entity<Income>().HasQueryFilter(e => e.TenantId == _tenantContext.TenantId);
             modelBuilder.Entity<Expense>().HasQueryFilter(e => e.TenantId == _tenantContext.TenantId);

--- a/SideHustleIncomeTracker/src/SideHustleIncomeTracker.Infrastructure/SideHustleIncomeTracker.Infrastructure.csproj
+++ b/SideHustleIncomeTracker/src/SideHustleIncomeTracker.Infrastructure/SideHustleIncomeTracker.Infrastructure.csproj
@@ -7,6 +7,16 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <FrameworkReference Include="Microsoft.AspNetCore.App" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="8.0.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="8.0.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="8.0.0" />
+  </ItemGroup>
+
+  <ItemGroup>
     <ProjectReference Include="..\SideHustleIncomeTracker.Core\SideHustleIncomeTracker.Core.csproj" />
   </ItemGroup>
 

--- a/SkillDevelopmentTracker/src/SkillDevelopmentTracker.Infrastructure/Data/SeedData.cs
+++ b/SkillDevelopmentTracker/src/SkillDevelopmentTracker.Infrastructure/Data/SeedData.cs
@@ -21,7 +21,7 @@ public static class SeedData
     /// <param name="context">The database context.</param>
     /// <param name="logger">The logger.</param>
     /// <returns>A task representing the asynchronous operation.</returns>
-    public static async Task SeedAsync(SkillDevelopmentTrackerContext context context, ILogger logger, IPasswordHasher passwordHasher)
+    public static async Task SeedAsync(SkillDevelopmentTrackerContext context, ILogger logger, IPasswordHasher passwordHasher)
     {
         ArgumentNullException.ThrowIfNull(context);
         ArgumentNullException.ThrowIfNull(logger);

--- a/SkillDevelopmentTracker/src/SkillDevelopmentTracker.Infrastructure/Data/SkillDevelopmentTrackerContext.cs
+++ b/SkillDevelopmentTracker/src/SkillDevelopmentTracker.Infrastructure/Data/SkillDevelopmentTrackerContext.cs
@@ -55,18 +55,13 @@ public class SkillDevelopmentTrackerContext : DbContext, ISkillDevelopmentTracke
     /// <inheritdoc/>
     protected override void OnModelCreating(ModelBuilder modelBuilder)
     {
-        
-        // Apply tenant filter to User
-        modelBuilder.Entity<User>().HasQueryFilter(u => u.TenantId == _tenantContext.TenantId);
-
-        // Apply tenant filter to Role
-        modelBuilder.Entity<Role>().HasQueryFilter(r => r.TenantId == _tenantContext.TenantId);
-
         base.OnModelCreating(modelBuilder);
 
         // Apply tenant isolation filters
         if (_tenantContext != null)
         {
+            modelBuilder.Entity<User>().HasQueryFilter(u => u.TenantId == _tenantContext.TenantId);
+            modelBuilder.Entity<Role>().HasQueryFilter(r => r.TenantId == _tenantContext.TenantId);
             modelBuilder.Entity<Skill>().HasQueryFilter(e => e.TenantId == _tenantContext.TenantId);
             modelBuilder.Entity<Course>().HasQueryFilter(e => e.TenantId == _tenantContext.TenantId);
             modelBuilder.Entity<Certification>().HasQueryFilter(e => e.TenantId == _tenantContext.TenantId);

--- a/SkillDevelopmentTracker/src/SkillDevelopmentTracker.Infrastructure/SkillDevelopmentTracker.Infrastructure.csproj
+++ b/SkillDevelopmentTracker/src/SkillDevelopmentTracker.Infrastructure/SkillDevelopmentTracker.Infrastructure.csproj
@@ -7,6 +7,16 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <FrameworkReference Include="Microsoft.AspNetCore.App" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="8.0.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="8.0.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="8.0.0" />
+  </ItemGroup>
+
+  <ItemGroup>
     <ProjectReference Include="..\SkillDevelopmentTracker.Core\SkillDevelopmentTracker.Core.csproj" />
   </ItemGroup>
 

--- a/SportsTeamFollowingTracker/src/SportsTeamFollowingTracker.Infrastructure/Data/SeedData.cs
+++ b/SportsTeamFollowingTracker/src/SportsTeamFollowingTracker.Infrastructure/Data/SeedData.cs
@@ -21,7 +21,7 @@ public static class SeedData
     /// <param name="context">The database context.</param>
     /// <param name="logger">The logger.</param>
     /// <returns>A task representing the asynchronous operation.</returns>
-    public static async Task SeedAsync(SportsTeamFollowingTrackerContext context context, ILogger logger, IPasswordHasher passwordHasher)
+    public static async Task SeedAsync(SportsTeamFollowingTrackerContext context, ILogger logger, IPasswordHasher passwordHasher)
     {
         ArgumentNullException.ThrowIfNull(context);
         ArgumentNullException.ThrowIfNull(logger);

--- a/SportsTeamFollowingTracker/src/SportsTeamFollowingTracker.Infrastructure/Data/SportsTeamFollowingTrackerContext.cs
+++ b/SportsTeamFollowingTracker/src/SportsTeamFollowingTracker.Infrastructure/Data/SportsTeamFollowingTrackerContext.cs
@@ -55,18 +55,13 @@ public class SportsTeamFollowingTrackerContext : DbContext, ISportsTeamFollowing
     /// <inheritdoc/>
     protected override void OnModelCreating(ModelBuilder modelBuilder)
     {
-        
-        // Apply tenant filter to User
-        modelBuilder.Entity<User>().HasQueryFilter(u => u.TenantId == _tenantContext.TenantId);
-
-        // Apply tenant filter to Role
-        modelBuilder.Entity<Role>().HasQueryFilter(r => r.TenantId == _tenantContext.TenantId);
-
         base.OnModelCreating(modelBuilder);
 
         // Apply tenant isolation filters
         if (_tenantContext != null)
         {
+            modelBuilder.Entity<User>().HasQueryFilter(u => u.TenantId == _tenantContext.TenantId);
+            modelBuilder.Entity<Role>().HasQueryFilter(r => r.TenantId == _tenantContext.TenantId);
             modelBuilder.Entity<Team>().HasQueryFilter(e => e.TenantId == _tenantContext.TenantId);
             modelBuilder.Entity<Game>().HasQueryFilter(e => e.TenantId == _tenantContext.TenantId);
             modelBuilder.Entity<Season>().HasQueryFilter(e => e.TenantId == _tenantContext.TenantId);

--- a/SportsTeamFollowingTracker/src/SportsTeamFollowingTracker.Infrastructure/SportsTeamFollowingTracker.Infrastructure.csproj
+++ b/SportsTeamFollowingTracker/src/SportsTeamFollowingTracker.Infrastructure/SportsTeamFollowingTracker.Infrastructure.csproj
@@ -7,6 +7,16 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <FrameworkReference Include="Microsoft.AspNetCore.App" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="8.0.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="8.0.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="8.0.0" />
+  </ItemGroup>
+
+  <ItemGroup>
     <ProjectReference Include="..\SportsTeamFollowingTracker.Core\SportsTeamFollowingTracker.Core.csproj" />
   </ItemGroup>
 

--- a/StressMoodTracker/src/StressMoodTracker.Infrastructure/Data/SeedData.cs
+++ b/StressMoodTracker/src/StressMoodTracker.Infrastructure/Data/SeedData.cs
@@ -21,7 +21,7 @@ public static class SeedData
     /// <param name="context">The database context.</param>
     /// <param name="logger">The logger.</param>
     /// <returns>A task representing the asynchronous operation.</returns>
-    public static async Task SeedAsync(StressMoodTrackerContext context context, ILogger logger, IPasswordHasher passwordHasher)
+    public static async Task SeedAsync(StressMoodTrackerContext context, ILogger logger, IPasswordHasher passwordHasher)
     {
         ArgumentNullException.ThrowIfNull(context);
         ArgumentNullException.ThrowIfNull(logger);

--- a/StressMoodTracker/src/StressMoodTracker.Infrastructure/Data/StressMoodTrackerContext.cs
+++ b/StressMoodTracker/src/StressMoodTracker.Infrastructure/Data/StressMoodTrackerContext.cs
@@ -52,18 +52,13 @@ public class StressMoodTrackerContext : DbContext, IStressMoodTrackerContext
     /// <inheritdoc/>
     protected override void OnModelCreating(ModelBuilder modelBuilder)
     {
-        
-        // Apply tenant filter to User
-        modelBuilder.Entity<User>().HasQueryFilter(u => u.TenantId == _tenantContext.TenantId);
-
-        // Apply tenant filter to Role
-        modelBuilder.Entity<Role>().HasQueryFilter(r => r.TenantId == _tenantContext.TenantId);
-
         base.OnModelCreating(modelBuilder);
 
         // Apply tenant isolation filters
         if (_tenantContext != null)
         {
+            modelBuilder.Entity<User>().HasQueryFilter(u => u.TenantId == _tenantContext.TenantId);
+            modelBuilder.Entity<Role>().HasQueryFilter(r => r.TenantId == _tenantContext.TenantId);
             modelBuilder.Entity<MoodEntry>().HasQueryFilter(e => e.TenantId == _tenantContext.TenantId);
             modelBuilder.Entity<Trigger>().HasQueryFilter(e => e.TenantId == _tenantContext.TenantId);
             modelBuilder.Entity<Journal>().HasQueryFilter(e => e.TenantId == _tenantContext.TenantId);

--- a/StressMoodTracker/src/StressMoodTracker.Infrastructure/StressMoodTracker.Infrastructure.csproj
+++ b/StressMoodTracker/src/StressMoodTracker.Infrastructure/StressMoodTracker.Infrastructure.csproj
@@ -7,6 +7,16 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <FrameworkReference Include="Microsoft.AspNetCore.App" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="8.0.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="8.0.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="8.0.0" />
+  </ItemGroup>
+
+  <ItemGroup>
     <ProjectReference Include="..\StressMoodTracker.Core\StressMoodTracker.Core.csproj" />
   </ItemGroup>
 

--- a/SubscriptionAuditTool/src/SubscriptionAuditTool.Infrastructure/Data/SeedData.cs
+++ b/SubscriptionAuditTool/src/SubscriptionAuditTool.Infrastructure/Data/SeedData.cs
@@ -21,7 +21,7 @@ public static class SeedData
     /// <param name="context">The database context.</param>
     /// <param name="logger">The logger.</param>
     /// <returns>A task representing the asynchronous operation.</returns>
-    public static async Task SeedAsync(SubscriptionAuditToolContext context context, ILogger logger, IPasswordHasher passwordHasher)
+    public static async Task SeedAsync(SubscriptionAuditToolContext context, ILogger logger, IPasswordHasher passwordHasher)
     {
         ArgumentNullException.ThrowIfNull(context);
         ArgumentNullException.ThrowIfNull(logger);

--- a/SubscriptionAuditTool/src/SubscriptionAuditTool.Infrastructure/Data/SubscriptionAuditToolContext.cs
+++ b/SubscriptionAuditTool/src/SubscriptionAuditTool.Infrastructure/Data/SubscriptionAuditToolContext.cs
@@ -49,18 +49,13 @@ public class SubscriptionAuditToolContext : DbContext, ISubscriptionAuditToolCon
     /// <inheritdoc/>
     protected override void OnModelCreating(ModelBuilder modelBuilder)
     {
-        
-        // Apply tenant filter to User
-        modelBuilder.Entity<User>().HasQueryFilter(u => u.TenantId == _tenantContext.TenantId);
-
-        // Apply tenant filter to Role
-        modelBuilder.Entity<Role>().HasQueryFilter(r => r.TenantId == _tenantContext.TenantId);
-
         base.OnModelCreating(modelBuilder);
 
         // Apply tenant isolation filters
         if (_tenantContext != null)
         {
+            modelBuilder.Entity<User>().HasQueryFilter(u => u.TenantId == _tenantContext.TenantId);
+            modelBuilder.Entity<Role>().HasQueryFilter(r => r.TenantId == _tenantContext.TenantId);
             modelBuilder.Entity<Subscription>().HasQueryFilter(e => e.TenantId == _tenantContext.TenantId);
             modelBuilder.Entity<Category>().HasQueryFilter(e => e.TenantId == _tenantContext.TenantId);
         }

--- a/SubscriptionAuditTool/src/SubscriptionAuditTool.Infrastructure/SubscriptionAuditTool.Infrastructure.csproj
+++ b/SubscriptionAuditTool/src/SubscriptionAuditTool.Infrastructure/SubscriptionAuditTool.Infrastructure.csproj
@@ -7,6 +7,16 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <FrameworkReference Include="Microsoft.AspNetCore.App" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="8.0.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="8.0.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="8.0.0" />
+  </ItemGroup>
+
+  <ItemGroup>
     <ProjectReference Include="..\SubscriptionAuditTool.Core\SubscriptionAuditTool.Core.csproj" />
   </ItemGroup>
 

--- a/TaxDeductionOrganizer/src/TaxDeductionOrganizer.Infrastructure/Data/SeedData.cs
+++ b/TaxDeductionOrganizer/src/TaxDeductionOrganizer.Infrastructure/Data/SeedData.cs
@@ -21,7 +21,7 @@ public static class SeedData
     /// <param name="context">The database context.</param>
     /// <param name="logger">The logger.</param>
     /// <returns>A task representing the asynchronous operation.</returns>
-    public static async Task SeedAsync(TaxDeductionOrganizerContext context context, ILogger logger, IPasswordHasher passwordHasher)
+    public static async Task SeedAsync(TaxDeductionOrganizerContext context, ILogger logger, IPasswordHasher passwordHasher)
     {
         ArgumentNullException.ThrowIfNull(context);
         ArgumentNullException.ThrowIfNull(logger);

--- a/TaxDeductionOrganizer/src/TaxDeductionOrganizer.Infrastructure/Data/TaxDeductionOrganizerContext.cs
+++ b/TaxDeductionOrganizer/src/TaxDeductionOrganizer.Infrastructure/Data/TaxDeductionOrganizerContext.cs
@@ -52,18 +52,13 @@ public class TaxDeductionOrganizerContext : DbContext, ITaxDeductionOrganizerCon
     /// <inheritdoc/>
     protected override void OnModelCreating(ModelBuilder modelBuilder)
     {
-        
-        // Apply tenant filter to User
-        modelBuilder.Entity<User>().HasQueryFilter(u => u.TenantId == _tenantContext.TenantId);
-
-        // Apply tenant filter to Role
-        modelBuilder.Entity<Role>().HasQueryFilter(r => r.TenantId == _tenantContext.TenantId);
-
         base.OnModelCreating(modelBuilder);
 
         // Apply tenant isolation filters
         if (_tenantContext != null)
         {
+            modelBuilder.Entity<User>().HasQueryFilter(u => u.TenantId == _tenantContext.TenantId);
+            modelBuilder.Entity<Role>().HasQueryFilter(r => r.TenantId == _tenantContext.TenantId);
             modelBuilder.Entity<Deduction>().HasQueryFilter(e => e.TenantId == _tenantContext.TenantId);
             modelBuilder.Entity<Receipt>().HasQueryFilter(e => e.TenantId == _tenantContext.TenantId);
             modelBuilder.Entity<TaxYear>().HasQueryFilter(e => e.TenantId == _tenantContext.TenantId);

--- a/TaxDeductionOrganizer/src/TaxDeductionOrganizer.Infrastructure/TaxDeductionOrganizer.Infrastructure.csproj
+++ b/TaxDeductionOrganizer/src/TaxDeductionOrganizer.Infrastructure/TaxDeductionOrganizer.Infrastructure.csproj
@@ -7,6 +7,16 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <FrameworkReference Include="Microsoft.AspNetCore.App" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="8.0.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="8.0.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="8.0.0" />
+  </ItemGroup>
+
+  <ItemGroup>
     <ProjectReference Include="..\TaxDeductionOrganizer.Core\TaxDeductionOrganizer.Core.csproj" />
   </ItemGroup>
 

--- a/TimeAuditTracker/src/TimeAuditTracker.Infrastructure/Data/SeedData.cs
+++ b/TimeAuditTracker/src/TimeAuditTracker.Infrastructure/Data/SeedData.cs
@@ -21,7 +21,7 @@ public static class SeedData
     /// <param name="context">The database context.</param>
     /// <param name="logger">The logger.</param>
     /// <returns>A task representing the asynchronous operation.</returns>
-    public static async Task SeedAsync(TimeAuditTrackerContext context context, ILogger logger, IPasswordHasher passwordHasher)
+    public static async Task SeedAsync(TimeAuditTrackerContext context, ILogger logger, IPasswordHasher passwordHasher)
     {
         ArgumentNullException.ThrowIfNull(context);
         ArgumentNullException.ThrowIfNull(logger);

--- a/TimeAuditTracker/src/TimeAuditTracker.Infrastructure/Data/TimeAuditTrackerContext.cs
+++ b/TimeAuditTracker/src/TimeAuditTracker.Infrastructure/Data/TimeAuditTrackerContext.cs
@@ -52,18 +52,13 @@ public class TimeAuditTrackerContext : DbContext, ITimeAuditTrackerContext
     /// <inheritdoc/>
     protected override void OnModelCreating(ModelBuilder modelBuilder)
     {
-        
-        // Apply tenant filter to User
-        modelBuilder.Entity<User>().HasQueryFilter(u => u.TenantId == _tenantContext.TenantId);
-
-        // Apply tenant filter to Role
-        modelBuilder.Entity<Role>().HasQueryFilter(r => r.TenantId == _tenantContext.TenantId);
-
         base.OnModelCreating(modelBuilder);
 
         // Apply tenant isolation filters
         if (_tenantContext != null)
         {
+            modelBuilder.Entity<User>().HasQueryFilter(u => u.TenantId == _tenantContext.TenantId);
+            modelBuilder.Entity<Role>().HasQueryFilter(r => r.TenantId == _tenantContext.TenantId);
             modelBuilder.Entity<TimeBlock>().HasQueryFilter(e => e.TenantId == _tenantContext.TenantId);
             modelBuilder.Entity<AuditReport>().HasQueryFilter(e => e.TenantId == _tenantContext.TenantId);
             modelBuilder.Entity<Goal>().HasQueryFilter(e => e.TenantId == _tenantContext.TenantId);

--- a/TimeAuditTracker/src/TimeAuditTracker.Infrastructure/TimeAuditTracker.Infrastructure.csproj
+++ b/TimeAuditTracker/src/TimeAuditTracker.Infrastructure/TimeAuditTracker.Infrastructure.csproj
@@ -7,6 +7,16 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <FrameworkReference Include="Microsoft.AspNetCore.App" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="8.0.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="8.0.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="8.0.0" />
+  </ItemGroup>
+
+  <ItemGroup>
     <ProjectReference Include="..\TimeAuditTracker.Core\TimeAuditTracker.Core.csproj" />
   </ItemGroup>
 

--- a/TravelDestinationWishlist/src/TravelDestinationWishlist.Infrastructure/Data/SeedData.cs
+++ b/TravelDestinationWishlist/src/TravelDestinationWishlist.Infrastructure/Data/SeedData.cs
@@ -21,7 +21,7 @@ public static class SeedData
     /// <param name="context">The database context.</param>
     /// <param name="logger">The logger.</param>
     /// <returns>A task representing the asynchronous operation.</returns>
-    public static async Task SeedAsync(TravelDestinationWishlistContext context context, ILogger logger, IPasswordHasher passwordHasher)
+    public static async Task SeedAsync(TravelDestinationWishlistContext context, ILogger logger, IPasswordHasher passwordHasher)
     {
         ArgumentNullException.ThrowIfNull(context);
         ArgumentNullException.ThrowIfNull(logger);

--- a/TravelDestinationWishlist/src/TravelDestinationWishlist.Infrastructure/Data/TravelDestinationWishlistContext.cs
+++ b/TravelDestinationWishlist/src/TravelDestinationWishlist.Infrastructure/Data/TravelDestinationWishlistContext.cs
@@ -52,18 +52,13 @@ public class TravelDestinationWishlistContext : DbContext, ITravelDestinationWis
     /// <inheritdoc/>
     protected override void OnModelCreating(ModelBuilder modelBuilder)
     {
-        
-        // Apply tenant filter to User
-        modelBuilder.Entity<User>().HasQueryFilter(u => u.TenantId == _tenantContext.TenantId);
-
-        // Apply tenant filter to Role
-        modelBuilder.Entity<Role>().HasQueryFilter(r => r.TenantId == _tenantContext.TenantId);
-
         base.OnModelCreating(modelBuilder);
 
         // Apply tenant isolation filters
         if (_tenantContext != null)
         {
+            modelBuilder.Entity<User>().HasQueryFilter(u => u.TenantId == _tenantContext.TenantId);
+            modelBuilder.Entity<Role>().HasQueryFilter(r => r.TenantId == _tenantContext.TenantId);
             modelBuilder.Entity<Destination>().HasQueryFilter(e => e.TenantId == _tenantContext.TenantId);
             modelBuilder.Entity<Trip>().HasQueryFilter(e => e.TenantId == _tenantContext.TenantId);
             modelBuilder.Entity<Memory>().HasQueryFilter(e => e.TenantId == _tenantContext.TenantId);

--- a/TravelDestinationWishlist/src/TravelDestinationWishlist.Infrastructure/TravelDestinationWishlist.Infrastructure.csproj
+++ b/TravelDestinationWishlist/src/TravelDestinationWishlist.Infrastructure/TravelDestinationWishlist.Infrastructure.csproj
@@ -7,6 +7,16 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <FrameworkReference Include="Microsoft.AspNetCore.App" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="8.0.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="8.0.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="8.0.0" />
+  </ItemGroup>
+
+  <ItemGroup>
     <ProjectReference Include="..\TravelDestinationWishlist.Core\TravelDestinationWishlist.Core.csproj" />
   </ItemGroup>
 

--- a/VehicleMaintenanceLogger/src/VehicleMaintenanceLogger.Infrastructure/Data/SeedData.cs
+++ b/VehicleMaintenanceLogger/src/VehicleMaintenanceLogger.Infrastructure/Data/SeedData.cs
@@ -21,7 +21,7 @@ public static class SeedData
     /// <param name="context">The database context.</param>
     /// <param name="logger">The logger.</param>
     /// <returns>A task representing the asynchronous operation.</returns>
-    public static async Task SeedAsync(VehicleMaintenanceLoggerContext context context, ILogger logger, IPasswordHasher passwordHasher)
+    public static async Task SeedAsync(VehicleMaintenanceLoggerContext context, ILogger logger, IPasswordHasher passwordHasher)
     {
         ArgumentNullException.ThrowIfNull(context);
         ArgumentNullException.ThrowIfNull(logger);

--- a/VehicleMaintenanceLogger/src/VehicleMaintenanceLogger.Infrastructure/Data/VehicleMaintenanceLoggerContext.cs
+++ b/VehicleMaintenanceLogger/src/VehicleMaintenanceLogger.Infrastructure/Data/VehicleMaintenanceLoggerContext.cs
@@ -52,18 +52,13 @@ public class VehicleMaintenanceLoggerContext : DbContext, IVehicleMaintenanceLog
     /// <inheritdoc/>
     protected override void OnModelCreating(ModelBuilder modelBuilder)
     {
-        
-        // Apply tenant filter to User
-        modelBuilder.Entity<User>().HasQueryFilter(u => u.TenantId == _tenantContext.TenantId);
-
-        // Apply tenant filter to Role
-        modelBuilder.Entity<Role>().HasQueryFilter(r => r.TenantId == _tenantContext.TenantId);
-
         base.OnModelCreating(modelBuilder);
 
         // Apply tenant isolation filters
         if (_tenantContext != null)
         {
+            modelBuilder.Entity<User>().HasQueryFilter(u => u.TenantId == _tenantContext.TenantId);
+            modelBuilder.Entity<Role>().HasQueryFilter(r => r.TenantId == _tenantContext.TenantId);
             modelBuilder.Entity<Vehicle>().HasQueryFilter(e => e.TenantId == _tenantContext.TenantId);
             modelBuilder.Entity<ServiceRecord>().HasQueryFilter(e => e.TenantId == _tenantContext.TenantId);
             modelBuilder.Entity<MaintenanceSchedule>().HasQueryFilter(e => e.TenantId == _tenantContext.TenantId);

--- a/VehicleMaintenanceLogger/src/VehicleMaintenanceLogger.Infrastructure/VehicleMaintenanceLogger.Infrastructure.csproj
+++ b/VehicleMaintenanceLogger/src/VehicleMaintenanceLogger.Infrastructure/VehicleMaintenanceLogger.Infrastructure.csproj
@@ -7,6 +7,16 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <FrameworkReference Include="Microsoft.AspNetCore.App" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="8.0.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="8.0.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="8.0.0" />
+  </ItemGroup>
+
+  <ItemGroup>
     <ProjectReference Include="..\VehicleMaintenanceLogger.Core\VehicleMaintenanceLogger.Core.csproj" />
   </ItemGroup>
 

--- a/VehicleValueTracker/src/VehicleValueTracker.Infrastructure/Data/SeedData.cs
+++ b/VehicleValueTracker/src/VehicleValueTracker.Infrastructure/Data/SeedData.cs
@@ -21,7 +21,7 @@ public static class SeedData
     /// <param name="context">The database context.</param>
     /// <param name="logger">The logger.</param>
     /// <returns>A task representing the asynchronous operation.</returns>
-    public static async Task SeedAsync(VehicleValueTrackerContext context context, ILogger logger, IPasswordHasher passwordHasher)
+    public static async Task SeedAsync(VehicleValueTrackerContext context, ILogger logger, IPasswordHasher passwordHasher)
     {
         ArgumentNullException.ThrowIfNull(context);
         ArgumentNullException.ThrowIfNull(logger);

--- a/VehicleValueTracker/src/VehicleValueTracker.Infrastructure/Data/VehicleValueTrackerContext.cs
+++ b/VehicleValueTracker/src/VehicleValueTracker.Infrastructure/Data/VehicleValueTrackerContext.cs
@@ -52,18 +52,13 @@ public class VehicleValueTrackerContext : DbContext, IVehicleValueTrackerContext
     /// <inheritdoc/>
     protected override void OnModelCreating(ModelBuilder modelBuilder)
     {
-        
-        // Apply tenant filter to User
-        modelBuilder.Entity<User>().HasQueryFilter(u => u.TenantId == _tenantContext.TenantId);
-
-        // Apply tenant filter to Role
-        modelBuilder.Entity<Role>().HasQueryFilter(r => r.TenantId == _tenantContext.TenantId);
-
         base.OnModelCreating(modelBuilder);
 
         // Apply tenant isolation filters
         if (_tenantContext != null)
         {
+            modelBuilder.Entity<User>().HasQueryFilter(u => u.TenantId == _tenantContext.TenantId);
+            modelBuilder.Entity<Role>().HasQueryFilter(r => r.TenantId == _tenantContext.TenantId);
             modelBuilder.Entity<Vehicle>().HasQueryFilter(e => e.TenantId == _tenantContext.TenantId);
             modelBuilder.Entity<ValueAssessment>().HasQueryFilter(e => e.TenantId == _tenantContext.TenantId);
             modelBuilder.Entity<MarketComparison>().HasQueryFilter(e => e.TenantId == _tenantContext.TenantId);

--- a/VehicleValueTracker/src/VehicleValueTracker.Infrastructure/VehicleValueTracker.Infrastructure.csproj
+++ b/VehicleValueTracker/src/VehicleValueTracker.Infrastructure/VehicleValueTracker.Infrastructure.csproj
@@ -7,6 +7,16 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <FrameworkReference Include="Microsoft.AspNetCore.App" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="8.0.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="8.0.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="8.0.0" />
+  </ItemGroup>
+
+  <ItemGroup>
     <ProjectReference Include="..\VehicleValueTracker.Core\VehicleValueTracker.Core.csproj" />
   </ItemGroup>
 

--- a/VideoGameCollectionManager/src/VideoGameCollectionManager.Infrastructure/Data/SeedData.cs
+++ b/VideoGameCollectionManager/src/VideoGameCollectionManager.Infrastructure/Data/SeedData.cs
@@ -21,7 +21,7 @@ public static class SeedData
     /// <param name="context">The database context.</param>
     /// <param name="logger">The logger.</param>
     /// <returns>A task representing the asynchronous operation.</returns>
-    public static async Task SeedAsync(VideoGameCollectionManagerContext context context, ILogger logger, IPasswordHasher passwordHasher)
+    public static async Task SeedAsync(VideoGameCollectionManagerContext context, ILogger logger, IPasswordHasher passwordHasher)
     {
         ArgumentNullException.ThrowIfNull(context);
         ArgumentNullException.ThrowIfNull(logger);

--- a/VideoGameCollectionManager/src/VideoGameCollectionManager.Infrastructure/Data/VideoGameCollectionManagerContext.cs
+++ b/VideoGameCollectionManager/src/VideoGameCollectionManager.Infrastructure/Data/VideoGameCollectionManagerContext.cs
@@ -52,18 +52,13 @@ public class VideoGameCollectionManagerContext : DbContext, IVideoGameCollection
     /// <inheritdoc/>
     protected override void OnModelCreating(ModelBuilder modelBuilder)
     {
-        
-        // Apply tenant filter to User
-        modelBuilder.Entity<User>().HasQueryFilter(u => u.TenantId == _tenantContext.TenantId);
-
-        // Apply tenant filter to Role
-        modelBuilder.Entity<Role>().HasQueryFilter(r => r.TenantId == _tenantContext.TenantId);
-
         base.OnModelCreating(modelBuilder);
 
         // Apply tenant isolation filters
         if (_tenantContext != null)
         {
+            modelBuilder.Entity<User>().HasQueryFilter(u => u.TenantId == _tenantContext.TenantId);
+            modelBuilder.Entity<Role>().HasQueryFilter(r => r.TenantId == _tenantContext.TenantId);
             modelBuilder.Entity<Game>().HasQueryFilter(e => e.TenantId == _tenantContext.TenantId);
             modelBuilder.Entity<PlaySession>().HasQueryFilter(e => e.TenantId == _tenantContext.TenantId);
             modelBuilder.Entity<Wishlist>().HasQueryFilter(e => e.TenantId == _tenantContext.TenantId);

--- a/VideoGameCollectionManager/src/VideoGameCollectionManager.Infrastructure/VideoGameCollectionManager.Infrastructure.csproj
+++ b/VideoGameCollectionManager/src/VideoGameCollectionManager.Infrastructure/VideoGameCollectionManager.Infrastructure.csproj
@@ -7,6 +7,16 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <FrameworkReference Include="Microsoft.AspNetCore.App" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="8.0.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="8.0.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="8.0.0" />
+  </ItemGroup>
+
+  <ItemGroup>
     <ProjectReference Include="..\VideoGameCollectionManager.Core\VideoGameCollectionManager.Core.csproj" />
   </ItemGroup>
 

--- a/WarrantyReturnPeriodTracker/src/WarrantyReturnPeriodTracker.Infrastructure/Data/SeedData.cs
+++ b/WarrantyReturnPeriodTracker/src/WarrantyReturnPeriodTracker.Infrastructure/Data/SeedData.cs
@@ -21,7 +21,7 @@ public static class SeedData
     /// <param name="context">The database context.</param>
     /// <param name="logger">The logger.</param>
     /// <returns>A task representing the asynchronous operation.</returns>
-    public static async Task SeedAsync(WarrantyReturnPeriodTrackerContext context context, ILogger logger, IPasswordHasher passwordHasher)
+    public static async Task SeedAsync(WarrantyReturnPeriodTrackerContext context, ILogger logger, IPasswordHasher passwordHasher)
     {
         ArgumentNullException.ThrowIfNull(context);
         ArgumentNullException.ThrowIfNull(logger);

--- a/WarrantyReturnPeriodTracker/src/WarrantyReturnPeriodTracker.Infrastructure/Data/WarrantyReturnPeriodTrackerContext.cs
+++ b/WarrantyReturnPeriodTracker/src/WarrantyReturnPeriodTracker.Infrastructure/Data/WarrantyReturnPeriodTrackerContext.cs
@@ -55,18 +55,13 @@ public class WarrantyReturnPeriodTrackerContext : DbContext, IWarrantyReturnPeri
     /// <inheritdoc/>
     protected override void OnModelCreating(ModelBuilder modelBuilder)
     {
-        
-        // Apply tenant filter to User
-        modelBuilder.Entity<User>().HasQueryFilter(u => u.TenantId == _tenantContext.TenantId);
-
-        // Apply tenant filter to Role
-        modelBuilder.Entity<Role>().HasQueryFilter(r => r.TenantId == _tenantContext.TenantId);
-
         base.OnModelCreating(modelBuilder);
 
         // Apply tenant isolation filters
         if (_tenantContext != null)
         {
+            modelBuilder.Entity<User>().HasQueryFilter(u => u.TenantId == _tenantContext.TenantId);
+            modelBuilder.Entity<Role>().HasQueryFilter(r => r.TenantId == _tenantContext.TenantId);
             modelBuilder.Entity<Purchase>().HasQueryFilter(e => e.TenantId == _tenantContext.TenantId);
             modelBuilder.Entity<Warranty>().HasQueryFilter(e => e.TenantId == _tenantContext.TenantId);
             modelBuilder.Entity<ReturnWindow>().HasQueryFilter(e => e.TenantId == _tenantContext.TenantId);

--- a/WarrantyReturnPeriodTracker/src/WarrantyReturnPeriodTracker.Infrastructure/WarrantyReturnPeriodTracker.Infrastructure.csproj
+++ b/WarrantyReturnPeriodTracker/src/WarrantyReturnPeriodTracker.Infrastructure/WarrantyReturnPeriodTracker.Infrastructure.csproj
@@ -7,6 +7,16 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <FrameworkReference Include="Microsoft.AspNetCore.App" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="8.0.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="8.0.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="8.0.0" />
+  </ItemGroup>
+
+  <ItemGroup>
     <ProjectReference Include="..\WarrantyReturnPeriodTracker.Core\WarrantyReturnPeriodTracker.Core.csproj" />
   </ItemGroup>
 

--- a/WeeklyReviewSystem/src/WeeklyReviewSystem.Infrastructure/Data/SeedData.cs
+++ b/WeeklyReviewSystem/src/WeeklyReviewSystem.Infrastructure/Data/SeedData.cs
@@ -21,7 +21,7 @@ public static class SeedData
     /// <param name="context">The database context.</param>
     /// <param name="logger">The logger.</param>
     /// <returns>A task representing the asynchronous operation.</returns>
-    public static async Task SeedAsync(WeeklyReviewSystemContext context context, ILogger logger, IPasswordHasher passwordHasher)
+    public static async Task SeedAsync(WeeklyReviewSystemContext context, ILogger logger, IPasswordHasher passwordHasher)
     {
         ArgumentNullException.ThrowIfNull(context);
         ArgumentNullException.ThrowIfNull(logger);

--- a/WeeklyReviewSystem/src/WeeklyReviewSystem.Infrastructure/Data/WeeklyReviewSystemContext.cs
+++ b/WeeklyReviewSystem/src/WeeklyReviewSystem.Infrastructure/Data/WeeklyReviewSystemContext.cs
@@ -55,18 +55,13 @@ public class WeeklyReviewSystemContext : DbContext, IWeeklyReviewSystemContext
     /// <inheritdoc/>
     protected override void OnModelCreating(ModelBuilder modelBuilder)
     {
-        
-        // Apply tenant filter to User
-        modelBuilder.Entity<User>().HasQueryFilter(u => u.TenantId == _tenantContext.TenantId);
-
-        // Apply tenant filter to Role
-        modelBuilder.Entity<Role>().HasQueryFilter(r => r.TenantId == _tenantContext.TenantId);
-
         base.OnModelCreating(modelBuilder);
 
         // Apply tenant isolation filters
         if (_tenantContext != null)
         {
+            modelBuilder.Entity<User>().HasQueryFilter(u => u.TenantId == _tenantContext.TenantId);
+            modelBuilder.Entity<Role>().HasQueryFilter(r => r.TenantId == _tenantContext.TenantId);
             modelBuilder.Entity<WeeklyReview>().HasQueryFilter(e => e.TenantId == _tenantContext.TenantId);
             modelBuilder.Entity<Accomplishment>().HasQueryFilter(e => e.TenantId == _tenantContext.TenantId);
             modelBuilder.Entity<Challenge>().HasQueryFilter(e => e.TenantId == _tenantContext.TenantId);

--- a/WeeklyReviewSystem/src/WeeklyReviewSystem.Infrastructure/WeeklyReviewSystem.Infrastructure.csproj
+++ b/WeeklyReviewSystem/src/WeeklyReviewSystem.Infrastructure/WeeklyReviewSystem.Infrastructure.csproj
@@ -7,6 +7,16 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <FrameworkReference Include="Microsoft.AspNetCore.App" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="8.0.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="8.0.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="8.0.0" />
+  </ItemGroup>
+
+  <ItemGroup>
     <ProjectReference Include="..\WeeklyReviewSystem.Core\WeeklyReviewSystem.Core.csproj" />
   </ItemGroup>
 

--- a/WineCellarInventory/src/WineCellarInventory.Infrastructure/Data/SeedData.cs
+++ b/WineCellarInventory/src/WineCellarInventory.Infrastructure/Data/SeedData.cs
@@ -21,7 +21,7 @@ public static class SeedData
     /// <param name="context">The database context.</param>
     /// <param name="logger">The logger.</param>
     /// <returns>A task representing the asynchronous operation.</returns>
-    public static async Task SeedAsync(WineCellarInventoryContext context context, ILogger logger, IPasswordHasher passwordHasher)
+    public static async Task SeedAsync(WineCellarInventoryContext context, ILogger logger, IPasswordHasher passwordHasher)
     {
         ArgumentNullException.ThrowIfNull(context);
         ArgumentNullException.ThrowIfNull(logger);

--- a/WineCellarInventory/src/WineCellarInventory.Infrastructure/Data/WineCellarInventoryContext.cs
+++ b/WineCellarInventory/src/WineCellarInventory.Infrastructure/Data/WineCellarInventoryContext.cs
@@ -52,18 +52,13 @@ public class WineCellarInventoryContext : DbContext, IWineCellarInventoryContext
     /// <inheritdoc/>
     protected override void OnModelCreating(ModelBuilder modelBuilder)
     {
-        
-        // Apply tenant filter to User
-        modelBuilder.Entity<User>().HasQueryFilter(u => u.TenantId == _tenantContext.TenantId);
-
-        // Apply tenant filter to Role
-        modelBuilder.Entity<Role>().HasQueryFilter(r => r.TenantId == _tenantContext.TenantId);
-
         base.OnModelCreating(modelBuilder);
 
         // Apply tenant isolation filters
         if (_tenantContext != null)
         {
+            modelBuilder.Entity<User>().HasQueryFilter(u => u.TenantId == _tenantContext.TenantId);
+            modelBuilder.Entity<Role>().HasQueryFilter(r => r.TenantId == _tenantContext.TenantId);
             modelBuilder.Entity<Wine>().HasQueryFilter(e => e.TenantId == _tenantContext.TenantId);
             modelBuilder.Entity<TastingNote>().HasQueryFilter(e => e.TenantId == _tenantContext.TenantId);
             modelBuilder.Entity<DrinkingWindow>().HasQueryFilter(e => e.TenantId == _tenantContext.TenantId);

--- a/WineCellarInventory/src/WineCellarInventory.Infrastructure/WineCellarInventory.Infrastructure.csproj
+++ b/WineCellarInventory/src/WineCellarInventory.Infrastructure/WineCellarInventory.Infrastructure.csproj
@@ -7,6 +7,16 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <FrameworkReference Include="Microsoft.AspNetCore.App" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="8.0.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="8.0.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="8.0.0" />
+  </ItemGroup>
+
+  <ItemGroup>
     <ProjectReference Include="..\WineCellarInventory.Core\WineCellarInventory.Core.csproj" />
   </ItemGroup>
 

--- a/WorkoutPlanBuilder/src/WorkoutPlanBuilder.Infrastructure/Data/SeedData.cs
+++ b/WorkoutPlanBuilder/src/WorkoutPlanBuilder.Infrastructure/Data/SeedData.cs
@@ -21,7 +21,7 @@ public static class SeedData
     /// <param name="context">The database context.</param>
     /// <param name="logger">The logger.</param>
     /// <returns>A task representing the asynchronous operation.</returns>
-    public static async Task SeedAsync(WorkoutPlanBuilderContext context context, ILogger logger, IPasswordHasher passwordHasher)
+    public static async Task SeedAsync(WorkoutPlanBuilderContext context, ILogger logger, IPasswordHasher passwordHasher)
     {
         ArgumentNullException.ThrowIfNull(context);
         ArgumentNullException.ThrowIfNull(logger);

--- a/WorkoutPlanBuilder/src/WorkoutPlanBuilder.Infrastructure/Data/WorkoutPlanBuilderContext.cs
+++ b/WorkoutPlanBuilder/src/WorkoutPlanBuilder.Infrastructure/Data/WorkoutPlanBuilderContext.cs
@@ -52,18 +52,13 @@ public class WorkoutPlanBuilderContext : DbContext, IWorkoutPlanBuilderContext
     /// <inheritdoc/>
     protected override void OnModelCreating(ModelBuilder modelBuilder)
     {
-        
-        // Apply tenant filter to User
-        modelBuilder.Entity<User>().HasQueryFilter(u => u.TenantId == _tenantContext.TenantId);
-
-        // Apply tenant filter to Role
-        modelBuilder.Entity<Role>().HasQueryFilter(r => r.TenantId == _tenantContext.TenantId);
-
         base.OnModelCreating(modelBuilder);
 
         // Apply tenant isolation filters
         if (_tenantContext != null)
         {
+            modelBuilder.Entity<User>().HasQueryFilter(u => u.TenantId == _tenantContext.TenantId);
+            modelBuilder.Entity<Role>().HasQueryFilter(r => r.TenantId == _tenantContext.TenantId);
             modelBuilder.Entity<Workout>().HasQueryFilter(e => e.TenantId == _tenantContext.TenantId);
             modelBuilder.Entity<Exercise>().HasQueryFilter(e => e.TenantId == _tenantContext.TenantId);
             modelBuilder.Entity<ProgressRecord>().HasQueryFilter(e => e.TenantId == _tenantContext.TenantId);

--- a/WorkoutPlanBuilder/src/WorkoutPlanBuilder.Infrastructure/WorkoutPlanBuilder.Infrastructure.csproj
+++ b/WorkoutPlanBuilder/src/WorkoutPlanBuilder.Infrastructure/WorkoutPlanBuilder.Infrastructure.csproj
@@ -7,6 +7,16 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <FrameworkReference Include="Microsoft.AspNetCore.App" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="8.0.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="8.0.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="8.0.0" />
+  </ItemGroup>
+
+  <ItemGroup>
     <ProjectReference Include="..\WorkoutPlanBuilder.Core\WorkoutPlanBuilder.Core.csproj" />
   </ItemGroup>
 


### PR DESCRIPTION
- Fix SeedData.cs syntax error: removed duplicate 'context' parameter in SeedAsync method (76 files)
- Fix null reference warnings in Context.cs: moved User/Role tenant filters inside null check (79 files)
- Add missing package references to .csproj files: Microsoft.AspNetCore.App framework reference, Microsoft.EntityFrameworkCore.SqlServer, and Microsoft.EntityFrameworkCore.Relational (82 files)