### PR TITLE
Add Microsoft.EntityFrameworkCore.InMemory to all Infrastructure.Test…

### DIFF
--- a/AnnualHealthScreeningReminder/tests/AnnualHealthScreeningReminder.Infrastructure.Tests/AnnualHealthScreeningReminder.Infrastructure.Tests.csproj
+++ b/AnnualHealthScreeningReminder/tests/AnnualHealthScreeningReminder.Infrastructure.Tests/AnnualHealthScreeningReminder.Infrastructure.Tests.csproj
@@ -9,6 +9,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="8.0.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
     <PackageReference Include="NUnit" Version="4.0.1" />
     <PackageReference Include="NUnit3TestAdapter" Version="4.5.0" />

--- a/ApplianceWarrantyManualOrganizer/tests/ApplianceWarrantyManualOrganizer.Infrastructure.Tests/ApplianceWarrantyManualOrganizer.Infrastructure.Tests.csproj
+++ b/ApplianceWarrantyManualOrganizer/tests/ApplianceWarrantyManualOrganizer.Infrastructure.Tests/ApplianceWarrantyManualOrganizer.Infrastructure.Tests.csproj
@@ -9,6 +9,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="8.0.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
     <PackageReference Include="NUnit" Version="4.0.1" />
     <PackageReference Include="NUnit3TestAdapter" Version="4.5.0" />

--- a/BBQGrillingRecipeBook/tests/BBQGrillingRecipeBook.Infrastructure.Tests/BBQGrillingRecipeBook.Infrastructure.Tests.csproj
+++ b/BBQGrillingRecipeBook/tests/BBQGrillingRecipeBook.Infrastructure.Tests/BBQGrillingRecipeBook.Infrastructure.Tests.csproj
@@ -9,6 +9,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="8.0.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
     <PackageReference Include="NUnit" Version="4.0.1" />
     <PackageReference Include="NUnit3TestAdapter" Version="4.5.0" />

--- a/BillPaymentScheduler/tests/BillPaymentScheduler.Infrastructure.Tests/BillPaymentScheduler.Infrastructure.Tests.csproj
+++ b/BillPaymentScheduler/tests/BillPaymentScheduler.Infrastructure.Tests/BillPaymentScheduler.Infrastructure.Tests.csproj
@@ -9,6 +9,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="8.0.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
     <PackageReference Include="NUnit" Version="4.0.1" />
     <PackageReference Include="NUnit3TestAdapter" Version="4.5.0" />

--- a/BloodPressureMonitor/tests/BloodPressureMonitor.Infrastructure.Tests/BloodPressureMonitor.Infrastructure.Tests.csproj
+++ b/BloodPressureMonitor/tests/BloodPressureMonitor.Infrastructure.Tests/BloodPressureMonitor.Infrastructure.Tests.csproj
@@ -9,6 +9,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="8.0.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
     <PackageReference Include="NUnit" Version="4.0.1" />
     <PackageReference Include="NUnit3TestAdapter" Version="4.5.0" />

--- a/BookReadingTrackerLibrary/tests/BookReadingTrackerLibrary.Infrastructure.Tests/BookReadingTrackerLibrary.Infrastructure.Tests.csproj
+++ b/BookReadingTrackerLibrary/tests/BookReadingTrackerLibrary.Infrastructure.Tests/BookReadingTrackerLibrary.Infrastructure.Tests.csproj
@@ -9,6 +9,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="8.0.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
     <PackageReference Include="NUnit" Version="4.0.1" />
     <PackageReference Include="NUnit3TestAdapter" Version="4.5.0" />

--- a/BucketListManager/tests/BucketListManager.Infrastructure.Tests/BucketListManager.Infrastructure.Tests.csproj
+++ b/BucketListManager/tests/BucketListManager.Infrastructure.Tests/BucketListManager.Infrastructure.Tests.csproj
@@ -9,6 +9,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="8.0.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
     <PackageReference Include="NUnit" Version="4.0.1" />
     <PackageReference Include="NUnit3TestAdapter" Version="4.5.0" />

--- a/CampingTripPlanner/tests/CampingTripPlanner.Infrastructure.Tests/CampingTripPlanner.Infrastructure.Tests.csproj
+++ b/CampingTripPlanner/tests/CampingTripPlanner.Infrastructure.Tests/CampingTripPlanner.Infrastructure.Tests.csproj
@@ -9,6 +9,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="8.0.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
     <PackageReference Include="NUnit" Version="4.0.1" />
     <PackageReference Include="NUnit3TestAdapter" Version="4.5.0" />

--- a/CarModificationPartsDatabase/tests/CarModificationPartsDatabase.Infrastructure.Tests/CarModificationPartsDatabase.Infrastructure.Tests.csproj
+++ b/CarModificationPartsDatabase/tests/CarModificationPartsDatabase.Infrastructure.Tests/CarModificationPartsDatabase.Infrastructure.Tests.csproj
@@ -9,6 +9,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="8.0.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
     <PackageReference Include="NUnit" Version="4.0.1" />
     <PackageReference Include="NUnit3TestAdapter" Version="4.5.0" />

--- a/CharitableGivingTracker/tests/CharitableGivingTracker.Infrastructure.Tests/CharitableGivingTracker.Infrastructure.Tests.csproj
+++ b/CharitableGivingTracker/tests/CharitableGivingTracker.Infrastructure.Tests/CharitableGivingTracker.Infrastructure.Tests.csproj
@@ -9,6 +9,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="8.0.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
     <PackageReference Include="NUnit" Version="4.0.1" />
     <PackageReference Include="NUnit3TestAdapter" Version="4.5.0" />

