### PR TITLE
Add Entity Framework Design reference and migrations

### DIFF
--- a/AnniversaryBirthdayReminder/src/AnniversaryBirthdayReminder.Api/AnniversaryBirthdayReminder.Api.csproj
+++ b/AnniversaryBirthdayReminder/src/AnniversaryBirthdayReminder.Api/AnniversaryBirthdayReminder.Api.csproj
@@ -14,6 +14,10 @@
     <PackageReference Include="Serilog.Enrichers.Thread" Version="3.1.0" />
     <PackageReference Include="Serilog.Settings.Configuration" Version="8.0.0" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="6.5.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="8.0.0">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
   </ItemGroup>
 
   <ItemGroup>

--- a/AnnualHealthScreeningReminder/src/AnnualHealthScreeningReminder.Api/AnnualHealthScreeningReminder.Api.csproj
+++ b/AnnualHealthScreeningReminder/src/AnnualHealthScreeningReminder.Api/AnnualHealthScreeningReminder.Api.csproj
@@ -14,6 +14,10 @@
     <PackageReference Include="Serilog.Sinks.Console" Version="5.0.1" />
     <PackageReference Include="Serilog.Sinks.File" Version="5.0.0" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="6.5.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="8.0.0">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
   </ItemGroup>
 
   <ItemGroup>

--- a/ApplianceWarrantyManualOrganizer/src/ApplianceWarrantyManualOrganizer.Api/ApplianceWarrantyManualOrganizer.Api.csproj
+++ b/ApplianceWarrantyManualOrganizer/src/ApplianceWarrantyManualOrganizer.Api/ApplianceWarrantyManualOrganizer.Api.csproj
@@ -14,6 +14,10 @@
     <PackageReference Include="Serilog.Sinks.Console" Version="5.0.1" />
     <PackageReference Include="Serilog.Sinks.File" Version="5.0.0" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="6.5.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="8.0.0">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
   </ItemGroup>
 
   <ItemGroup>

--- a/BillPaymentScheduler/src/BillPaymentScheduler.Api/BillPaymentScheduler.Api.csproj
+++ b/BillPaymentScheduler/src/BillPaymentScheduler.Api/BillPaymentScheduler.Api.csproj
@@ -13,6 +13,10 @@
     <PackageReference Include="Serilog.Sinks.Console" Version="5.0.1" />
     <PackageReference Include="Serilog.Sinks.File" Version="5.0.0" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="6.5.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="8.0.0">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
   </ItemGroup>
 
   <ItemGroup>

--- a/BloodPressureMonitor/src/BloodPressureMonitor.Api/BloodPressureMonitor.Api.csproj
+++ b/BloodPressureMonitor/src/BloodPressureMonitor.Api/BloodPressureMonitor.Api.csproj
@@ -14,6 +14,10 @@
     <PackageReference Include="Serilog.Enrichers.Thread" Version="3.1.0" />
     <PackageReference Include="Serilog.Settings.Configuration" Version="8.0.0" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="6.5.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="8.0.0">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
   </ItemGroup>
 
   <ItemGroup>

--- a/BookReadingTrackerLibrary/src/BookReadingTrackerLibrary.Api/BookReadingTrackerLibrary.Api.csproj
+++ b/BookReadingTrackerLibrary/src/BookReadingTrackerLibrary.Api/BookReadingTrackerLibrary.Api.csproj
@@ -13,6 +13,10 @@
     <PackageReference Include="Serilog.Enrichers.Environment" Version="2.3.0" />
     <PackageReference Include="Serilog.Enrichers.Thread" Version="3.1.0" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="6.5.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="8.0.0">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
   </ItemGroup>
 
   <ItemGroup>

--- a/BucketListManager/src/BucketListManager.Api/BucketListManager.Api.csproj
+++ b/BucketListManager/src/BucketListManager.Api/BucketListManager.Api.csproj
@@ -13,6 +13,10 @@
     <PackageReference Include="Serilog.Enrichers.Environment" Version="2.3.0" />
     <PackageReference Include="Serilog.Enrichers.Thread" Version="3.1.0" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="6.5.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="8.0.0">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
   </ItemGroup>
 
   <ItemGroup>

--- a/CampingTripPlanner/src/CampingTripPlanner.Api/CampingTripPlanner.Api.csproj
+++ b/CampingTripPlanner/src/CampingTripPlanner.Api/CampingTripPlanner.Api.csproj
@@ -13,6 +13,10 @@
     <PackageReference Include="Serilog.Enrichers.Environment" Version="2.3.0" />
     <PackageReference Include="Serilog.Enrichers.Thread" Version="3.1.0" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="6.5.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="8.0.0">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
   </ItemGroup>
 
   <ItemGroup>