--- a/ChoreAssignmentTracker/tests/ChoreAssignmentTracker.Infrastructure.Tests/ChoreAssignmentTracker.Infrastructure.Tests.csproj
+++ b/ChoreAssignmentTracker/tests/ChoreAssignmentTracker.Infrastructure.Tests/ChoreAssignmentTracker.Infrastructure.Tests.csproj
@@ -9,6 +9,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="8.0.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
     <PackageReference Include="NUnit" Version="4.0.1" />
     <PackageReference Include="NUnit3TestAdapter" Version="4.5.0" />

--- a/CollegeSavingsPlanner/tests/CollegeSavingsPlanner.Infrastructure.Tests/CollegeSavingsPlanner.Infrastructure.Tests.csproj
+++ b/CollegeSavingsPlanner/tests/CollegeSavingsPlanner.Infrastructure.Tests/CollegeSavingsPlanner.Infrastructure.Tests.csproj
@@ -9,6 +9,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="8.0.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
     <PackageReference Include="NUnit" Version="4.0.1" />
     <PackageReference Include="NUnit3TestAdapter" Version="4.5.0" />

--- a/ConferenceEventManager/tests/ConferenceEventManager.Infrastructure.Tests/ConferenceEventManager.Infrastructure.Tests.csproj
+++ b/ConferenceEventManager/tests/ConferenceEventManager.Infrastructure.Tests/ConferenceEventManager.Infrastructure.Tests.csproj
@@ -9,6 +9,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="8.0.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
     <PackageReference Include="NUnit" Version="4.0.1" />
     <PackageReference Include="NUnit3TestAdapter" Version="4.5.0" />

--- a/ConversationStarterApp/tests/ConversationStarterApp.Infrastructure.Tests/ConversationStarterApp.Infrastructure.Tests.csproj
+++ b/ConversationStarterApp/tests/ConversationStarterApp.Infrastructure.Tests/ConversationStarterApp.Infrastructure.Tests.csproj
@@ -9,6 +9,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="8.0.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
     <PackageReference Include="NUnit" Version="4.0.1" />
     <PackageReference Include="NUnit3TestAdapter" Version="4.5.0" />

--- a/CouplesGoalTracker/tests/CouplesGoalTracker.Infrastructure.Tests/CouplesGoalTracker.Infrastructure.Tests.csproj
+++ b/CouplesGoalTracker/tests/CouplesGoalTracker.Infrastructure.Tests/CouplesGoalTracker.Infrastructure.Tests.csproj
@@ -9,6 +9,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="8.0.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
     <PackageReference Include="NUnit" Version="4.0.1" />
     <PackageReference Include="NUnit3TestAdapter" Version="4.5.0" />

--- a/DailyJournalingApp/tests/DailyJournalingApp.Infrastructure.Tests/DailyJournalingApp.Infrastructure.Tests.csproj
+++ b/DailyJournalingApp/tests/DailyJournalingApp.Infrastructure.Tests/DailyJournalingApp.Infrastructure.Tests.csproj
@@ -9,6 +9,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="8.0.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
     <PackageReference Include="NUnit" Version="4.0.1" />
     <PackageReference Include="NUnit3TestAdapter" Version="4.5.0" />

--- a/DigitalLegacyPlanner/tests/DigitalLegacyPlanner.Infrastructure.Tests/DigitalLegacyPlanner.Infrastructure.Tests.csproj
+++ b/DigitalLegacyPlanner/tests/DigitalLegacyPlanner.Infrastructure.Tests/DigitalLegacyPlanner.Infrastructure.Tests.csproj
@@ -9,6 +9,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="8.0.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
     <PackageReference Include="NUnit" Version="4.0.1" />
     <PackageReference Include="NUnit3TestAdapter" Version="4.5.0" />

--- a/FamilyCalendarEventPlanner/tests/FamilyCalendarEventPlanner.Infrastructure.Tests/FamilyCalendarEventPlanner.Infrastructure.Tests.csproj
+++ b/FamilyCalendarEventPlanner/tests/FamilyCalendarEventPlanner.Infrastructure.Tests/FamilyCalendarEventPlanner.Infrastructure.Tests.csproj
@@ -9,6 +9,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="8.0.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
     <PackageReference Include="NUnit" Version="4.0.1" />
     <PackageReference Include="NUnit3TestAdapter" Version="4.5.0" />

--- a/FamilyPhotoAlbumOrganizer/tests/FamilyPhotoAlbumOrganizer.Infrastructure.Tests/FamilyPhotoAlbumOrganizer.Infrastructure.Tests.csproj
+++ b/FamilyPhotoAlbumOrganizer/tests/FamilyPhotoAlbumOrganizer.Infrastructure.Tests/FamilyPhotoAlbumOrganizer.Infrastructure.Tests.csproj
@@ -9,6 +9,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="8.0.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
     <PackageReference Include="NUnit" Version="4.0.1" />
     <PackageReference Include="NUnit3TestAdapter" Version="4.5.0" />

--- a/FamilyTreeBuilder/tests/FamilyTreeBuilder.Infrastructure.Tests/FamilyTreeBuilder.Infrastructure.Tests.csproj
+++ b/FamilyTreeBuilder/tests/FamilyTreeBuilder.Infrastructure.Tests/FamilyTreeBuilder.Infrastructure.Tests.csproj
@@ -9,6 +9,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="8.0.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
     <PackageReference Include="NUnit" Version="4.0.1" />
     <PackageReference Include="NUnit3TestAdapter" Version="4.5.0" />