--- a/CarModificationPartsDatabase/src/CarModificationPartsDatabase.Api/CarModificationPartsDatabase.Api.csproj
+++ b/CarModificationPartsDatabase/src/CarModificationPartsDatabase.Api/CarModificationPartsDatabase.Api.csproj
@@ -14,6 +14,10 @@
     <PackageReference Include="Serilog.Enrichers.Thread" Version="3.1.0" />
     <PackageReference Include="Serilog.Settings.Configuration" Version="8.0.0" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="6.5.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="8.0.0">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
   </ItemGroup>
 
   <ItemGroup>

--- a/ConversationStarterApp/src/ConversationStarterApp.Api/ConversationStarterApp.Api.csproj
+++ b/ConversationStarterApp/src/ConversationStarterApp.Api/ConversationStarterApp.Api.csproj
@@ -14,6 +14,10 @@
     <PackageReference Include="Serilog.Enrichers.Thread" Version="3.1.0" />
     <PackageReference Include="Serilog.Settings.Configuration" Version="8.0.0" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="6.5.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="8.0.0">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
   </ItemGroup>
 
   <ItemGroup>

--- a/DailyJournalingApp/src/DailyJournalingApp.Api/DailyJournalingApp.Api.csproj
+++ b/DailyJournalingApp/src/DailyJournalingApp.Api/DailyJournalingApp.Api.csproj
@@ -13,6 +13,10 @@
     <PackageReference Include="Serilog.Enrichers.Environment" Version="2.3.0" />
     <PackageReference Include="Serilog.Enrichers.Thread" Version="3.1.0" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="6.5.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="8.0.0">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
   </ItemGroup>
 
   <ItemGroup>

--- a/FamilyVacationPlanner/src/FamilyVacationPlanner.Api/FamilyVacationPlanner.Api.csproj
+++ b/FamilyVacationPlanner/src/FamilyVacationPlanner.Api/FamilyVacationPlanner.Api.csproj
@@ -13,6 +13,10 @@
     <PackageReference Include="Serilog.Enrichers.Environment" Version="2.3.0" />
     <PackageReference Include="Serilog.Enrichers.Thread" Version="3.1.0" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="6.5.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="8.0.0">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
   </ItemGroup>
 
   <ItemGroup>

--- a/FinancialGoalTracker/src/FinancialGoalTracker.Api/FinancialGoalTracker.Api.csproj
+++ b/FinancialGoalTracker/src/FinancialGoalTracker.Api/FinancialGoalTracker.Api.csproj
@@ -13,6 +13,10 @@
     <PackageReference Include="Serilog.Enrichers.Environment" Version="2.3.0" />
     <PackageReference Include="Serilog.Enrichers.Thread" Version="3.1.0" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="6.5.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="8.0.0">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
   </ItemGroup>
 
   <ItemGroup>

--- a/GiftIdeaTracker/src/GiftIdeaTracker.Api/GiftIdeaTracker.Api.csproj
+++ b/GiftIdeaTracker/src/GiftIdeaTracker.Api/GiftIdeaTracker.Api.csproj
@@ -13,6 +13,10 @@
     <PackageReference Include="Serilog.Enrichers.Environment" Version="2.3.0" />
     <PackageReference Include="Serilog.Enrichers.Thread" Version="3.1.0" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="6.5.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="8.0.0">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
   </ItemGroup>
 
   <ItemGroup>

--- a/GolfScoreTracker/src/GolfScoreTracker.Api/GolfScoreTracker.Api.csproj
+++ b/GolfScoreTracker/src/GolfScoreTracker.Api/GolfScoreTracker.Api.csproj
@@ -14,6 +14,10 @@
     <PackageReference Include="Serilog.AspNetCore" Version="8.0.0" />
     <PackageReference Include="Serilog.Sinks.Console" Version="5.0.1" />
     <PackageReference Include="Serilog.Sinks.File" Version="5.0.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="8.0.0">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
   </ItemGroup>
 
   <ItemGroup>

--- a/HabitFormationApp/src/HabitFormationApp.Api/HabitFormationApp.Api.csproj
+++ b/HabitFormationApp/src/HabitFormationApp.Api/HabitFormationApp.Api.csproj
@@ -13,6 +13,10 @@
     <PackageReference Include="Serilog.Enrichers.Environment" Version="2.3.0" />
     <PackageReference Include="Serilog.Enrichers.Thread" Version="3.1.0" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="6.5.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="8.0.0">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
   </ItemGroup>
 
   <ItemGroup>