--- a/FamilyVacationPlanner/tests/FamilyVacationPlanner.Infrastructure.Tests/FamilyVacationPlanner.Infrastructure.Tests.csproj
+++ b/FamilyVacationPlanner/tests/FamilyVacationPlanner.Infrastructure.Tests/FamilyVacationPlanner.Infrastructure.Tests.csproj
@@ -9,6 +9,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="8.0.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
     <PackageReference Include="NUnit" Version="4.0.1" />
     <PackageReference Include="NUnit3TestAdapter" Version="4.5.0" />

--- a/FinancialGoalTracker/tests/FinancialGoalTracker.Infrastructure.Tests/FinancialGoalTracker.Infrastructure.Tests.csproj
+++ b/FinancialGoalTracker/tests/FinancialGoalTracker.Infrastructure.Tests/FinancialGoalTracker.Infrastructure.Tests.csproj
@@ -9,6 +9,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="8.0.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
     <PackageReference Include="NUnit" Version="4.0.1" />
     <PackageReference Include="NUnit3TestAdapter" Version="4.5.0" />

--- a/FocusSessionTracker/tests/FocusSessionTracker.Infrastructure.Tests/FocusSessionTracker.Infrastructure.Tests.csproj
+++ b/FocusSessionTracker/tests/FocusSessionTracker.Infrastructure.Tests/FocusSessionTracker.Infrastructure.Tests.csproj
@@ -9,6 +9,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="8.0.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
     <PackageReference Include="NUnit" Version="4.0.1" />
     <PackageReference Include="NUnit3TestAdapter" Version="4.5.0" />

--- a/FreelanceProjectManager/tests/FreelanceProjectManager.Infrastructure.Tests/FreelanceProjectManager.Infrastructure.Tests.csproj
+++ b/FreelanceProjectManager/tests/FreelanceProjectManager.Infrastructure.Tests/FreelanceProjectManager.Infrastructure.Tests.csproj
@@ -9,6 +9,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="8.0.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
     <PackageReference Include="NUnit" Version="4.0.1" />
     <PackageReference Include="NUnit3TestAdapter" Version="4.5.0" />

--- a/FriendGroupEventCoordinator/tests/FriendGroupEventCoordinator.Infrastructure.Tests/FriendGroupEventCoordinator.Infrastructure.Tests.csproj
+++ b/FriendGroupEventCoordinator/tests/FriendGroupEventCoordinator.Infrastructure.Tests/FriendGroupEventCoordinator.Infrastructure.Tests.csproj
@@ -9,6 +9,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="8.0.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
     <PackageReference Include="NUnit" Version="4.0.1" />
     <PackageReference Include="NUnit3TestAdapter" Version="4.5.0" />

--- a/FuelEconomyTracker/tests/FuelEconomyTracker.Infrastructure.Tests/FuelEconomyTracker.Infrastructure.Tests.csproj
+++ b/FuelEconomyTracker/tests/FuelEconomyTracker.Infrastructure.Tests/FuelEconomyTracker.Infrastructure.Tests.csproj
@@ -9,6 +9,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="8.0.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
     <PackageReference Include="NUnit" Version="4.0.1" />
     <PackageReference Include="NUnit3TestAdapter" Version="4.5.0" />

--- a/GiftIdeaTracker/tests/GiftIdeaTracker.Infrastructure.Tests/GiftIdeaTracker.Infrastructure.Tests.csproj
+++ b/GiftIdeaTracker/tests/GiftIdeaTracker.Infrastructure.Tests/GiftIdeaTracker.Infrastructure.Tests.csproj
@@ -9,6 +9,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="8.0.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
     <PackageReference Include="NUnit" Version="4.0.1" />
     <PackageReference Include="NUnit3TestAdapter" Version="4.5.0" />

--- a/GolfScoreTracker/tests/GolfScoreTracker.Infrastructure.Tests/GolfScoreTracker.Infrastructure.Tests.csproj
+++ b/GolfScoreTracker/tests/GolfScoreTracker.Infrastructure.Tests/GolfScoreTracker.Infrastructure.Tests.csproj
@@ -9,6 +9,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="8.0.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
     <PackageReference Include="NUnit" Version="4.0.1" />
     <PackageReference Include="NUnit3TestAdapter" Version="4.5.0" />

--- a/GroceryShoppingListApp/tests/GroceryShoppingListApp.Infrastructure.Tests/GroceryShoppingListApp.Infrastructure.Tests.csproj
+++ b/GroceryShoppingListApp/tests/GroceryShoppingListApp.Infrastructure.Tests/GroceryShoppingListApp.Infrastructure.Tests.csproj
@@ -9,6 +9,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="8.0.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
     <PackageReference Include="NUnit" Version="4.0.1" />
     <PackageReference Include="NUnit3TestAdapter" Version="4.5.0" />

--- a/HabitFormationApp/tests/HabitFormationApp.Infrastructure.Tests/HabitFormationApp.Infrastructure.Tests.csproj
+++ b/HabitFormationApp/tests/HabitFormationApp.Infrastructure.Tests/HabitFormationApp.Infrastructure.Tests.csproj
@@ -9,6 +9,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="8.0.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
     <PackageReference Include="NUnit" Version="4.0.1" />
     <PackageReference Include="NUnit3TestAdapter" Version="4.5.0" />