--- a/HomeInventoryManager/src/HomeInventoryManager.Api/HomeInventoryManager.Api.csproj
+++ b/HomeInventoryManager/src/HomeInventoryManager.Api/HomeInventoryManager.Api.csproj
@@ -13,6 +13,10 @@
     <PackageReference Include="Serilog.Enrichers.Environment" Version="2.3.0" />
     <PackageReference Include="Serilog.Enrichers.Thread" Version="3.1.0" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="6.5.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="8.0.0">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
   </ItemGroup>
 
   <ItemGroup>

--- a/HouseholdBudgetManager/src/HouseholdBudgetManager.Api/HouseholdBudgetManager.Api.csproj
+++ b/HouseholdBudgetManager/src/HouseholdBudgetManager.Api/HouseholdBudgetManager.Api.csproj
@@ -13,6 +13,10 @@
     <PackageReference Include="Serilog.Enrichers.Environment" Version="2.3.0" />
     <PackageReference Include="Serilog.Enrichers.Thread" Version="3.1.0" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="6.5.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="8.0.0">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
   </ItemGroup>
 
   <ItemGroup>

--- a/HydrationTracker/src/HydrationTracker.Api/HydrationTracker.Api.csproj
+++ b/HydrationTracker/src/HydrationTracker.Api/HydrationTracker.Api.csproj
@@ -13,6 +13,10 @@
     <PackageReference Include="Serilog.Enrichers.Environment" Version="2.3.0" />
     <PackageReference Include="Serilog.Enrichers.Thread" Version="3.1.0" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="6.5.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="8.0.0">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
   </ItemGroup>
 
   <ItemGroup>

--- a/InjuryPreventionRecoveryTracker/src/InjuryPreventionRecoveryTracker.Api/InjuryPreventionRecoveryTracker.Api.csproj
+++ b/InjuryPreventionRecoveryTracker/src/InjuryPreventionRecoveryTracker.Api/InjuryPreventionRecoveryTracker.Api.csproj
@@ -13,6 +13,10 @@
     <PackageReference Include="Serilog.Enrichers.Environment" Version="2.3.0" />
     <PackageReference Include="Serilog.Enrichers.Thread" Version="3.1.0" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="6.5.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="8.0.0">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
   </ItemGroup>
 
   <ItemGroup>

--- a/InvestmentPortfolioTracker/src/InvestmentPortfolioTracker.Api/InvestmentPortfolioTracker.Api.csproj
+++ b/InvestmentPortfolioTracker/src/InvestmentPortfolioTracker.Api/InvestmentPortfolioTracker.Api.csproj
@@ -13,6 +13,10 @@
     <PackageReference Include="Serilog.Enrichers.Environment" Version="2.3.0" />
     <PackageReference Include="Serilog.Enrichers.Thread" Version="3.1.0" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="6.5.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="8.0.0">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
   </ItemGroup>
 
   <ItemGroup>

--- a/JobSearchOrganizer/src/JobSearchOrganizer.Api/JobSearchOrganizer.Api.csproj
+++ b/JobSearchOrganizer/src/JobSearchOrganizer.Api/JobSearchOrganizer.Api.csproj
@@ -11,6 +11,10 @@
     <PackageReference Include="Serilog.Enrichers.Environment" Version="2.3.0" />
     <PackageReference Include="Serilog.Enrichers.Thread" Version="2.3.0" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="6.5.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="8.0.0">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\JobSearchOrganizer.Core\JobSearchOrganizer.Core.csproj" />

--- a/KidsActivitySportsTracker/src/KidsActivitySportsTracker.Api/KidsActivitySportsTracker.Api.csproj
+++ b/KidsActivitySportsTracker/src/KidsActivitySportsTracker.Api/KidsActivitySportsTracker.Api.csproj
@@ -13,6 +13,10 @@
     <PackageReference Include="Serilog.Enrichers.Environment" Version="2.3.0" />
     <PackageReference Include="Serilog.Enrichers.Thread" Version="3.1.0" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="6.5.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="8.0.0">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
   </ItemGroup>
 
   <ItemGroup>

--- a/KnowledgeBaseSecondBrain/src/KnowledgeBaseSecondBrain.Api/KnowledgeBaseSecondBrain.Api.csproj
+++ b/KnowledgeBaseSecondBrain/src/KnowledgeBaseSecondBrain.Api/KnowledgeBaseSecondBrain.Api.csproj
@@ -13,6 +13,10 @@
     <PackageReference Include="Serilog.Enrichers.Environment" Version="2.3.0" />
     <PackageReference Include="Serilog.Enrichers.Thread" Version="3.1.0" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="6.5.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="8.0.0">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
   </ItemGroup>
 
   <ItemGroup>

--- a/LetterToFutureSelf/src/LetterToFutureSelf.Api/LetterToFutureSelf.Api.csproj
+++ b/LetterToFutureSelf/src/LetterToFutureSelf.Api/LetterToFutureSelf.Api.csproj
@@ -13,6 +13,10 @@
     <PackageReference Include="Serilog.Enrichers.Environment" Version="2.3.0" />
     <PackageReference Include="Serilog.Enrichers.Thread" Version="3.1.0" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="6.5.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="8.0.0">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
   </ItemGroup>
 
   <ItemGroup>

--- a/LifeAdminDashboard/src/LifeAdminDashboard.Api/LifeAdminDashboard.Api.csproj
+++ b/LifeAdminDashboard/src/LifeAdminDashboard.Api/LifeAdminDashboard.Api.csproj
@@ -13,6 +13,10 @@
     <PackageReference Include="Serilog.Enrichers.Environment" Version="2.3.0" />
     <PackageReference Include="Serilog.Enrichers.Thread" Version="3.1.0" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="6.5.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="8.0.0">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
   </ItemGroup>
 
   <ItemGroup>

--- a/MarriageEnrichmentJournal/src/MarriageEnrichmentJournal.Api/MarriageEnrichmentJournal.Api.csproj
+++ b/MarriageEnrichmentJournal/src/MarriageEnrichmentJournal.Api/MarriageEnrichmentJournal.Api.csproj
@@ -13,6 +13,10 @@
     <PackageReference Include="Serilog.Enrichers.Environment" Version="2.3.0" />
     <PackageReference Include="Serilog.Enrichers.Thread" Version="3.1.0" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="6.5.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="8.0.0">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
   </ItemGroup>
 
   <ItemGroup>

--- a/MealPrepPlanner/src/MealPrepPlanner.Api/MealPrepPlanner.Api.csproj
+++ b/MealPrepPlanner/src/MealPrepPlanner.Api/MealPrepPlanner.Api.csproj
@@ -13,6 +13,10 @@
     <PackageReference Include="Serilog.Enrichers.Environment" Version="2.3.0" />
     <PackageReference Include="Serilog.Enrichers.Thread" Version="3.1.0" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="6.5.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="8.0.0">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
   </ItemGroup>
 
   <ItemGroup>

--- a/MeetingNotesActionItemTracker/src/MeetingNotesActionItemTracker.Api/MeetingNotesActionItemTracker.Api.csproj
+++ b/MeetingNotesActionItemTracker/src/MeetingNotesActionItemTracker.Api/MeetingNotesActionItemTracker.Api.csproj
@@ -13,6 +13,10 @@
     <PackageReference Include="Serilog.Enrichers.Environment" Version="2.3.0" />
     <PackageReference Include="Serilog.Enrichers.Thread" Version="3.1.0" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="6.5.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="8.0.0">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
   </ItemGroup>
 
   <ItemGroup>

--- a/MensGroupDiscussionTracker/src/MensGroupDiscussionTracker.Api/MensGroupDiscussionTracker.Api.csproj
+++ b/MensGroupDiscussionTracker/src/MensGroupDiscussionTracker.Api/MensGroupDiscussionTracker.Api.csproj
@@ -13,6 +13,10 @@
     <PackageReference Include="Serilog.Enrichers.Environment" Version="2.3.0" />
     <PackageReference Include="Serilog.Enrichers.Thread" Version="3.1.0" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="6.5.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="8.0.0">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
   </ItemGroup>
 
   <ItemGroup>

--- a/MorningRoutineBuilder/src/MorningRoutineBuilder.Api/MorningRoutineBuilder.Api.csproj
+++ b/MorningRoutineBuilder/src/MorningRoutineBuilder.Api/MorningRoutineBuilder.Api.csproj
@@ -13,6 +13,10 @@
     <PackageReference Include="Serilog.Enrichers.Environment" Version="2.3.0" />
     <PackageReference Include="Serilog.Enrichers.Thread" Version="3.1.0" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="6.5.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="8.0.0">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
   </ItemGroup>
 
   <ItemGroup>