--- a/HomeGymEquipmentManager/tests/HomeGymEquipmentManager.Infrastructure.Tests/HomeGymEquipmentManager.Infrastructure.Tests.csproj
+++ b/HomeGymEquipmentManager/tests/HomeGymEquipmentManager.Infrastructure.Tests/HomeGymEquipmentManager.Infrastructure.Tests.csproj
@@ -9,6 +9,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="8.0.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
     <PackageReference Include="NUnit" Version="4.0.1" />
     <PackageReference Include="NUnit3TestAdapter" Version="4.5.0" />

--- a/HomeInventoryManager/tests/HomeInventoryManager.Infrastructure.Tests/HomeInventoryManager.Infrastructure.Tests.csproj
+++ b/HomeInventoryManager/tests/HomeInventoryManager.Infrastructure.Tests/HomeInventoryManager.Infrastructure.Tests.csproj
@@ -9,6 +9,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="8.0.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
     <PackageReference Include="NUnit" Version="4.0.1" />
     <PackageReference Include="NUnit3TestAdapter" Version="4.5.0" />

--- a/HouseholdBudgetManager/tests/HouseholdBudgetManager.Infrastructure.Tests/HouseholdBudgetManager.Infrastructure.Tests.csproj
+++ b/HouseholdBudgetManager/tests/HouseholdBudgetManager.Infrastructure.Tests/HouseholdBudgetManager.Infrastructure.Tests.csproj
@@ -9,6 +9,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="8.0.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
     <PackageReference Include="NUnit" Version="4.0.1" />
     <PackageReference Include="NUnit3TestAdapter" Version="4.5.0" />

--- a/HydrationTracker/tests/HydrationTracker.Infrastructure.Tests/HydrationTracker.Infrastructure.Tests.csproj
+++ b/HydrationTracker/tests/HydrationTracker.Infrastructure.Tests/HydrationTracker.Infrastructure.Tests.csproj
@@ -9,6 +9,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="8.0.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
     <PackageReference Include="NUnit" Version="4.0.1" />
     <PackageReference Include="NUnit3TestAdapter" Version="4.5.0" />

--- a/InjuryPreventionRecoveryTracker/tests/InjuryPreventionRecoveryTracker.Infrastructure.Tests/InjuryPreventionRecoveryTracker.Infrastructure.Tests.csproj
+++ b/InjuryPreventionRecoveryTracker/tests/InjuryPreventionRecoveryTracker.Infrastructure.Tests/InjuryPreventionRecoveryTracker.Infrastructure.Tests.csproj
@@ -9,6 +9,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="8.0.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
     <PackageReference Include="NUnit" Version="4.0.1" />
     <PackageReference Include="NUnit3TestAdapter" Version="4.5.0" />

--- a/InvestmentPortfolioTracker/tests/InvestmentPortfolioTracker.Infrastructure.Tests/InvestmentPortfolioTracker.Infrastructure.Tests.csproj
+++ b/InvestmentPortfolioTracker/tests/InvestmentPortfolioTracker.Infrastructure.Tests/InvestmentPortfolioTracker.Infrastructure.Tests.csproj
@@ -9,6 +9,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="8.0.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
     <PackageReference Include="NUnit" Version="4.0.1" />
     <PackageReference Include="NUnit3TestAdapter" Version="4.5.0" />

--- a/JobSearchOrganizer/tests/JobSearchOrganizer.Infrastructure.Tests/JobSearchOrganizer.Infrastructure.Tests.csproj
+++ b/JobSearchOrganizer/tests/JobSearchOrganizer.Infrastructure.Tests/JobSearchOrganizer.Infrastructure.Tests.csproj
@@ -9,6 +9,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="8.0.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
     <PackageReference Include="NUnit" Version="4.0.1" />
     <PackageReference Include="NUnit3TestAdapter" Version="4.5.0" />

--- a/KidsActivitySportsTracker/tests/KidsActivitySportsTracker.Infrastructure.Tests/KidsActivitySportsTracker.Infrastructure.Tests.csproj
+++ b/KidsActivitySportsTracker/tests/KidsActivitySportsTracker.Infrastructure.Tests/KidsActivitySportsTracker.Infrastructure.Tests.csproj
@@ -9,6 +9,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="8.0.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
     <PackageReference Include="NUnit" Version="4.0.1" />
     <PackageReference Include="NUnit3TestAdapter" Version="4.5.0" />

--- a/KnowledgeBaseSecondBrain/tests/KnowledgeBaseSecondBrain.Infrastructure.Tests/KnowledgeBaseSecondBrain.Infrastructure.Tests.csproj
+++ b/KnowledgeBaseSecondBrain/tests/KnowledgeBaseSecondBrain.Infrastructure.Tests/KnowledgeBaseSecondBrain.Infrastructure.Tests.csproj
@@ -9,6 +9,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="8.0.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
     <PackageReference Include="NUnit" Version="4.0.1" />
     <PackageReference Include="NUnit3TestAdapter" Version="4.5.0" />

--- a/LetterToFutureSelf/tests/LetterToFutureSelf.Infrastructure.Tests/LetterToFutureSelf.Infrastructure.Tests.csproj
+++ b/LetterToFutureSelf/tests/LetterToFutureSelf.Infrastructure.Tests/LetterToFutureSelf.Infrastructure.Tests.csproj
@@ -9,6 +9,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="8.0.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
     <PackageReference Include="NUnit" Version="4.0.1" />
     <PackageReference Include="NUnit3TestAdapter" Version="4.5.0" />