--- a/NeighborhoodSocialNetwork/src/NeighborhoodSocialNetwork.Api/NeighborhoodSocialNetwork.Api.csproj
+++ b/NeighborhoodSocialNetwork/src/NeighborhoodSocialNetwork.Api/NeighborhoodSocialNetwork.Api.csproj
@@ -13,6 +13,10 @@
     <PackageReference Include="Serilog.Enrichers.Environment" Version="2.3.0" />
     <PackageReference Include="Serilog.Enrichers.Thread" Version="3.1.0" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="6.5.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="8.0.0">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
   </ItemGroup>
 
   <ItemGroup>

--- a/NutritionLabelScanner/src/NutritionLabelScanner.Api/NutritionLabelScanner.Api.csproj
+++ b/NutritionLabelScanner/src/NutritionLabelScanner.Api/NutritionLabelScanner.Api.csproj
@@ -13,6 +13,10 @@
     <PackageReference Include="Serilog.Enrichers.Environment" Version="2.3.0" />
     <PackageReference Include="Serilog.Enrichers.Thread" Version="3.1.0" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="6.5.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="8.0.0">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
   </ItemGroup>
 
   <ItemGroup>

--- a/PersonalHealthDashboard/src/PersonalHealthDashboard.Api/PersonalHealthDashboard.Api.csproj
+++ b/PersonalHealthDashboard/src/PersonalHealthDashboard.Api/PersonalHealthDashboard.Api.csproj
@@ -13,6 +13,10 @@
     <PackageReference Include="Serilog.Enrichers.Environment" Version="2.3.0" />
     <PackageReference Include="Serilog.Enrichers.Thread" Version="3.1.0" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="6.5.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="8.0.0">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
   </ItemGroup>
 
   <ItemGroup>

--- a/PersonalLibraryLessonsLearned/src/PersonalLibraryLessonsLearned.Api/PersonalLibraryLessonsLearned.Api.csproj
+++ b/PersonalLibraryLessonsLearned/src/PersonalLibraryLessonsLearned.Api/PersonalLibraryLessonsLearned.Api.csproj
@@ -13,6 +13,10 @@
     <PackageReference Include="Serilog.Enrichers.Environment" Version="2.3.0" />
     <PackageReference Include="Serilog.Enrichers.Thread" Version="3.1.0" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="6.5.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="8.0.0">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
   </ItemGroup>
 
   <ItemGroup>

--- a/PersonalLoanComparisonTool/src/PersonalLoanComparisonTool.Api/PersonalLoanComparisonTool.Api.csproj
+++ b/PersonalLoanComparisonTool/src/PersonalLoanComparisonTool.Api/PersonalLoanComparisonTool.Api.csproj
@@ -13,6 +13,10 @@
     <PackageReference Include="Serilog.Enrichers.Environment" Version="2.3.0" />
     <PackageReference Include="Serilog.Enrichers.Thread" Version="3.1.0" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="6.5.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="8.0.0">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
   </ItemGroup>
 
   <ItemGroup>

--- a/PersonalMissionStatementBuilder/src/PersonalMissionStatementBuilder.Api/PersonalMissionStatementBuilder.Api.csproj
+++ b/PersonalMissionStatementBuilder/src/PersonalMissionStatementBuilder.Api/PersonalMissionStatementBuilder.Api.csproj
@@ -13,6 +13,10 @@
     <PackageReference Include="Serilog.Enrichers.Environment" Version="2.3.0" />
     <PackageReference Include="Serilog.Enrichers.Thread" Version="3.1.0" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="6.5.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="8.0.0">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
   </ItemGroup>
 
   <ItemGroup>

--- a/PersonalNetWorthDashboard/src/PersonalNetWorthDashboard.Api/PersonalNetWorthDashboard.Api.csproj
+++ b/PersonalNetWorthDashboard/src/PersonalNetWorthDashboard.Api/PersonalNetWorthDashboard.Api.csproj
@@ -13,6 +13,10 @@
     <PackageReference Include="Serilog.Enrichers.Environment" Version="2.3.0" />
     <PackageReference Include="Serilog.Enrichers.Thread" Version="3.1.0" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="6.5.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="8.0.0">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
   </ItemGroup>
 
   <ItemGroup>

--- a/PersonalProjectPipeline/src/PersonalProjectPipeline.Api/PersonalProjectPipeline.Api.csproj
+++ b/PersonalProjectPipeline/src/PersonalProjectPipeline.Api/PersonalProjectPipeline.Api.csproj
@@ -13,6 +13,10 @@
     <PackageReference Include="Serilog.Enrichers.Environment" Version="2.3.0" />
     <PackageReference Include="Serilog.Enrichers.Thread" Version="3.1.0" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="6.5.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="8.0.0">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
   </ItemGroup>
 
   <ItemGroup>

--- a/PersonalWiki/src/PersonalWiki.Api/PersonalWiki.Api.csproj
+++ b/PersonalWiki/src/PersonalWiki.Api/PersonalWiki.Api.csproj
@@ -13,6 +13,10 @@
     <PackageReference Include="Serilog.Enrichers.Environment" Version="2.3.0" />
     <PackageReference Include="Serilog.Enrichers.Thread" Version="3.1.0" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="6.5.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="8.0.0">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
   </ItemGroup>
 
   <ItemGroup>

--- a/PhotographySessionLogger/src/PhotographySessionLogger.Api/PhotographySessionLogger.Api.csproj
+++ b/PhotographySessionLogger/src/PhotographySessionLogger.Api/PhotographySessionLogger.Api.csproj
@@ -13,6 +13,10 @@
     <PackageReference Include="Serilog.Enrichers.Environment" Version="2.3.0" />
     <PackageReference Include="Serilog.Enrichers.Thread" Version="3.1.0" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="6.5.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="8.0.0">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
   </ItemGroup>
 
   <ItemGroup>

--- a/ProfessionalNetworkCRM/src/ProfessionalNetworkCRM.Api/ProfessionalNetworkCRM.Api.csproj
+++ b/ProfessionalNetworkCRM/src/ProfessionalNetworkCRM.Api/ProfessionalNetworkCRM.Api.csproj
@@ -13,6 +13,10 @@
     <PackageReference Include="Serilog.Enrichers.Environment" Version="2.3.0" />
     <PackageReference Include="Serilog.Enrichers.Thread" Version="3.1.0" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="6.5.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="8.0.0">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
   </ItemGroup>
 
   <ItemGroup>

--- a/ProfessionalReadingList/src/ProfessionalReadingList.Api/ProfessionalReadingList.Api.csproj
+++ b/ProfessionalReadingList/src/ProfessionalReadingList.Api/ProfessionalReadingList.Api.csproj
@@ -13,6 +13,10 @@
     <PackageReference Include="Serilog.Enrichers.Environment" Version="2.3.0" />
     <PackageReference Include="Serilog.Enrichers.Thread" Version="3.1.0" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="6.5.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="8.0.0">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
   </ItemGroup>
 
   <ItemGroup>

--- a/RecipeManagerMealPlanner/src/RecipeManagerMealPlanner.Api/RecipeManagerMealPlanner.Api.csproj
+++ b/RecipeManagerMealPlanner/src/RecipeManagerMealPlanner.Api/RecipeManagerMealPlanner.Api.csproj
@@ -13,6 +13,10 @@
     <PackageReference Include="Serilog.Enrichers.Environment" Version="2.3.0" />
     <PackageReference Include="Serilog.Enrichers.Thread" Version="3.1.0" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="6.5.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="8.0.0">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
   </ItemGroup>
 
   <ItemGroup>

--- a/ResumeCareerAchievementTracker/src/ResumeCareerAchievementTracker.Api/ResumeCareerAchievementTracker.Api.csproj
+++ b/ResumeCareerAchievementTracker/src/ResumeCareerAchievementTracker.Api/ResumeCareerAchievementTracker.Api.csproj
@@ -13,6 +13,10 @@
     <PackageReference Include="Serilog.Enrichers.Environment" Version="2.3.0" />
     <PackageReference Include="Serilog.Enrichers.Thread" Version="3.1.0" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="6.5.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="8.0.0">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
   </ItemGroup>
 
   <ItemGroup>

--- a/RetirementSavingsCalculator/src/RetirementSavingsCalculator.Api/RetirementSavingsCalculator.Api.csproj
+++ b/RetirementSavingsCalculator/src/RetirementSavingsCalculator.Api/RetirementSavingsCalculator.Api.csproj
@@ -13,6 +13,10 @@
     <PackageReference Include="Serilog.Enrichers.Environment" Version="2.3.0" />
     <PackageReference Include="Serilog.Enrichers.Thread" Version="3.1.0" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="6.5.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="8.0.0">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
   </ItemGroup>
 
   <ItemGroup>

--- a/RoadsideAssistanceInfoHub/src/RoadsideAssistanceInfoHub.Api/RoadsideAssistanceInfoHub.Api.csproj
+++ b/RoadsideAssistanceInfoHub/src/RoadsideAssistanceInfoHub.Api/RoadsideAssistanceInfoHub.Api.csproj
@@ -13,6 +13,10 @@
     <PackageReference Include="Serilog.Enrichers.Environment" Version="2.3.0" />
     <PackageReference Include="Serilog.Enrichers.Thread" Version="3.1.0" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="6.5.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="8.0.0">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
   </ItemGroup>
 
   <ItemGroup>