--- a/LifeAdminDashboard/tests/LifeAdminDashboard.Infrastructure.Tests/LifeAdminDashboard.Infrastructure.Tests.csproj
+++ b/LifeAdminDashboard/tests/LifeAdminDashboard.Infrastructure.Tests/LifeAdminDashboard.Infrastructure.Tests.csproj
@@ -9,6 +9,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="8.0.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
     <PackageReference Include="NUnit" Version="4.0.1" />
     <PackageReference Include="NUnit3TestAdapter" Version="4.5.0" />

--- a/MarriageEnrichmentJournal/tests/MarriageEnrichmentJournal.Infrastructure.Tests/MarriageEnrichmentJournal.Infrastructure.Tests.csproj
+++ b/MarriageEnrichmentJournal/tests/MarriageEnrichmentJournal.Infrastructure.Tests/MarriageEnrichmentJournal.Infrastructure.Tests.csproj
@@ -9,6 +9,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="8.0.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
     <PackageReference Include="NUnit" Version="4.0.1" />
     <PackageReference Include="NUnit3TestAdapter" Version="4.5.0" />

--- a/MealPrepPlanner/tests/MealPrepPlanner.Infrastructure.Tests/MealPrepPlanner.Infrastructure.Tests.csproj
+++ b/MealPrepPlanner/tests/MealPrepPlanner.Infrastructure.Tests/MealPrepPlanner.Infrastructure.Tests.csproj
@@ -9,6 +9,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="8.0.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
     <PackageReference Include="NUnit" Version="4.0.1" />
     <PackageReference Include="NUnit3TestAdapter" Version="4.5.0" />

--- a/MeetingNotesActionItemTracker/tests/MeetingNotesActionItemTracker.Infrastructure.Tests/MeetingNotesActionItemTracker.Infrastructure.Tests.csproj
+++ b/MeetingNotesActionItemTracker/tests/MeetingNotesActionItemTracker.Infrastructure.Tests/MeetingNotesActionItemTracker.Infrastructure.Tests.csproj
@@ -9,6 +9,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="8.0.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
     <PackageReference Include="NUnit" Version="4.0.1" />
     <PackageReference Include="NUnit3TestAdapter" Version="4.5.0" />

--- a/MensGroupDiscussionTracker/tests/MensGroupDiscussionTracker.Infrastructure.Tests/MensGroupDiscussionTracker.Infrastructure.Tests.csproj
+++ b/MensGroupDiscussionTracker/tests/MensGroupDiscussionTracker.Infrastructure.Tests/MensGroupDiscussionTracker.Infrastructure.Tests.csproj
@@ -9,6 +9,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="8.0.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
     <PackageReference Include="NUnit" Version="4.0.1" />
     <PackageReference Include="NUnit3TestAdapter" Version="4.5.0" />

--- a/MorningRoutineBuilder/tests/MorningRoutineBuilder.Infrastructure.Tests/MorningRoutineBuilder.Infrastructure.Tests.csproj
+++ b/MorningRoutineBuilder/tests/MorningRoutineBuilder.Infrastructure.Tests/MorningRoutineBuilder.Infrastructure.Tests.csproj
@@ -9,6 +9,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="8.0.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
     <PackageReference Include="NUnit" Version="4.0.1" />
     <PackageReference Include="NUnit3TestAdapter" Version="4.5.0" />

--- a/NeighborhoodSocialNetwork/tests/NeighborhoodSocialNetwork.Infrastructure.Tests/NeighborhoodSocialNetwork.Infrastructure.Tests.csproj
+++ b/NeighborhoodSocialNetwork/tests/NeighborhoodSocialNetwork.Infrastructure.Tests/NeighborhoodSocialNetwork.Infrastructure.Tests.csproj
@@ -9,6 +9,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="8.0.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
     <PackageReference Include="NUnit" Version="4.0.1" />
     <PackageReference Include="NUnit3TestAdapter" Version="4.5.0" />

--- a/NutritionLabelScanner/tests/NutritionLabelScanner.Infrastructure.Tests/NutritionLabelScanner.Infrastructure.Tests.csproj
+++ b/NutritionLabelScanner/tests/NutritionLabelScanner.Infrastructure.Tests/NutritionLabelScanner.Infrastructure.Tests.csproj
@@ -9,6 +9,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="8.0.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
     <PackageReference Include="NUnit" Version="4.0.1" />
     <PackageReference Include="NUnit3TestAdapter" Version="4.5.0" />

--- a/PersonalHealthDashboard/tests/PersonalHealthDashboard.Infrastructure.Tests/PersonalHealthDashboard.Infrastructure.Tests.csproj
+++ b/PersonalHealthDashboard/tests/PersonalHealthDashboard.Infrastructure.Tests/PersonalHealthDashboard.Infrastructure.Tests.csproj
@@ -9,6 +9,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="8.0.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
     <PackageReference Include="NUnit" Version="4.0.1" />
     <PackageReference Include="NUnit3TestAdapter" Version="4.5.0" />

--- a/PersonalLibraryLessonsLearned/tests/PersonalLibraryLessonsLearned.Infrastructure.Tests/PersonalLibraryLessonsLearned.Infrastructure.Tests.csproj
+++ b/PersonalLibraryLessonsLearned/tests/PersonalLibraryLessonsLearned.Infrastructure.Tests/PersonalLibraryLessonsLearned.Infrastructure.Tests.csproj
@@ -9,6 +9,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="8.0.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
     <PackageReference Include="NUnit" Version="4.0.1" />
     <PackageReference Include="NUnit3TestAdapter" Version="4.5.0" />