--- a/RunningLogRaceTracker/src/RunningLogRaceTracker.Api/RunningLogRaceTracker.Api.csproj
+++ b/RunningLogRaceTracker/src/RunningLogRaceTracker.Api/RunningLogRaceTracker.Api.csproj
@@ -13,6 +13,10 @@
     <PackageReference Include="Serilog.Enrichers.Environment" Version="2.3.0" />
     <PackageReference Include="Serilog.Enrichers.Thread" Version="3.1.0" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="6.5.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="8.0.0">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
   </ItemGroup>
 
   <ItemGroup>

--- a/SalaryCompensationTracker/src/SalaryCompensationTracker.Api/SalaryCompensationTracker.Api.csproj
+++ b/SalaryCompensationTracker/src/SalaryCompensationTracker.Api/SalaryCompensationTracker.Api.csproj
@@ -13,6 +13,10 @@
     <PackageReference Include="Serilog.Enrichers.Environment" Version="2.3.0" />
     <PackageReference Include="Serilog.Enrichers.Thread" Version="3.1.0" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="6.5.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="8.0.0">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
   </ItemGroup>
 
   <ItemGroup>

--- a/SideHustleIncomeTracker/src/SideHustleIncomeTracker.Api/SideHustleIncomeTracker.Api.csproj
+++ b/SideHustleIncomeTracker/src/SideHustleIncomeTracker.Api/SideHustleIncomeTracker.Api.csproj
@@ -13,6 +13,10 @@
     <PackageReference Include="Serilog.Enrichers.Environment" Version="2.3.0" />
     <PackageReference Include="Serilog.Enrichers.Thread" Version="3.1.0" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="6.5.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="8.0.0">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
   </ItemGroup>
 
   <ItemGroup>

--- a/SkillDevelopmentTracker/src/SkillDevelopmentTracker.Api/SkillDevelopmentTracker.Api.csproj
+++ b/SkillDevelopmentTracker/src/SkillDevelopmentTracker.Api/SkillDevelopmentTracker.Api.csproj
@@ -13,6 +13,10 @@
     <PackageReference Include="Serilog.Enrichers.Environment" Version="2.3.0" />
     <PackageReference Include="Serilog.Enrichers.Thread" Version="3.1.0" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="6.5.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="8.0.0">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
   </ItemGroup>
 
   <ItemGroup>

--- a/SportsTeamFollowingTracker/src/SportsTeamFollowingTracker.Api/SportsTeamFollowingTracker.Api.csproj
+++ b/SportsTeamFollowingTracker/src/SportsTeamFollowingTracker.Api/SportsTeamFollowingTracker.Api.csproj
@@ -13,6 +13,10 @@
     <PackageReference Include="Serilog.Enrichers.Environment" Version="2.3.0" />
     <PackageReference Include="Serilog.Enrichers.Thread" Version="3.1.0" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="6.5.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="8.0.0">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
   </ItemGroup>
 
   <ItemGroup>

--- a/StressMoodTracker/src/StressMoodTracker.Api/StressMoodTracker.Api.csproj
+++ b/StressMoodTracker/src/StressMoodTracker.Api/StressMoodTracker.Api.csproj
@@ -13,6 +13,10 @@
     <PackageReference Include="Serilog.Enrichers.Environment" Version="2.3.0" />
     <PackageReference Include="Serilog.Enrichers.Thread" Version="3.1.0" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="6.5.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="8.0.0">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
   </ItemGroup>
 
   <ItemGroup>

--- a/SubscriptionAuditTool/src/SubscriptionAuditTool.Api/SubscriptionAuditTool.Api.csproj
+++ b/SubscriptionAuditTool/src/SubscriptionAuditTool.Api/SubscriptionAuditTool.Api.csproj
@@ -13,6 +13,10 @@
     <PackageReference Include="Serilog.Enrichers.Environment" Version="2.3.0" />
     <PackageReference Include="Serilog.Enrichers.Thread" Version="3.1.0" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="6.5.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="8.0.0">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
   </ItemGroup>
 
   <ItemGroup>

--- a/TimeAuditTracker/src/TimeAuditTracker.Api/TimeAuditTracker.Api.csproj
+++ b/TimeAuditTracker/src/TimeAuditTracker.Api/TimeAuditTracker.Api.csproj
@@ -13,6 +13,10 @@
     <PackageReference Include="Serilog.Enrichers.Environment" Version="2.3.0" />
     <PackageReference Include="Serilog.Enrichers.Thread" Version="3.1.0" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="6.5.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="8.0.0">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
   </ItemGroup>
 
   <ItemGroup>

--- a/TravelDestinationWishlist/src/TravelDestinationWishlist.Api/TravelDestinationWishlist.Api.csproj
+++ b/TravelDestinationWishlist/src/TravelDestinationWishlist.Api/TravelDestinationWishlist.Api.csproj
@@ -13,6 +13,10 @@
     <PackageReference Include="Serilog.Enrichers.Environment" Version="2.3.0" />
     <PackageReference Include="Serilog.Enrichers.Thread" Version="3.1.0" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="6.5.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="8.0.0">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
   </ItemGroup>
 
   <ItemGroup>

--- a/VehicleMaintenanceLogger/src/VehicleMaintenanceLogger.Api/VehicleMaintenanceLogger.Api.csproj
+++ b/VehicleMaintenanceLogger/src/VehicleMaintenanceLogger.Api/VehicleMaintenanceLogger.Api.csproj
@@ -13,6 +13,10 @@
     <PackageReference Include="Serilog.Enrichers.Environment" Version="2.3.0" />
     <PackageReference Include="Serilog.Enrichers.Thread" Version="3.1.0" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="6.5.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="8.0.0">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
   </ItemGroup>
 
   <ItemGroup>

--- a/VehicleValueTracker/src/VehicleValueTracker.Api/VehicleValueTracker.Api.csproj
+++ b/VehicleValueTracker/src/VehicleValueTracker.Api/VehicleValueTracker.Api.csproj
@@ -13,6 +13,10 @@
     <PackageReference Include="Serilog.Enrichers.Environment" Version="2.3.0" />
     <PackageReference Include="Serilog.Enrichers.Thread" Version="3.1.0" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="6.5.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="8.0.0">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
   </ItemGroup>
 
   <ItemGroup>

--- a/VideoGameCollectionManager/src/VideoGameCollectionManager.Api/VideoGameCollectionManager.Api.csproj
+++ b/VideoGameCollectionManager/src/VideoGameCollectionManager.Api/VideoGameCollectionManager.Api.csproj
@@ -13,6 +13,10 @@
     <PackageReference Include="Serilog.Enrichers.Environment" Version="2.3.0" />
     <PackageReference Include="Serilog.Enrichers.Thread" Version="3.1.0" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="6.5.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="8.0.0">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
   </ItemGroup>
 
   <ItemGroup>

--- a/WeeklyReviewSystem/src/WeeklyReviewSystem.Api/WeeklyReviewSystem.Api.csproj
+++ b/WeeklyReviewSystem/src/WeeklyReviewSystem.Api/WeeklyReviewSystem.Api.csproj
@@ -13,6 +13,10 @@
     <PackageReference Include="Serilog.Enrichers.Environment" Version="2.3.0" />
     <PackageReference Include="Serilog.Enrichers.Thread" Version="3.1.0" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="6.5.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="8.0.0">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
   </ItemGroup>
 
   <ItemGroup>

--- a/WineCellarInventory/src/WineCellarInventory.Api/WineCellarInventory.Api.csproj
+++ b/WineCellarInventory/src/WineCellarInventory.Api/WineCellarInventory.Api.csproj
@@ -13,6 +13,10 @@
     <PackageReference Include="Serilog.Enrichers.Environment" Version="2.3.0" />
     <PackageReference Include="Serilog.Enrichers.Thread" Version="3.1.0" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="6.5.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="8.0.0">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
   </ItemGroup>
 
   <ItemGroup>

--- a/WorkoutPlanBuilder/src/WorkoutPlanBuilder.Api/WorkoutPlanBuilder.Api.csproj
+++ b/WorkoutPlanBuilder/src/WorkoutPlanBuilder.Api/WorkoutPlanBuilder.Api.csproj
@@ -13,6 +13,10 @@
     <PackageReference Include="Serilog.Enrichers.Environment" Version="2.3.0" />
     <PackageReference Include="Serilog.Enrichers.Thread" Version="3.1.0" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="6.5.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="8.0.0">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Added the EF Core Design package reference to 62 Api projects that were missing it, enabling EF Core migrations tooling. The package reference follows the same pattern as DateNightIdeaGenerator.Api.csproj with PrivateAssets and IncludeAssets properly configured.