--- a/PersonalLoanComparisonTool/tests/PersonalLoanComparisonTool.Infrastructure.Tests/PersonalLoanComparisonTool.Infrastructure.Tests.csproj
+++ b/PersonalLoanComparisonTool/tests/PersonalLoanComparisonTool.Infrastructure.Tests/PersonalLoanComparisonTool.Infrastructure.Tests.csproj
@@ -9,6 +9,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="8.0.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
     <PackageReference Include="NUnit" Version="4.0.1" />
     <PackageReference Include="NUnit3TestAdapter" Version="4.5.0" />

--- a/PersonalMissionStatementBuilder/tests/PersonalMissionStatementBuilder.Infrastructure.Tests/PersonalMissionStatementBuilder.Infrastructure.Tests.csproj
+++ b/PersonalMissionStatementBuilder/tests/PersonalMissionStatementBuilder.Infrastructure.Tests/PersonalMissionStatementBuilder.Infrastructure.Tests.csproj
@@ -9,6 +9,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="8.0.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
     <PackageReference Include="NUnit" Version="4.0.1" />
     <PackageReference Include="NUnit3TestAdapter" Version="4.5.0" />

--- a/PersonalNetWorthDashboard/tests/PersonalNetWorthDashboard.Infrastructure.Tests/PersonalNetWorthDashboard.Infrastructure.Tests.csproj
+++ b/PersonalNetWorthDashboard/tests/PersonalNetWorthDashboard.Infrastructure.Tests/PersonalNetWorthDashboard.Infrastructure.Tests.csproj
@@ -9,6 +9,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="8.0.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
     <PackageReference Include="NUnit" Version="4.0.1" />
     <PackageReference Include="NUnit3TestAdapter" Version="4.5.0" />

--- a/PersonalProjectPipeline/tests/PersonalProjectPipeline.Infrastructure.Tests/PersonalProjectPipeline.Infrastructure.Tests.csproj
+++ b/PersonalProjectPipeline/tests/PersonalProjectPipeline.Infrastructure.Tests/PersonalProjectPipeline.Infrastructure.Tests.csproj
@@ -9,6 +9,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="8.0.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
     <PackageReference Include="NUnit" Version="4.0.1" />
     <PackageReference Include="NUnit3TestAdapter" Version="4.5.0" />

--- a/PersonalWiki/tests/PersonalWiki.Infrastructure.Tests/PersonalWiki.Infrastructure.Tests.csproj
+++ b/PersonalWiki/tests/PersonalWiki.Infrastructure.Tests/PersonalWiki.Infrastructure.Tests.csproj
@@ -9,6 +9,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="8.0.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
     <PackageReference Include="NUnit" Version="4.0.1" />
     <PackageReference Include="NUnit3TestAdapter" Version="4.5.0" />

--- a/PhotographySessionLogger/tests/PhotographySessionLogger.Infrastructure.Tests/PhotographySessionLogger.Infrastructure.Tests.csproj
+++ b/PhotographySessionLogger/tests/PhotographySessionLogger.Infrastructure.Tests/PhotographySessionLogger.Infrastructure.Tests.csproj
@@ -9,6 +9,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="8.0.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
     <PackageReference Include="NUnit" Version="4.0.1" />
     <PackageReference Include="NUnit3TestAdapter" Version="4.5.0" />

--- a/ProfessionalNetworkCRM/tests/ProfessionalNetworkCRM.Infrastructure.Tests/ProfessionalNetworkCRM.Infrastructure.Tests.csproj
+++ b/ProfessionalNetworkCRM/tests/ProfessionalNetworkCRM.Infrastructure.Tests/ProfessionalNetworkCRM.Infrastructure.Tests.csproj
@@ -9,6 +9,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="8.0.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
     <PackageReference Include="NUnit" Version="4.0.1" />
     <PackageReference Include="NUnit3TestAdapter" Version="4.5.0" />

--- a/ProfessionalReadingList/tests/ProfessionalReadingList.Infrastructure.Tests/ProfessionalReadingList.Infrastructure.Tests.csproj
+++ b/ProfessionalReadingList/tests/ProfessionalReadingList.Infrastructure.Tests/ProfessionalReadingList.Infrastructure.Tests.csproj
@@ -9,6 +9,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="8.0.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
     <PackageReference Include="NUnit" Version="4.0.1" />
     <PackageReference Include="NUnit3TestAdapter" Version="4.5.0" />

--- a/RecipeManagerMealPlanner/tests/RecipeManagerMealPlanner.Infrastructure.Tests/RecipeManagerMealPlanner.Infrastructure.Tests.csproj
+++ b/RecipeManagerMealPlanner/tests/RecipeManagerMealPlanner.Infrastructure.Tests/RecipeManagerMealPlanner.Infrastructure.Tests.csproj
@@ -9,6 +9,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="8.0.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
     <PackageReference Include="NUnit" Version="4.0.1" />
     <PackageReference Include="NUnit3TestAdapter" Version="4.5.0" />

--- a/ResumeCareerAchievementTracker/tests/ResumeCareerAchievementTracker.Infrastructure.Tests/ResumeCareerAchievementTracker.Infrastructure.Tests.csproj
+++ b/ResumeCareerAchievementTracker/tests/ResumeCareerAchievementTracker.Infrastructure.Tests/ResumeCareerAchievementTracker.Infrastructure.Tests.csproj
@@ -9,6 +9,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="8.0.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
     <PackageReference Include="NUnit" Version="4.0.1" />
     <PackageReference Include="NUnit3TestAdapter" Version="4.5.0" />

--- a/RetirementSavingsCalculator/tests/RetirementSavingsCalculator.Infrastructure.Tests/RetirementSavingsCalculator.Infrastructure.Tests.csproj
+++ b/RetirementSavingsCalculator/tests/RetirementSavingsCalculator.Infrastructure.Tests/RetirementSavingsCalculator.Infrastructure.Tests.csproj
@@ -9,6 +9,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="8.0.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
     <PackageReference Include="NUnit" Version="4.0.1" />
     <PackageReference Include="NUnit3TestAdapter" Version="4.5.0" />

--- a/RoadsideAssistanceInfoHub/tests/RoadsideAssistanceInfoHub.Infrastructure.Tests/RoadsideAssistanceInfoHub.Infrastructure.Tests.csproj
+++ b/RoadsideAssistanceInfoHub/tests/RoadsideAssistanceInfoHub.Infrastructure.Tests/RoadsideAssistanceInfoHub.Infrastructure.Tests.csproj
@@ -9,6 +9,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="8.0.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
     <PackageReference Include="NUnit" Version="4.0.1" />
     <PackageReference Include="NUnit3TestAdapter" Version="4.5.0" />

--- a/RunningLogRaceTracker/tests/RunningLogRaceTracker.Infrastructure.Tests/RunningLogRaceTracker.Infrastructure.Tests.csproj
+++ b/RunningLogRaceTracker/tests/RunningLogRaceTracker.Infrastructure.Tests/RunningLogRaceTracker.Infrastructure.Tests.csproj
@@ -9,6 +9,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="8.0.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
     <PackageReference Include="NUnit" Version="4.0.1" />
     <PackageReference Include="NUnit3TestAdapter" Version="4.5.0" />

--- a/SalaryCompensationTracker/tests/SalaryCompensationTracker.Infrastructure.Tests/SalaryCompensationTracker.Infrastructure.Tests.csproj
+++ b/SalaryCompensationTracker/tests/SalaryCompensationTracker.Infrastructure.Tests/SalaryCompensationTracker.Infrastructure.Tests.csproj
@@ -9,6 +9,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="8.0.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
     <PackageReference Include="NUnit" Version="4.0.1" />
     <PackageReference Include="NUnit3TestAdapter" Version="4.5.0" />

--- a/SideHustleIncomeTracker/tests/SideHustleIncomeTracker.Infrastructure.Tests/SideHustleIncomeTracker.Infrastructure.Tests.csproj
+++ b/SideHustleIncomeTracker/tests/SideHustleIncomeTracker.Infrastructure.Tests/SideHustleIncomeTracker.Infrastructure.Tests.csproj
@@ -9,6 +9,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="8.0.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
     <PackageReference Include="NUnit" Version="4.0.1" />
     <PackageReference Include="NUnit3TestAdapter" Version="4.5.0" />

--- a/SkillDevelopmentTracker/tests/SkillDevelopmentTracker.Infrastructure.Tests/SkillDevelopmentTracker.Infrastructure.Tests.csproj
+++ b/SkillDevelopmentTracker/tests/SkillDevelopmentTracker.Infrastructure.Tests/SkillDevelopmentTracker.Infrastructure.Tests.csproj
@@ -9,6 +9,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="8.0.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
     <PackageReference Include="NUnit" Version="4.0.1" />
     <PackageReference Include="NUnit3TestAdapter" Version="4.5.0" />

--- a/SportsTeamFollowingTracker/tests/SportsTeamFollowingTracker.Infrastructure.Tests/SportsTeamFollowingTracker.Infrastructure.Tests.csproj
+++ b/SportsTeamFollowingTracker/tests/SportsTeamFollowingTracker.Infrastructure.Tests/SportsTeamFollowingTracker.Infrastructure.Tests.csproj
@@ -9,6 +9,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="8.0.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
     <PackageReference Include="NUnit" Version="4.0.1" />
     <PackageReference Include="NUnit3TestAdapter" Version="4.5.0" />

--- a/StressMoodTracker/tests/StressMoodTracker.Infrastructure.Tests/StressMoodTracker.Infrastructure.Tests.csproj
+++ b/StressMoodTracker/tests/StressMoodTracker.Infrastructure.Tests/StressMoodTracker.Infrastructure.Tests.csproj
@@ -9,6 +9,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="8.0.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
     <PackageReference Include="NUnit" Version="4.0.1" />
     <PackageReference Include="NUnit3TestAdapter" Version="4.5.0" />

--- a/SubscriptionAuditTool/tests/SubscriptionAuditTool.Infrastructure.Tests/SubscriptionAuditTool.Infrastructure.Tests.csproj
+++ b/SubscriptionAuditTool/tests/SubscriptionAuditTool.Infrastructure.Tests/SubscriptionAuditTool.Infrastructure.Tests.csproj
@@ -9,6 +9,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="8.0.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
     <PackageReference Include="NUnit" Version="4.0.1" />
     <PackageReference Include="NUnit3TestAdapter" Version="4.5.0" />

--- a/TaxDeductionOrganizer/tests/TaxDeductionOrganizer.Infrastructure.Tests/TaxDeductionOrganizer.Infrastructure.Tests.csproj
+++ b/TaxDeductionOrganizer/tests/TaxDeductionOrganizer.Infrastructure.Tests/TaxDeductionOrganizer.Infrastructure.Tests.csproj
@@ -9,6 +9,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="8.0.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
     <PackageReference Include="NUnit" Version="4.0.1" />
     <PackageReference Include="NUnit3TestAdapter" Version="4.5.0" />

--- a/TimeAuditTracker/tests/TimeAuditTracker.Infrastructure.Tests/TimeAuditTracker.Infrastructure.Tests.csproj
+++ b/TimeAuditTracker/tests/TimeAuditTracker.Infrastructure.Tests/TimeAuditTracker.Infrastructure.Tests.csproj
@@ -9,6 +9,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="8.0.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
     <PackageReference Include="NUnit" Version="4.0.1" />
     <PackageReference Include="NUnit3TestAdapter" Version="4.5.0" />

--- a/TravelDestinationWishlist/tests/TravelDestinationWishlist.Infrastructure.Tests/TravelDestinationWishlist.Infrastructure.Tests.csproj
+++ b/TravelDestinationWishlist/tests/TravelDestinationWishlist.Infrastructure.Tests/TravelDestinationWishlist.Infrastructure.Tests.csproj
@@ -9,6 +9,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="8.0.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
     <PackageReference Include="NUnit" Version="4.0.1" />
     <PackageReference Include="NUnit3TestAdapter" Version="4.5.0" />

--- a/VehicleMaintenanceLogger/tests/VehicleMaintenanceLogger.Infrastructure.Tests/VehicleMaintenanceLogger.Infrastructure.Tests.csproj
+++ b/VehicleMaintenanceLogger/tests/VehicleMaintenanceLogger.Infrastructure.Tests/VehicleMaintenanceLogger.Infrastructure.Tests.csproj
@@ -9,6 +9,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="8.0.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
     <PackageReference Include="NUnit" Version="4.0.1" />
     <PackageReference Include="NUnit3TestAdapter" Version="4.5.0" />

--- a/VehicleValueTracker/tests/VehicleValueTracker.Infrastructure.Tests/VehicleValueTracker.Infrastructure.Tests.csproj
+++ b/VehicleValueTracker/tests/VehicleValueTracker.Infrastructure.Tests/VehicleValueTracker.Infrastructure.Tests.csproj
@@ -9,6 +9,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="8.0.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
     <PackageReference Include="NUnit" Version="4.0.1" />
     <PackageReference Include="NUnit3TestAdapter" Version="4.5.0" />

--- a/VideoGameCollectionManager/tests/VideoGameCollectionManager.Infrastructure.Tests/VideoGameCollectionManager.Infrastructure.Tests.csproj
+++ b/VideoGameCollectionManager/tests/VideoGameCollectionManager.Infrastructure.Tests/VideoGameCollectionManager.Infrastructure.Tests.csproj
@@ -9,6 +9,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="8.0.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
     <PackageReference Include="NUnit" Version="4.0.1" />
     <PackageReference Include="NUnit3TestAdapter" Version="4.5.0" />

--- a/WarrantyReturnPeriodTracker/tests/WarrantyReturnPeriodTracker.Infrastructure.Tests/WarrantyReturnPeriodTracker.Infrastructure.Tests.csproj
+++ b/WarrantyReturnPeriodTracker/tests/WarrantyReturnPeriodTracker.Infrastructure.Tests/WarrantyReturnPeriodTracker.Infrastructure.Tests.csproj
@@ -9,6 +9,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="8.0.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
     <PackageReference Include="NUnit" Version="4.0.1" />
     <PackageReference Include="NUnit3TestAdapter" Version="4.5.0" />

--- a/WeeklyReviewSystem/tests/WeeklyReviewSystem.Infrastructure.Tests/WeeklyReviewSystem.Infrastructure.Tests.csproj
+++ b/WeeklyReviewSystem/tests/WeeklyReviewSystem.Infrastructure.Tests/WeeklyReviewSystem.Infrastructure.Tests.csproj
@@ -9,6 +9,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="8.0.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
     <PackageReference Include="NUnit" Version="4.0.1" />
     <PackageReference Include="NUnit3TestAdapter" Version="4.5.0" />

--- a/WineCellarInventory/tests/WineCellarInventory.Infrastructure.Tests/WineCellarInventory.Infrastructure.Tests.csproj
+++ b/WineCellarInventory/tests/WineCellarInventory.Infrastructure.Tests/WineCellarInventory.Infrastructure.Tests.csproj
@@ -9,6 +9,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="8.0.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
     <PackageReference Include="NUnit" Version="4.0.1" />
     <PackageReference Include="NUnit3TestAdapter" Version="4.5.0" />

--- a/WorkoutPlanBuilder/tests/WorkoutPlanBuilder.Infrastructure.Tests/WorkoutPlanBuilder.Infrastructure.Tests.csproj
+++ b/WorkoutPlanBuilder/tests/WorkoutPlanBuilder.Infrastructure.Tests/WorkoutPlanBuilder.Infrastructure.Tests.csproj
@@ -9,6 +9,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="8.0.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
     <PackageReference Include="NUnit" Version="4.0.1" />
     <PackageReference Include="NUnit3TestAdapter" Version="4.5.0" />


### PR DESCRIPTION
…s projects

Added the EF Core InMemory package (version 8.0.0) to enable in-memory database testing for infrastructure layer tests.